### PR TITLE
feat(chat): add session persistence and message history (Phase 1.2)

### DIFF
--- a/migrations/20250522_01_add_chat_session_tables.sql
+++ b/migrations/20250522_01_add_chat_session_tables.sql
@@ -1,0 +1,187 @@
+-- Migration: Add Chat Session Tables
+-- Description: Creates tables for chat session management and message history
+-- Created: 2025-05-22
+
+-- Create chat_sessions table
+CREATE TABLE IF NOT EXISTS chat_sessions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    ended_at TIMESTAMP WITH TIME ZONE,
+    metadata JSONB DEFAULT '{}',
+    
+    -- Indexes for performance
+    CONSTRAINT chat_sessions_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- Create index on user_id for efficient lookups
+CREATE INDEX idx_chat_sessions_user_id ON chat_sessions(user_id);
+CREATE INDEX idx_chat_sessions_created_at ON chat_sessions(created_at DESC);
+CREATE INDEX idx_chat_sessions_updated_at ON chat_sessions(updated_at DESC);
+
+COMMENT ON TABLE chat_sessions IS 'Chat sessions for tracking conversations with AI assistant';
+COMMENT ON COLUMN chat_sessions.id IS 'Unique identifier for the chat session (UUID)';
+COMMENT ON COLUMN chat_sessions.user_id IS 'Reference to the user who owns this session';
+COMMENT ON COLUMN chat_sessions.created_at IS 'When the session was created';
+COMMENT ON COLUMN chat_sessions.updated_at IS 'When the session was last active';
+COMMENT ON COLUMN chat_sessions.ended_at IS 'When the session was explicitly ended (null if active)';
+COMMENT ON COLUMN chat_sessions.metadata IS 'Additional session metadata (e.g., context settings, preferences)';
+
+-- Create chat_messages table
+CREATE TABLE IF NOT EXISTS chat_messages (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    session_id UUID NOT NULL REFERENCES chat_sessions(id) ON DELETE CASCADE,
+    role TEXT NOT NULL,
+    content TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    metadata JSONB DEFAULT '{}',
+    
+    -- Constraints
+    CONSTRAINT chat_messages_role_check CHECK (role IN ('user', 'assistant', 'system')),
+    CONSTRAINT chat_messages_content_length CHECK (length(content) <= 32768)
+);
+
+-- Create indexes for efficient querying
+CREATE INDEX idx_chat_messages_session_id ON chat_messages(session_id);
+CREATE INDEX idx_chat_messages_created_at ON chat_messages(session_id, created_at DESC);
+CREATE INDEX idx_chat_messages_role ON chat_messages(session_id, role);
+
+COMMENT ON TABLE chat_messages IS 'Individual messages within chat sessions';
+COMMENT ON COLUMN chat_messages.id IS 'Unique identifier for the message';
+COMMENT ON COLUMN chat_messages.session_id IS 'Reference to the chat session';
+COMMENT ON COLUMN chat_messages.role IS 'Role of the message sender (user, assistant, system)';
+COMMENT ON COLUMN chat_messages.content IS 'The actual message content (limited to 32KB)';
+COMMENT ON COLUMN chat_messages.created_at IS 'When the message was created';
+COMMENT ON COLUMN chat_messages.metadata IS 'Additional metadata (e.g., tool calls, token usage, model info)';
+
+-- Create chat_tool_calls table for tracking tool usage
+CREATE TABLE IF NOT EXISTS chat_tool_calls (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    message_id BIGINT NOT NULL REFERENCES chat_messages(id) ON DELETE CASCADE,
+    tool_id TEXT NOT NULL,
+    tool_name TEXT NOT NULL,
+    arguments JSONB NOT NULL DEFAULT '{}',
+    result JSONB,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    completed_at TIMESTAMP WITH TIME ZONE,
+    error_message TEXT,
+    
+    -- Constraints
+    CONSTRAINT chat_tool_calls_status_check CHECK (status IN ('pending', 'running', 'completed', 'failed'))
+);
+
+-- Create indexes for tool calls
+CREATE INDEX idx_chat_tool_calls_message_id ON chat_tool_calls(message_id);
+CREATE INDEX idx_chat_tool_calls_status ON chat_tool_calls(status);
+CREATE INDEX idx_chat_tool_calls_tool_name ON chat_tool_calls(tool_name);
+
+COMMENT ON TABLE chat_tool_calls IS 'Tool calls made during chat conversations';
+COMMENT ON COLUMN chat_tool_calls.id IS 'Unique identifier for the tool call';
+COMMENT ON COLUMN chat_tool_calls.message_id IS 'Reference to the message that triggered this tool call';
+COMMENT ON COLUMN chat_tool_calls.tool_id IS 'Unique identifier for the specific tool call instance';
+COMMENT ON COLUMN chat_tool_calls.tool_name IS 'Name of the tool that was called';
+COMMENT ON COLUMN chat_tool_calls.arguments IS 'Arguments passed to the tool';
+COMMENT ON COLUMN chat_tool_calls.result IS 'Result returned by the tool (if successful)';
+COMMENT ON COLUMN chat_tool_calls.status IS 'Current status of the tool call';
+COMMENT ON COLUMN chat_tool_calls.created_at IS 'When the tool call was initiated';
+COMMENT ON COLUMN chat_tool_calls.completed_at IS 'When the tool call completed (success or failure)';
+COMMENT ON COLUMN chat_tool_calls.error_message IS 'Error message if the tool call failed';
+
+-- Update trigger for chat_sessions
+CREATE TRIGGER update_chat_sessions_updated_at
+BEFORE UPDATE ON chat_sessions
+FOR EACH ROW
+EXECUTE FUNCTION update_updated_at_column();
+
+-- Create function to get recent messages with context window management
+CREATE OR REPLACE FUNCTION get_recent_messages(
+    p_session_id UUID,
+    p_limit INTEGER DEFAULT 10,
+    p_max_tokens INTEGER DEFAULT 8000
+) RETURNS TABLE (
+    id BIGINT,
+    role TEXT,
+    content TEXT,
+    created_at TIMESTAMP WITH TIME ZONE,
+    metadata JSONB,
+    estimated_tokens INTEGER
+) AS $$
+DECLARE
+    v_total_tokens INTEGER := 0;
+    v_message RECORD;
+BEGIN
+    -- Estimate tokens as roughly 4 characters per token (conservative estimate)
+    -- Return most recent messages that fit within token limit
+    FOR v_message IN 
+        SELECT 
+            m.id,
+            m.role,
+            m.content,
+            m.created_at,
+            m.metadata,
+            CEIL(LENGTH(m.content) / 4.0)::INTEGER as estimated_tokens
+        FROM chat_messages m
+        WHERE m.session_id = p_session_id
+        ORDER BY m.created_at DESC
+        LIMIT p_limit
+    LOOP
+        -- Check if adding this message would exceed token limit
+        IF v_total_tokens + v_message.estimated_tokens > p_max_tokens THEN
+            EXIT;
+        END IF;
+        
+        v_total_tokens := v_total_tokens + v_message.estimated_tokens;
+        
+        RETURN QUERY SELECT 
+            v_message.id,
+            v_message.role,
+            v_message.content,
+            v_message.created_at,
+            v_message.metadata,
+            v_message.estimated_tokens;
+    END LOOP;
+    
+    RETURN;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION get_recent_messages IS 'Retrieves recent messages from a session with context window management';
+
+-- Create view for active sessions
+CREATE OR REPLACE VIEW active_chat_sessions AS
+SELECT 
+    cs.id,
+    cs.user_id,
+    cs.created_at,
+    cs.updated_at,
+    cs.metadata,
+    COUNT(cm.id) as message_count,
+    MAX(cm.created_at) as last_message_at
+FROM chat_sessions cs
+LEFT JOIN chat_messages cm ON cs.id = cm.session_id
+WHERE cs.ended_at IS NULL
+GROUP BY cs.id, cs.user_id, cs.created_at, cs.updated_at, cs.metadata;
+
+COMMENT ON VIEW active_chat_sessions IS 'View of currently active chat sessions with message statistics';
+
+-- Create function to clean up old sessions (optional, for maintenance)
+CREATE OR REPLACE FUNCTION cleanup_old_sessions(p_days_old INTEGER DEFAULT 30)
+RETURNS INTEGER AS $$
+DECLARE
+    v_deleted_count INTEGER;
+BEGIN
+    WITH deleted AS (
+        DELETE FROM chat_sessions
+        WHERE updated_at < NOW() - INTERVAL '1 day' * p_days_old
+        AND ended_at IS NOT NULL
+        RETURNING 1
+    )
+    SELECT COUNT(*) INTO v_deleted_count FROM deleted;
+    
+    RETURN v_deleted_count;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION cleanup_old_sessions IS 'Removes old ended sessions for maintenance';

--- a/migrations/20250522_01_add_chat_session_tables_rollback.sql
+++ b/migrations/20250522_01_add_chat_session_tables_rollback.sql
@@ -2,17 +2,21 @@
 -- Description: Removes chat session management tables and related objects
 -- Created: 2025-05-22
 
+-- Drop triggers
+DROP TRIGGER IF EXISTS audit_chat_sessions ON chat_sessions;
+DROP TRIGGER IF EXISTS update_chat_sessions_updated_at ON chat_sessions;
+
 -- Drop views
 DROP VIEW IF EXISTS active_chat_sessions;
 
 -- Drop functions
+DROP FUNCTION IF EXISTS audit_chat_session_changes();
+DROP FUNCTION IF EXISTS expire_inactive_sessions(INTEGER);
 DROP FUNCTION IF EXISTS cleanup_old_sessions(INTEGER);
-DROP FUNCTION IF EXISTS get_recent_messages(UUID, INTEGER, INTEGER);
-
--- Drop triggers
-DROP TRIGGER IF EXISTS update_chat_sessions_updated_at ON chat_sessions;
+DROP FUNCTION IF EXISTS get_recent_messages(UUID, INTEGER, INTEGER, INTEGER, INTEGER);
 
 -- Drop tables (in reverse order of dependencies)
+DROP TABLE IF EXISTS chat_session_audit CASCADE;
 DROP TABLE IF EXISTS chat_tool_calls CASCADE;
 DROP TABLE IF EXISTS chat_messages CASCADE;
 DROP TABLE IF EXISTS chat_sessions CASCADE;

--- a/migrations/20250522_01_add_chat_session_tables_rollback.sql
+++ b/migrations/20250522_01_add_chat_session_tables_rollback.sql
@@ -1,0 +1,29 @@
+-- Rollback Migration: Add Chat Session Tables
+-- Description: Removes chat session management tables and related objects
+-- Created: 2025-05-22
+
+-- Drop views
+DROP VIEW IF EXISTS active_chat_sessions;
+
+-- Drop functions
+DROP FUNCTION IF EXISTS cleanup_old_sessions(INTEGER);
+DROP FUNCTION IF EXISTS get_recent_messages(UUID, INTEGER, INTEGER);
+
+-- Drop triggers
+DROP TRIGGER IF EXISTS update_chat_sessions_updated_at ON chat_sessions;
+
+-- Drop tables (in reverse order of dependencies)
+DROP TABLE IF EXISTS chat_tool_calls CASCADE;
+DROP TABLE IF EXISTS chat_messages CASCADE;
+DROP TABLE IF EXISTS chat_sessions CASCADE;
+
+-- Drop indexes (if they weren't dropped with tables)
+DROP INDEX IF EXISTS idx_chat_tool_calls_tool_name;
+DROP INDEX IF EXISTS idx_chat_tool_calls_status;
+DROP INDEX IF EXISTS idx_chat_tool_calls_message_id;
+DROP INDEX IF EXISTS idx_chat_messages_role;
+DROP INDEX IF EXISTS idx_chat_messages_created_at;
+DROP INDEX IF EXISTS idx_chat_messages_session_id;
+DROP INDEX IF EXISTS idx_chat_sessions_updated_at;
+DROP INDEX IF EXISTS idx_chat_sessions_created_at;
+DROP INDEX IF EXISTS idx_chat_sessions_user_id;

--- a/tasks/TODO-INTEGRATION.md
+++ b/tasks/TODO-INTEGRATION.md
@@ -43,11 +43,11 @@ The AI chat interface frontend components have been successfully implemented wit
   - Format: Server-Sent Events (SSE) compatible with Vercel AI SDK
   - Implemented: Vercel AI SDK data stream protocol (0:text, 3:error, d:finish)
 
-- [ ] **Add chat session management**
-  - [ ] Session persistence in database
-  - [ ] Message history storage
-  - [ ] Context window management
-  - Integration: Use existing auth middleware
+- [x] **Add chat session management** ✅ COMPLETED (PR #122)
+  - [x] Session persistence in database
+  - [x] Message history storage
+  - [x] Context window management
+  - Integration: Uses existing auth middleware
 
 ## Phase 2: Authentication & BYOK Integration 🔐
 

--- a/tests/api/services/test_chat_service.py
+++ b/tests/api/services/test_chat_service.py
@@ -1,21 +1,21 @@
 """Tests for the chat service."""
 
-import asyncio
+import time
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import UUID, uuid4
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
 
 import pytest
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tripsage.api.core.exceptions import NotFoundError, ValidationError
-from tripsage.api.services.chat_service import ChatService
+from tripsage.api.services.chat_service import ChatService, RateLimiter
 from tripsage.models.db.chat import (
     ChatMessageDB,
     ChatSessionDB,
     ChatSessionWithStats,
     ChatToolCallDB,
-    MessageWithTokenEstimate,
     RecentMessagesResponse,
 )
 
@@ -373,3 +373,263 @@ class TestChatService:
 
         # Assert
         assert count == deleted_count
+
+
+class TestRateLimiter:
+    """Test cases for RateLimiter."""
+
+    def test_rate_limiter_init(self):
+        """Test rate limiter initialization."""
+        limiter = RateLimiter(max_messages=5, window_seconds=30)
+        assert limiter.max_messages == 5
+        assert limiter.window_seconds == 30
+        assert limiter.user_windows == {}
+
+    def test_rate_limiter_allows_first_message(self):
+        """Test that rate limiter allows first message."""
+        limiter = RateLimiter(max_messages=5, window_seconds=30)
+        assert limiter.is_allowed(user_id=1) is True
+
+    def test_rate_limiter_blocks_after_limit(self):
+        """Test that rate limiter blocks after limit reached."""
+        limiter = RateLimiter(max_messages=3, window_seconds=30)
+        user_id = 1
+
+        # Allow first 3 messages
+        for _ in range(3):
+            assert limiter.is_allowed(user_id) is True
+
+        # Block 4th message
+        assert limiter.is_allowed(user_id) is False
+
+    def test_rate_limiter_allows_after_window(self):
+        """Test that rate limiter allows messages after time window."""
+        limiter = RateLimiter(max_messages=1, window_seconds=0.1)
+        user_id = 1
+
+        # First message allowed
+        assert limiter.is_allowed(user_id) is True
+
+        # Second message blocked
+        assert limiter.is_allowed(user_id) is False
+
+        # Wait for window to expire
+        time.sleep(0.2)
+
+        # Message allowed again
+        assert limiter.is_allowed(user_id) is True
+
+    def test_rate_limiter_batch_messages(self):
+        """Test rate limiter with batch message checking."""
+        limiter = RateLimiter(max_messages=5, window_seconds=30)
+        user_id = 1
+
+        # Allow batch of 3 messages
+        assert limiter.is_allowed(user_id, count=3) is True
+
+        # Allow 1 more message
+        assert limiter.is_allowed(user_id, count=1) is True
+
+        # Block batch that would exceed limit
+        assert limiter.is_allowed(user_id, count=2) is False
+
+        # But allow 1 more message
+        assert limiter.is_allowed(user_id, count=1) is True
+
+    def test_rate_limiter_reset_user(self):
+        """Test resetting rate limit for a user."""
+        limiter = RateLimiter(max_messages=1, window_seconds=30)
+        user_id = 1
+
+        # Use up limit
+        assert limiter.is_allowed(user_id) is True
+        assert limiter.is_allowed(user_id) is False
+
+        # Reset user
+        limiter.reset_user(user_id)
+
+        # Should be allowed again
+        assert limiter.is_allowed(user_id) is True
+
+
+class TestChatServiceEnhancements:
+    """Test cases for enhanced ChatService features."""
+
+    @pytest.fixture
+    async def mock_db(self):
+        """Create a mock database session."""
+        db = AsyncMock(spec=AsyncSession)
+        return db
+
+    @pytest.fixture
+    async def chat_service(self, mock_db):
+        """Create a chat service instance with mock database."""
+        rate_limiter = RateLimiter(max_messages=10, window_seconds=60)
+        return ChatService(mock_db, rate_limiter=rate_limiter)
+
+    async def test_add_message_with_rate_limiting(self, chat_service, mock_db):
+        """Test adding messages with rate limiting."""
+        session_id = uuid4()
+        user_id = 1
+
+        # Mock database response
+        mock_result = MagicMock()
+        mock_row = MagicMock()
+        mock_row.id = 1
+        mock_row.session_id = session_id
+        mock_row.role = "user"
+        mock_row.content = "Test"
+        mock_row.created_at = datetime.utcnow()
+        mock_row.metadata = {}
+        mock_result.fetchone.return_value = mock_row
+        mock_db.execute.return_value = mock_result
+
+        # Exhaust rate limit
+        chat_service.rate_limiter.max_messages = 1
+        chat_service.rate_limiter.is_allowed(user_id)
+
+        # Should raise ValidationError
+        with pytest.raises(ValidationError, match="Rate limit exceeded"):
+            await chat_service.add_message(
+                session_id=session_id,
+                role="user",
+                content="Test",
+                user_id=user_id,
+            )
+
+    async def test_add_message_content_sanitization(self, chat_service, mock_db):
+        """Test that message content is sanitized."""
+        session_id = uuid4()
+
+        # Mock database response
+        mock_result = MagicMock()
+        mock_row = MagicMock()
+        mock_row.id = 1
+        mock_row.session_id = session_id
+        mock_row.role = "user"
+        mock_row.content = "Test content"
+        mock_row.created_at = datetime.utcnow()
+        mock_row.metadata = {}
+        mock_result.fetchone.return_value = mock_row
+        mock_db.execute.return_value = mock_result
+
+        # Test with content that needs sanitization
+        dirty_content = "<script>alert('xss')</script>Test content"
+        message = await chat_service.add_message(
+            session_id=session_id,
+            role="user",
+            content=dirty_content,
+        )
+
+        # Verify execute was called with sanitized content
+        call_args = mock_db.execute.call_args[0][1]
+        assert "<script>" not in call_args["content"]
+
+    async def test_add_messages_batch(self, chat_service, mock_db):
+        """Test adding multiple messages in batch."""
+        session_id = uuid4()
+        messages = [
+            ("user", "First message", None),
+            ("assistant", "Response", {"tool": "test"}),
+            ("user", "Follow up", None),
+        ]
+
+        # Mock database responses
+        mock_db.begin.return_value.__aenter__ = AsyncMock()
+        mock_db.begin.return_value.__aexit__ = AsyncMock()
+
+        mock_results = []
+        for i, (role, content, metadata) in enumerate(messages):
+            mock_result = MagicMock()
+            mock_row = MagicMock()
+            mock_row.id = i + 1
+            mock_row.session_id = session_id
+            mock_row.role = role
+            mock_row.content = content
+            mock_row.created_at = datetime.utcnow()
+            mock_row.metadata = metadata or {}
+            mock_result.fetchone.return_value = mock_row
+            mock_results.append(mock_result)
+
+        mock_db.execute.side_effect = mock_results + [MagicMock()]  # +1 for update
+
+        # Add messages
+        created = await chat_service.add_messages_batch(session_id, messages)
+
+        # Verify results
+        assert len(created) == 3
+        assert created[0].role == "user"
+        assert created[1].role == "assistant"
+        assert created[2].role == "user"
+
+    async def test_retry_logic_on_database_error(self, chat_service, mock_db):
+        """Test retry logic on database errors."""
+        session_id = uuid4()
+
+        # First two attempts fail, third succeeds
+        mock_result = MagicMock()
+        mock_row = MagicMock()
+        mock_row.id = session_id
+        mock_row.user_id = 1
+        mock_row.created_at = datetime.utcnow()
+        mock_row.updated_at = datetime.utcnow()
+        mock_row.ended_at = None
+        mock_row.metadata = {}
+        mock_result.fetchone.return_value = mock_row
+
+        mock_db.execute.side_effect = [
+            OperationalError("Connection lost", None, None),
+            OperationalError("Connection lost", None, None),
+            mock_result,
+        ]
+
+        # Should succeed after retries
+        session = await chat_service.get_session(session_id)
+        assert session.id == session_id
+        assert mock_db.execute.call_count == 3
+
+    async def test_get_recent_messages_with_pagination(self, chat_service, mock_db):
+        """Test getting recent messages with pagination support."""
+        session_id = uuid4()
+
+        # Mock database response
+        mock_result = MagicMock()
+        mock_row = MagicMock()
+        mock_row.id = 1
+        mock_row.role = "user"
+        mock_row.content = "Hello"
+        mock_row.created_at = datetime.utcnow()
+        mock_row.metadata = {}
+        mock_row.estimated_tokens = 2
+        mock_row.total_messages = 10
+        mock_result.fetchall.return_value = [mock_row]
+        mock_db.execute.return_value = mock_result
+
+        # Get recent messages with custom parameters
+        response = await chat_service.get_recent_messages(
+            session_id, limit=5, max_tokens=100, offset=10, chars_per_token=3
+        )
+
+        # Verify parameters passed correctly
+        call_args = mock_db.execute.call_args[0][1]
+        assert call_args["limit"] == 5
+        assert call_args["max_tokens"] == 100
+        assert call_args["offset"] == 10
+        assert call_args["chars_per_token"] == 3
+
+    async def test_expire_inactive_sessions(self, chat_service, mock_db):
+        """Test expiring inactive sessions."""
+        # Mock database response
+        mock_result = MagicMock()
+        mock_result.scalar.return_value = 7
+        mock_db.execute.return_value = mock_result
+
+        # Expire sessions
+        count = await chat_service.expire_inactive_sessions(hours_inactive=12)
+
+        # Verify result
+        assert count == 7
+
+        # Verify function called with correct parameter
+        call_args = mock_db.execute.call_args[0][1]
+        assert call_args["hours_inactive"] == 12

--- a/tests/api/services/test_chat_service.py
+++ b/tests/api/services/test_chat_service.py
@@ -1,0 +1,375 @@
+"""Tests for the chat service."""
+
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tripsage.api.core.exceptions import NotFoundError, ValidationError
+from tripsage.api.services.chat_service import ChatService
+from tripsage.models.db.chat import (
+    ChatMessageDB,
+    ChatSessionDB,
+    ChatSessionWithStats,
+    ChatToolCallDB,
+    MessageWithTokenEstimate,
+    RecentMessagesResponse,
+)
+
+
+@pytest.fixture
+async def mock_db():
+    """Create a mock database session."""
+    db = AsyncMock(spec=AsyncSession)
+    return db
+
+
+@pytest.fixture
+async def chat_service(mock_db):
+    """Create a chat service instance with mock database."""
+    return ChatService(mock_db)
+
+
+class TestChatService:
+    """Test cases for ChatService."""
+
+    async def test_create_session(self, chat_service, mock_db):
+        """Test creating a new chat session."""
+        # Arrange
+        user_id = 1
+        metadata = {"source": "web", "device": "desktop"}
+        session_id = uuid4()
+        created_at = datetime.utcnow()
+
+        # Mock database response
+        mock_result = MagicMock()
+        mock_row = MagicMock()
+        mock_row.id = session_id
+        mock_row.user_id = user_id
+        mock_row.created_at = created_at
+        mock_row.updated_at = created_at
+        mock_row.ended_at = None
+        mock_row.metadata = metadata
+        mock_result.fetchone.return_value = mock_row
+        mock_db.execute.return_value = mock_result
+
+        # Act
+        session = await chat_service.create_session(user_id, metadata)
+
+        # Assert
+        assert isinstance(session, ChatSessionDB)
+        assert session.user_id == user_id
+        assert session.metadata == metadata
+        assert session.ended_at is None
+        mock_db.execute.assert_called_once()
+
+    async def test_create_session_failure(self, chat_service, mock_db):
+        """Test create session failure."""
+        # Arrange
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = None
+        mock_db.execute.return_value = mock_result
+
+        # Act & Assert
+        with pytest.raises(ValidationError, match="Failed to create chat session"):
+            await chat_service.create_session(1)
+
+    async def test_get_session(self, chat_service, mock_db):
+        """Test getting a session by ID."""
+        # Arrange
+        session_id = uuid4()
+        user_id = 1
+
+        mock_result = MagicMock()
+        mock_row = MagicMock()
+        mock_row.id = session_id
+        mock_row.user_id = user_id
+        mock_row.created_at = datetime.utcnow()
+        mock_row.updated_at = datetime.utcnow()
+        mock_row.ended_at = None
+        mock_row.metadata = {}
+        mock_result.fetchone.return_value = mock_row
+        mock_db.execute.return_value = mock_result
+
+        # Act
+        session = await chat_service.get_session(session_id, user_id)
+
+        # Assert
+        assert isinstance(session, ChatSessionDB)
+        assert session.id == session_id
+        assert session.user_id == user_id
+
+    async def test_get_session_not_found(self, chat_service, mock_db):
+        """Test get session not found."""
+        # Arrange
+        session_id = uuid4()
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = None
+        mock_db.execute.return_value = mock_result
+
+        # Act & Assert
+        with pytest.raises(NotFoundError, match=f"Chat session {session_id} not found"):
+            await chat_service.get_session(session_id)
+
+    async def test_get_active_sessions(self, chat_service, mock_db):
+        """Test getting active sessions for a user."""
+        # Arrange
+        user_id = 1
+        session_id = uuid4()
+
+        mock_result = MagicMock()
+        mock_row = MagicMock()
+        mock_row.id = session_id
+        mock_row.user_id = user_id
+        mock_row.created_at = datetime.utcnow()
+        mock_row.updated_at = datetime.utcnow()
+        mock_row.ended_at = None
+        mock_row.metadata = {}
+        mock_row.message_count = 5
+        mock_row.last_message_at = datetime.utcnow()
+        mock_result.fetchall.return_value = [mock_row]
+        mock_db.execute.return_value = mock_result
+
+        # Act
+        sessions = await chat_service.get_active_sessions(user_id)
+
+        # Assert
+        assert len(sessions) == 1
+        assert isinstance(sessions[0], ChatSessionWithStats)
+        assert sessions[0].message_count == 5
+
+    async def test_add_message(self, chat_service, mock_db):
+        """Test adding a message to a session."""
+        # Arrange
+        session_id = uuid4()
+        role = "user"
+        content = "Hello, I need help planning a trip"
+        metadata = {"timestamp": 123456}
+
+        mock_result = MagicMock()
+        mock_row = MagicMock()
+        mock_row.id = 1
+        mock_row.session_id = session_id
+        mock_row.role = role
+        mock_row.content = content
+        mock_row.created_at = datetime.utcnow()
+        mock_row.metadata = metadata
+        mock_result.fetchone.return_value = mock_row
+        mock_db.execute.return_value = mock_result
+
+        # Act
+        message = await chat_service.add_message(session_id, role, content, metadata)
+
+        # Assert
+        assert isinstance(message, ChatMessageDB)
+        assert message.role == role
+        assert message.content == content
+        assert message.metadata == metadata
+        assert mock_db.execute.call_count == 2  # Insert message + update session
+
+    async def test_add_message_invalid_role(self, chat_service, mock_db):
+        """Test adding a message with invalid role."""
+        # Act & Assert
+        with pytest.raises(ValidationError, match="Role must be one of"):
+            await chat_service.add_message(uuid4(), "invalid_role", "content")
+
+    async def test_add_message_content_too_long(self, chat_service, mock_db):
+        """Test adding a message with content exceeding limit."""
+        # Arrange
+        long_content = "x" * 40000  # Exceeds 32KB limit
+
+        # Act & Assert
+        with pytest.raises(ValidationError, match="exceeds 32KB limit"):
+            await chat_service.add_message(uuid4(), "user", long_content)
+
+    async def test_get_messages(self, chat_service, mock_db):
+        """Test getting messages for a session."""
+        # Arrange
+        session_id = uuid4()
+
+        mock_result = MagicMock()
+        mock_row1 = MagicMock()
+        mock_row1.id = 1
+        mock_row1.session_id = session_id
+        mock_row1.role = "user"
+        mock_row1.content = "Hello"
+        mock_row1.created_at = datetime.utcnow()
+        mock_row1.metadata = {}
+
+        mock_row2 = MagicMock()
+        mock_row2.id = 2
+        mock_row2.session_id = session_id
+        mock_row2.role = "assistant"
+        mock_row2.content = "Hi! How can I help?"
+        mock_row2.created_at = datetime.utcnow()
+        mock_row2.metadata = {}
+
+        mock_result.fetchall.return_value = [mock_row1, mock_row2]
+        mock_db.execute.return_value = mock_result
+
+        # Act
+        messages = await chat_service.get_messages(session_id, limit=10)
+
+        # Assert
+        assert len(messages) == 2
+        assert messages[0].role == "user"
+        assert messages[1].role == "assistant"
+
+    async def test_get_recent_messages(self, chat_service, mock_db):
+        """Test getting recent messages with token limit."""
+        # Arrange
+        session_id = uuid4()
+
+        mock_result = MagicMock()
+        mock_row = MagicMock()
+        mock_row.id = 1
+        mock_row.role = "user"
+        mock_row.content = "Hello world"
+        mock_row.created_at = datetime.utcnow()
+        mock_row.metadata = {}
+        mock_row.estimated_tokens = 3
+        mock_result.fetchall.return_value = [mock_row]
+        mock_db.execute.return_value = mock_result
+
+        # Act
+        response = await chat_service.get_recent_messages(session_id)
+
+        # Assert
+        assert isinstance(response, RecentMessagesResponse)
+        assert len(response.messages) == 1
+        assert response.total_tokens == 3
+        assert not response.truncated
+
+    async def test_add_tool_call(self, chat_service, mock_db):
+        """Test adding a tool call."""
+        # Arrange
+        message_id = 1
+        tool_id = "call_123"
+        tool_name = "search_flights"
+        arguments = {"from": "NYC", "to": "LAX"}
+
+        mock_result = MagicMock()
+        mock_row = MagicMock()
+        mock_row.id = 1
+        mock_row.message_id = message_id
+        mock_row.tool_id = tool_id
+        mock_row.tool_name = tool_name
+        mock_row.arguments = arguments
+        mock_row.result = None
+        mock_row.status = "pending"
+        mock_row.created_at = datetime.utcnow()
+        mock_row.completed_at = None
+        mock_row.error_message = None
+        mock_result.fetchone.return_value = mock_row
+        mock_db.execute.return_value = mock_result
+
+        # Act
+        tool_call = await chat_service.add_tool_call(
+            message_id, tool_id, tool_name, arguments
+        )
+
+        # Assert
+        assert isinstance(tool_call, ChatToolCallDB)
+        assert tool_call.tool_name == tool_name
+        assert tool_call.arguments == arguments
+        assert tool_call.status == "pending"
+
+    async def test_update_tool_call_success(self, chat_service, mock_db):
+        """Test updating a tool call with success."""
+        # Arrange
+        tool_call_id = 1
+        result = {"flights": [{"id": "123", "price": 299}]}
+
+        mock_result = MagicMock()
+        mock_row = MagicMock()
+        mock_row.id = tool_call_id
+        mock_row.message_id = 1
+        mock_row.tool_id = "call_123"
+        mock_row.tool_name = "search_flights"
+        mock_row.arguments = {}
+        mock_row.result = result
+        mock_row.status = "completed"
+        mock_row.created_at = datetime.utcnow()
+        mock_row.completed_at = datetime.utcnow()
+        mock_row.error_message = None
+        mock_result.fetchone.return_value = mock_row
+        mock_db.execute.return_value = mock_result
+
+        # Act
+        tool_call = await chat_service.update_tool_call(
+            tool_call_id, "completed", result=result
+        )
+
+        # Assert
+        assert tool_call.status == "completed"
+        assert tool_call.result == result
+        assert tool_call.completed_at is not None
+
+    async def test_update_tool_call_failure(self, chat_service, mock_db):
+        """Test updating a tool call with failure."""
+        # Arrange
+        tool_call_id = 1
+        error_message = "API rate limit exceeded"
+
+        mock_result = MagicMock()
+        mock_row = MagicMock()
+        mock_row.id = tool_call_id
+        mock_row.message_id = 1
+        mock_row.tool_id = "call_123"
+        mock_row.tool_name = "search_flights"
+        mock_row.arguments = {}
+        mock_row.result = None
+        mock_row.status = "failed"
+        mock_row.created_at = datetime.utcnow()
+        mock_row.completed_at = datetime.utcnow()
+        mock_row.error_message = error_message
+        mock_result.fetchone.return_value = mock_row
+        mock_db.execute.return_value = mock_result
+
+        # Act
+        tool_call = await chat_service.update_tool_call(
+            tool_call_id, "failed", error_message=error_message
+        )
+
+        # Assert
+        assert tool_call.status == "failed"
+        assert tool_call.error_message == error_message
+
+    async def test_end_session(self, chat_service, mock_db):
+        """Test ending a chat session."""
+        # Arrange
+        session_id = uuid4()
+
+        mock_result = MagicMock()
+        mock_row = MagicMock()
+        mock_row.id = session_id
+        mock_row.user_id = 1
+        mock_row.created_at = datetime.utcnow()
+        mock_row.updated_at = datetime.utcnow()
+        mock_row.ended_at = datetime.utcnow()
+        mock_row.metadata = {}
+        mock_result.fetchone.return_value = mock_row
+        mock_db.execute.return_value = mock_result
+
+        # Act
+        session = await chat_service.end_session(session_id)
+
+        # Assert
+        assert session.ended_at is not None
+
+    async def test_cleanup_old_sessions(self, chat_service, mock_db):
+        """Test cleaning up old sessions."""
+        # Arrange
+        deleted_count = 5
+        mock_result = MagicMock()
+        mock_result.scalar.return_value = deleted_count
+        mock_db.execute.return_value = mock_result
+
+        # Act
+        count = await chat_service.cleanup_old_sessions(30)
+
+        # Assert
+        assert count == deleted_count

--- a/tests/api/test_chat_endpoints.py
+++ b/tests/api/test_chat_endpoints.py
@@ -1,0 +1,381 @@
+"""Tests for chat API endpoints."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import status
+from httpx import AsyncClient
+
+from tripsage.models.db.chat import ChatMessageDB, ChatSessionDB
+from tripsage.models.db.user import UserDB
+
+
+@pytest.mark.asyncio
+class TestChatEndpoints:
+    """Test cases for chat API endpoints."""
+
+    @pytest.fixture
+    def mock_user(self):
+        """Create a mock user."""
+        return UserDB(
+            id=1,
+            email="test@example.com",
+            username="testuser",
+            is_active=True,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+        )
+
+    @pytest.fixture
+    def auth_headers(self):
+        """Create authentication headers."""
+        return {"Authorization": "Bearer test-token"}
+
+    async def test_chat_create_new_session(
+        self, client: AsyncClient, auth_headers, mock_user
+    ):
+        """Test creating a new chat session."""
+        with patch(
+            "tripsage.api.routers.chat.get_current_user", return_value=mock_user
+        ):
+            with patch("tripsage.api.routers.chat.get_chat_service") as mock_service:
+                # Mock chat service
+                mock_session = ChatSessionDB(
+                    id=uuid4(),
+                    user_id=mock_user.id,
+                    created_at=datetime.utcnow(),
+                    updated_at=datetime.utcnow(),
+                    ended_at=None,
+                    metadata={},
+                )
+                mock_service.return_value.create_session = AsyncMock(
+                    return_value=mock_session
+                )
+                mock_service.return_value.add_message = AsyncMock()
+                mock_service.return_value.get_recent_messages = AsyncMock(
+                    return_value=MagicMock(messages=[], total_tokens=0, truncated=False)
+                )
+
+                # Mock agent response
+                with patch("tripsage.api.routers.chat.get_travel_agent") as mock_agent:
+                    mock_agent.return_value.run = AsyncMock(
+                        return_value={
+                            "content": "Hello! How can I help you plan your trip?",
+                            "tool_calls": [],
+                        }
+                    )
+
+                    # Send request
+                    response = await client.post(
+                        "/api/chat/",
+                        headers=auth_headers,
+                        json={
+                            "messages": [{"role": "user", "content": "Hello"}],
+                            "stream": False,
+                        },
+                    )
+
+                    assert response.status_code == status.HTTP_200_OK
+                    data = response.json()
+                    assert "content" in data
+                    assert (
+                        data["content"] == "Hello! How can I help you plan your trip?"
+                    )
+
+    async def test_chat_continue_session(
+        self, client: AsyncClient, auth_headers, mock_user
+    ):
+        """Test continuing an existing chat session."""
+        session_id = uuid4()
+
+        with patch(
+            "tripsage.api.routers.chat.get_current_user", return_value=mock_user
+        ):
+            with patch("tripsage.api.routers.chat.get_chat_service") as mock_service:
+                # Mock chat service
+                mock_session = ChatSessionDB(
+                    id=session_id,
+                    user_id=mock_user.id,
+                    created_at=datetime.utcnow(),
+                    updated_at=datetime.utcnow(),
+                    ended_at=None,
+                    metadata={},
+                )
+                mock_service.return_value.get_session = AsyncMock(
+                    return_value=mock_session
+                )
+                mock_service.return_value.add_message = AsyncMock()
+                mock_service.return_value.get_recent_messages = AsyncMock(
+                    return_value=MagicMock(
+                        messages=[
+                            MagicMock(role="user", content="Hello"),
+                            MagicMock(role="assistant", content="Hi there!"),
+                        ],
+                        total_tokens=10,
+                        truncated=False,
+                    )
+                )
+
+                # Mock agent response
+                with patch("tripsage.api.routers.chat.get_travel_agent") as mock_agent:
+                    mock_agent.return_value.run = AsyncMock(
+                        return_value={
+                            "content": "Sure, I can help with that!",
+                            "tool_calls": [],
+                        }
+                    )
+
+                    # Send request
+                    response = await client.post(
+                        f"/api/chat/sessions/{session_id}/continue",
+                        headers=auth_headers,
+                        json={
+                            "messages": [
+                                {"role": "user", "content": "Plan a trip to Paris"}
+                            ],
+                            "stream": False,
+                        },
+                    )
+
+                    assert response.status_code == status.HTTP_200_OK
+                    data = response.json()
+                    assert str(data["id"]) == str(session_id)
+
+    async def test_chat_rate_limit_exceeded(
+        self, client: AsyncClient, auth_headers, mock_user
+    ):
+        """Test rate limit handling."""
+        with patch(
+            "tripsage.api.routers.chat.get_current_user", return_value=mock_user
+        ):
+            with patch("tripsage.api.routers.chat.get_chat_service") as mock_service:
+                # Mock rate limit error
+                mock_service.return_value.create_session = AsyncMock()
+                mock_service.return_value.add_message = AsyncMock(
+                    side_effect=Exception(
+                        "Rate limit exceeded. Maximum 10 messages per 60 seconds."
+                    )
+                )
+
+                # Send request
+                response = await client.post(
+                    "/api/chat/",
+                    headers=auth_headers,
+                    json={
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "stream": False,
+                    },
+                )
+
+                assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+    async def test_get_session_history(
+        self, client: AsyncClient, auth_headers, mock_user
+    ):
+        """Test getting session history."""
+        session_id = uuid4()
+
+        with patch(
+            "tripsage.api.routers.chat.get_current_user", return_value=mock_user
+        ):
+            with patch("tripsage.api.routers.chat.get_chat_service") as mock_service:
+                # Mock session and messages
+                mock_session = ChatSessionDB(
+                    id=session_id,
+                    user_id=mock_user.id,
+                    created_at=datetime.utcnow(),
+                    updated_at=datetime.utcnow(),
+                    ended_at=None,
+                    metadata={"agent": "travel_planning"},
+                )
+                mock_messages = [
+                    ChatMessageDB(
+                        id=1,
+                        session_id=session_id,
+                        role="user",
+                        content="Hello",
+                        created_at=datetime.utcnow(),
+                        metadata={},
+                    ),
+                    ChatMessageDB(
+                        id=2,
+                        session_id=session_id,
+                        role="assistant",
+                        content="Hi! How can I help?",
+                        created_at=datetime.utcnow(),
+                        metadata={},
+                    ),
+                ]
+
+                mock_service.return_value.get_session = AsyncMock(
+                    return_value=mock_session
+                )
+                mock_service.return_value.get_messages = AsyncMock(
+                    return_value=mock_messages
+                )
+
+                # Send request
+                response = await client.get(
+                    f"/api/chat/sessions/{session_id}/history",
+                    headers=auth_headers,
+                )
+
+                assert response.status_code == status.HTTP_200_OK
+                data = response.json()
+                assert str(data["session_id"]) == str(session_id)
+                assert len(data["messages"]) == 2
+                assert data["messages"][0]["role"] == "user"
+                assert data["messages"][1]["role"] == "assistant"
+
+    async def test_list_sessions(self, client: AsyncClient, auth_headers, mock_user):
+        """Test listing active sessions."""
+        with patch(
+            "tripsage.api.routers.chat.get_current_user", return_value=mock_user
+        ):
+            with patch("tripsage.api.routers.chat.get_chat_service") as mock_service:
+                # Mock sessions
+                mock_sessions = [
+                    MagicMock(
+                        id=uuid4(),
+                        created_at=datetime.utcnow(),
+                        updated_at=datetime.utcnow(),
+                        message_count=5,
+                        last_message_at=datetime.utcnow(),
+                        metadata={},
+                    ),
+                    MagicMock(
+                        id=uuid4(),
+                        created_at=datetime.utcnow(),
+                        updated_at=datetime.utcnow(),
+                        message_count=3,
+                        last_message_at=None,
+                        metadata={},
+                    ),
+                ]
+
+                mock_service.return_value.get_active_sessions = AsyncMock(
+                    return_value=mock_sessions
+                )
+
+                # Send request
+                response = await client.get(
+                    "/api/chat/sessions",
+                    headers=auth_headers,
+                )
+
+                assert response.status_code == status.HTTP_200_OK
+                data = response.json()
+                assert len(data["sessions"]) == 2
+                assert data["sessions"][0]["message_count"] == 5
+                assert data["sessions"][1]["message_count"] == 3
+
+    async def test_end_session(self, client: AsyncClient, auth_headers, mock_user):
+        """Test ending a chat session."""
+        session_id = uuid4()
+
+        with patch(
+            "tripsage.api.routers.chat.get_current_user", return_value=mock_user
+        ):
+            with patch("tripsage.api.routers.chat.get_chat_service") as mock_service:
+                # Mock session
+                mock_session = ChatSessionDB(
+                    id=session_id,
+                    user_id=mock_user.id,
+                    created_at=datetime.utcnow(),
+                    updated_at=datetime.utcnow(),
+                    ended_at=None,
+                    metadata={},
+                )
+
+                mock_service.return_value.get_session = AsyncMock(
+                    return_value=mock_session
+                )
+                mock_service.return_value.end_session = AsyncMock()
+
+                # Send request
+                response = await client.post(
+                    f"/api/chat/sessions/{session_id}/end",
+                    headers=auth_headers,
+                )
+
+                assert response.status_code == status.HTTP_200_OK
+                data = response.json()
+                assert data["message"] == "Session ended successfully"
+                assert str(data["session_id"]) == str(session_id)
+
+    async def test_chat_session_not_found(
+        self, client: AsyncClient, auth_headers, mock_user
+    ):
+        """Test accessing non-existent session."""
+        session_id = uuid4()
+
+        with patch(
+            "tripsage.api.routers.chat.get_current_user", return_value=mock_user
+        ):
+            with patch("tripsage.api.routers.chat.get_chat_service") as mock_service:
+                # Mock session not found
+                mock_service.return_value.get_session = AsyncMock(
+                    side_effect=Exception("Not found")
+                )
+
+                # Send request
+                response = await client.get(
+                    f"/api/chat/sessions/{session_id}/history",
+                    headers=auth_headers,
+                )
+
+                assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    async def test_chat_streaming_response(
+        self, client: AsyncClient, auth_headers, mock_user
+    ):
+        """Test streaming chat response."""
+        with patch(
+            "tripsage.api.routers.chat.get_current_user", return_value=mock_user
+        ):
+            with patch("tripsage.api.routers.chat.get_chat_service") as mock_service:
+                # Mock chat service
+                mock_session = ChatSessionDB(
+                    id=uuid4(),
+                    user_id=mock_user.id,
+                    created_at=datetime.utcnow(),
+                    updated_at=datetime.utcnow(),
+                    ended_at=None,
+                    metadata={},
+                )
+                mock_service.return_value.create_session = AsyncMock(
+                    return_value=mock_session
+                )
+                mock_service.return_value.add_message = AsyncMock()
+                mock_service.return_value.get_recent_messages = AsyncMock(
+                    return_value=MagicMock(messages=[], total_tokens=0, truncated=False)
+                )
+
+                # Mock agent response
+                with patch("tripsage.api.routers.chat.get_travel_agent") as mock_agent:
+                    mock_agent.return_value.run = AsyncMock(
+                        return_value={
+                            "content": "Streaming response test",
+                            "tool_calls": [],
+                        }
+                    )
+
+                    # Send request with streaming enabled
+                    response = await client.post(
+                        "/api/chat/",
+                        headers=auth_headers,
+                        json={
+                            "messages": [{"role": "user", "content": "Hello"}],
+                            "stream": True,
+                        },
+                    )
+
+                    assert response.status_code == status.HTTP_200_OK
+                    assert (
+                        response.headers["content-type"]
+                        == "text/event-stream; charset=utf-8"
+                    )
+                    assert response.headers.get("x-vercel-ai-data-stream") == "v1"
+                    assert response.headers.get("x-session-id") is not None

--- a/tests/api/test_chat_sessions.py
+++ b/tests/api/test_chat_sessions.py
@@ -1,0 +1,463 @@
+"""Tests for chat session management endpoints."""
+
+import json
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from tripsage.api.models.chat import ChatMessage, ChatRequest, SessionHistoryResponse
+from tripsage.models.db.chat import (
+    ChatMessageDB,
+    ChatSessionDB,
+    ChatSessionWithStats,
+    RecentMessagesResponse,
+    MessageWithTokenEstimate,
+)
+
+
+@pytest.fixture
+def mock_chat_service():
+    """Create a mock chat service."""
+    with patch("tripsage.api.routers.chat.ChatService") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_travel_agent():
+    """Create a mock travel agent."""
+    with patch("tripsage.api.routers.chat.get_travel_agent") as mock:
+        agent = AsyncMock()
+        agent.run = AsyncMock(
+            return_value={
+                "content": "I can help you plan your trip!",
+                "tool_calls": [],
+                "model": "gpt-4",
+            }
+        )
+        mock.return_value = agent
+        yield agent
+
+
+class TestChatSessionEndpoints:
+    """Test cases for chat session endpoints."""
+
+    def test_create_new_session(
+        self, client: TestClient, mock_chat_service, mock_travel_agent
+    ):
+        """Test creating a new chat session on first message."""
+        # Arrange
+        session_id = uuid4()
+        user_id = 1
+
+        # Mock chat service
+        mock_service_instance = AsyncMock()
+        mock_chat_service.return_value = mock_service_instance
+
+        # Mock create session
+        mock_session = ChatSessionDB(
+            id=session_id,
+            user_id=user_id,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+            ended_at=None,
+            metadata={},
+        )
+        mock_service_instance.create_session.return_value = mock_session
+
+        # Mock get recent messages
+        mock_service_instance.get_recent_messages.return_value = RecentMessagesResponse(
+            messages=[],
+            total_tokens=0,
+            truncated=False,
+        )
+
+        # Mock add message
+        mock_service_instance.add_message.return_value = AsyncMock()
+
+        # Act
+        response = client.post(
+            "/api/chat/",
+            json={
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": False,
+            },
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert "session_id" in data
+        assert data["content"] == "I can help you plan your trip!"
+        mock_service_instance.create_session.assert_called_once()
+
+    def test_continue_existing_session(
+        self, client: TestClient, mock_chat_service, mock_travel_agent
+    ):
+        """Test continuing an existing chat session."""
+        # Arrange
+        session_id = uuid4()
+        user_id = 1
+
+        # Mock chat service
+        mock_service_instance = AsyncMock()
+        mock_chat_service.return_value = mock_service_instance
+
+        # Mock get session
+        mock_session = ChatSessionDB(
+            id=session_id,
+            user_id=user_id,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+            ended_at=None,
+            metadata={},
+        )
+        mock_service_instance.get_session.return_value = mock_session
+
+        # Mock get recent messages with history
+        mock_messages = [
+            MessageWithTokenEstimate(
+                id=1,
+                session_id=session_id,
+                role="user",
+                content="Hello",
+                created_at=datetime.utcnow(),
+                metadata={},
+                estimated_tokens=2,
+            ),
+            MessageWithTokenEstimate(
+                id=2,
+                session_id=session_id,
+                role="assistant",
+                content="Hi! How can I help?",
+                created_at=datetime.utcnow(),
+                metadata={},
+                estimated_tokens=5,
+            ),
+        ]
+        mock_service_instance.get_recent_messages.return_value = RecentMessagesResponse(
+            messages=mock_messages,
+            total_tokens=7,
+            truncated=False,
+        )
+
+        # Mock add message
+        mock_service_instance.add_message.return_value = AsyncMock()
+
+        # Act
+        response = client.post(
+            "/api/chat/",
+            json={
+                "messages": [{"role": "user", "content": "Plan a trip to Paris"}],
+                "session_id": str(session_id),
+                "stream": False,
+            },
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["session_id"] == str(session_id)
+        mock_service_instance.get_session.assert_called_once_with(session_id, user_id)
+
+    def test_session_not_found(self, client: TestClient, mock_chat_service):
+        """Test handling of non-existent session."""
+        # Arrange
+        session_id = uuid4()
+
+        # Mock chat service
+        mock_service_instance = AsyncMock()
+        mock_chat_service.return_value = mock_service_instance
+        mock_service_instance.get_session.side_effect = Exception("Session not found")
+
+        # Act
+        response = client.post(
+            "/api/chat/",
+            json={
+                "messages": [{"role": "user", "content": "Hello"}],
+                "session_id": str(session_id),
+                "stream": False,
+            },
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert "Session not found" in response.json()["detail"]
+
+    def test_streaming_response(
+        self, client: TestClient, mock_chat_service, mock_travel_agent
+    ):
+        """Test streaming chat response."""
+        # Arrange
+        session_id = uuid4()
+        user_id = 1
+
+        # Mock chat service
+        mock_service_instance = AsyncMock()
+        mock_chat_service.return_value = mock_service_instance
+
+        # Mock create session
+        mock_session = ChatSessionDB(
+            id=session_id,
+            user_id=user_id,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+            ended_at=None,
+            metadata={},
+        )
+        mock_service_instance.create_session.return_value = mock_session
+        mock_service_instance.get_recent_messages.return_value = RecentMessagesResponse(
+            messages=[],
+            total_tokens=0,
+            truncated=False,
+        )
+        mock_service_instance.add_message.return_value = AsyncMock()
+
+        # Act
+        with client.stream(
+            "POST",
+            "/api/chat/",
+            json={
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+            },
+            headers={"Authorization": "Bearer test-token"},
+        ) as response:
+            # Assert
+            assert response.status_code == status.HTTP_200_OK
+            assert (
+                response.headers["content-type"] == "text/event-stream; charset=utf-8"
+            )
+            assert "X-Session-Id" in response.headers
+
+            # Read streaming content
+            chunks = []
+            for chunk in response.iter_text():
+                chunks.append(chunk)
+
+            # Should have text chunks and finish message
+            assert len(chunks) > 0
+            assert any('0:"' in chunk for chunk in chunks)  # Text chunks
+            assert any(
+                'd:{"finishReason":"stop"' in chunk for chunk in chunks
+            )  # Finish
+
+    def test_get_session_history(self, client: TestClient, mock_chat_service):
+        """Test getting session history."""
+        # Arrange
+        session_id = uuid4()
+        user_id = 1
+
+        # Mock chat service
+        mock_service_instance = AsyncMock()
+        mock_chat_service.return_value = mock_service_instance
+
+        # Mock get session
+        mock_session = ChatSessionDB(
+            id=session_id,
+            user_id=user_id,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+            ended_at=None,
+            metadata={"source": "web"},
+        )
+        mock_service_instance.get_session.return_value = mock_session
+
+        # Mock get messages
+        mock_messages = [
+            ChatMessageDB(
+                id=1,
+                session_id=session_id,
+                role="user",
+                content="Hello",
+                created_at=datetime.utcnow(),
+                metadata={},
+            ),
+            ChatMessageDB(
+                id=2,
+                session_id=session_id,
+                role="assistant",
+                content="Hi there!",
+                created_at=datetime.utcnow(),
+                metadata={},
+            ),
+        ]
+        mock_service_instance.get_messages.return_value = mock_messages
+
+        # Act
+        response = client.get(
+            f"/api/chat/sessions/{session_id}/history",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["session_id"] == str(session_id)
+        assert len(data["messages"]) == 2
+        assert data["messages"][0]["role"] == "user"
+        assert data["messages"][1]["role"] == "assistant"
+        assert data["metadata"] == {"source": "web"}
+
+    def test_get_active_sessions(self, client: TestClient, mock_chat_service):
+        """Test getting active sessions for a user."""
+        # Arrange
+        user_id = 1
+        session_id = uuid4()
+
+        # Mock chat service
+        mock_service_instance = AsyncMock()
+        mock_chat_service.return_value = mock_service_instance
+
+        # Mock active sessions
+        mock_sessions = [
+            ChatSessionWithStats(
+                id=session_id,
+                user_id=user_id,
+                created_at=datetime.utcnow(),
+                updated_at=datetime.utcnow(),
+                ended_at=None,
+                metadata={},
+                message_count=10,
+                last_message_at=datetime.utcnow(),
+            )
+        ]
+        mock_service_instance.get_active_sessions.return_value = mock_sessions
+
+        # Act
+        response = client.get(
+            "/api/chat/sessions/active?limit=5",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data["sessions"]) == 1
+        assert data["sessions"][0]["id"] == str(session_id)
+        assert data["sessions"][0]["message_count"] == 10
+
+    def test_end_session(self, client: TestClient, mock_chat_service):
+        """Test ending a chat session."""
+        # Arrange
+        session_id = uuid4()
+        user_id = 1
+
+        # Mock chat service
+        mock_service_instance = AsyncMock()
+        mock_chat_service.return_value = mock_service_instance
+
+        # Mock get session (for verification)
+        mock_session = ChatSessionDB(
+            id=session_id,
+            user_id=user_id,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+            ended_at=None,
+            metadata={},
+        )
+        mock_service_instance.get_session.return_value = mock_session
+
+        # Mock end session
+        mock_service_instance.end_session.return_value = AsyncMock()
+
+        # Act
+        response = client.post(
+            f"/api/chat/sessions/{session_id}/end",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["message"] == "Session ended successfully"
+        assert data["session_id"] == str(session_id)
+        mock_service_instance.end_session.assert_called_once_with(session_id)
+
+    def test_continue_session_endpoint(
+        self, client: TestClient, mock_chat_service, mock_travel_agent
+    ):
+        """Test the continue session specific endpoint."""
+        # Arrange
+        session_id = uuid4()
+        user_id = 1
+
+        # Mock chat service
+        mock_service_instance = AsyncMock()
+        mock_chat_service.return_value = mock_service_instance
+
+        # Mock get session
+        mock_session = ChatSessionDB(
+            id=session_id,
+            user_id=user_id,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+            ended_at=None,
+            metadata={},
+        )
+        mock_service_instance.get_session.return_value = mock_session
+        mock_service_instance.get_recent_messages.return_value = RecentMessagesResponse(
+            messages=[],
+            total_tokens=0,
+            truncated=False,
+        )
+        mock_service_instance.add_message.return_value = AsyncMock()
+
+        # Act
+        response = client.post(
+            f"/api/chat/sessions/{session_id}/continue",
+            json={
+                "messages": [{"role": "user", "content": "What about hotels?"}],
+                "stream": False,
+            },
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["session_id"] == str(session_id)
+
+    def test_invalid_message_format(self, client: TestClient):
+        """Test handling of invalid message format."""
+        # Act
+        response = client.post(
+            "/api/chat/",
+            json={
+                "messages": [],  # Empty messages
+                "stream": False,
+            },
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "No messages provided" in response.json()["detail"]
+
+    def test_last_message_not_user(self, client: TestClient):
+        """Test that last message must be from user."""
+        # Act
+        response = client.post(
+            "/api/chat/",
+            json={
+                "messages": [
+                    {"role": "user", "content": "Hello"},
+                    {
+                        "role": "assistant",
+                        "content": "Hi",
+                    },  # Last message not from user
+                ],
+                "stream": False,
+            },
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Assert
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Last message must be from user" in response.json()["detail"]

--- a/tripsage/api/routers/chat.py
+++ b/tripsage/api/routers/chat.py
@@ -1,7 +1,7 @@
 """Chat router for TripSage API.
 
 This module provides endpoints for AI chat functionality, including streaming
-responses compatible with Vercel AI SDK.
+responses compatible with Vercel AI SDK and session persistence.
 """
 
 import asyncio
@@ -12,17 +12,21 @@ from uuid import UUID, uuid4
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from tripsage.agents.travel import TravelPlanningAgent
-from tripsage.api.core.dependencies import get_session_memory
+from tripsage.api.core.dependencies import get_db, get_session_memory
 from tripsage.api.middlewares.auth import get_current_user
+from tripsage.api.services.chat_service import ChatService, RateLimiter
+from tripsage.models.db.user import UserDB
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-# Global agent instance (singleton pattern)
+# Global instances (singleton pattern)
 _travel_agent = None
+_rate_limiter = None
 
 
 def get_travel_agent() -> TravelPlanningAgent:
@@ -31,6 +35,19 @@ def get_travel_agent() -> TravelPlanningAgent:
     if _travel_agent is None:
         _travel_agent = TravelPlanningAgent()
     return _travel_agent
+
+
+def get_rate_limiter() -> RateLimiter:
+    """Get or create the rate limiter singleton."""
+    global _rate_limiter
+    if _rate_limiter is None:
+        _rate_limiter = RateLimiter(max_messages=10, window_seconds=60)
+    return _rate_limiter
+
+
+async def get_chat_service(db: AsyncSession = Depends(get_db)) -> ChatService:
+    """Get chat service instance."""
+    return ChatService(db, rate_limiter=get_rate_limiter())
 
 
 class ChatMessage(BaseModel):
@@ -136,15 +153,17 @@ async def stream_agent_response(
 @router.post("/")
 async def chat(
     request: ChatRequest,
-    user_id: str = Depends(get_current_user),
+    current_user: UserDB = Depends(get_current_user),
     session_memory: dict = Depends(get_session_memory),
+    chat_service: ChatService = Depends(get_chat_service),
 ):
-    """Handle chat requests with optional streaming.
+    """Handle chat requests with optional streaming and session persistence.
 
     Args:
         request: Chat request
-        user_id: Current user ID
+        current_user: Current user object
         session_memory: Session memory
+        chat_service: Chat service instance
 
     Returns:
         StreamingResponse for streaming requests, ChatResponse otherwise
@@ -166,30 +185,113 @@ async def chat(
             detail="Last message must be from user",
         )
 
-    # Build context
+    # Create or get session
+    session_id = request.session_id
+    if not session_id:
+        # Create new session
+        session = await chat_service.create_session(
+            user_id=current_user.id,
+            metadata={"agent": "travel_planning", "stream": request.stream},
+        )
+        session_id = session.id
+        logger.info(f"Created new chat session {session_id} for user {current_user.id}")
+    else:
+        # Verify session exists and belongs to user
+        try:
+            session = await chat_service.get_session(
+                session_id, user_id=current_user.id
+            )
+        except Exception:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Session not found or access denied",
+            )
+
+    # Store incoming message
+    try:
+        await chat_service.add_message(
+            session_id=session_id,
+            role=last_message.role,
+            content=last_message.content,
+            user_id=current_user.id,
+        )
+    except Exception as e:
+        if "Rate limit exceeded" in str(e):
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail=str(e),
+            )
+        raise
+
+    # Build context with session history
+    recent_messages = await chat_service.get_recent_messages(
+        session_id=session_id, limit=50, max_tokens=4000
+    )
+
     context = {
-        "user_id": user_id,
-        "session_id": str(request.session_id) if request.session_id else None,
+        "user_id": str(current_user.id),
+        "session_id": str(session_id),
         "session_memory": session_memory,
-        "message_history": [msg.model_dump() for msg in request.messages[:-1]],
+        "message_history": [
+            {"role": msg.role, "content": msg.content}
+            for msg in recent_messages.messages[
+                :-1
+            ]  # Exclude last message we just added
+        ],
     }
 
     # Handle streaming vs non-streaming
     if request.stream:
         # Return streaming response with Vercel AI SDK protocol
+        async def stream_with_persistence():
+            """Stream response and persist assistant message."""
+            full_content = ""
+            tool_calls = []
+
+            async for chunk in stream_agent_response(
+                agent, last_message.content, context
+            ):
+                # Extract content from chunk if it's a text chunk
+                if chunk.startswith('0:"'):
+                    content_part = chunk[3:-2]  # Remove 0:" prefix and "\n suffix
+                    full_content += content_part
+                yield chunk
+
+            # Store assistant response after streaming completes
+            if full_content:
+                await chat_service.add_message(
+                    session_id=session_id,
+                    role="assistant",
+                    content=full_content,
+                    metadata={"tool_calls": tool_calls} if tool_calls else None,
+                )
+
         return StreamingResponse(
-            stream_agent_response(agent, last_message.content, context),
+            stream_with_persistence(),
             media_type="text/event-stream",
             headers={
                 "Cache-Control": "no-cache",
                 "Connection": "keep-alive",
                 "X-Vercel-AI-Data-Stream": "v1",
+                "X-Session-Id": str(session_id),  # Include session ID in response
             },
         )
     else:
         # Return regular JSON response
         response = await agent.run(last_message.content, context)
+
+        # Store assistant response
+        await chat_service.add_message(
+            session_id=session_id,
+            role="assistant",
+            content=response.get("content", ""),
+            metadata={"tool_calls": response.get("tool_calls", [])}
+            if response.get("tool_calls")
+            else None,
+        )
+
         return ChatResponse(
+            id=session_id,  # Use session ID as response ID for consistency
             content=response.get("content", ""),
             tool_calls=response.get("tool_calls", []),
             finish_reason="stop",
@@ -200,16 +302,18 @@ async def chat(
 async def continue_session(
     session_id: UUID,
     request: ChatRequest,
-    user_id: str = Depends(get_current_user),
+    current_user: UserDB = Depends(get_current_user),
     session_memory: dict = Depends(get_session_memory),
+    chat_service: ChatService = Depends(get_chat_service),
 ):
     """Continue an existing chat session.
 
     Args:
         session_id: Session ID to continue
         request: Chat request
-        user_id: Current user ID
+        current_user: Current user object
         session_memory: Session memory
+        chat_service: Chat service instance
 
     Returns:
         StreamingResponse for streaming requests, ChatResponse otherwise
@@ -218,28 +322,121 @@ async def continue_session(
     request.session_id = session_id
 
     # Delegate to main chat endpoint
-    return await chat(request, user_id, session_memory)
+    return await chat(request, current_user, session_memory, chat_service)
 
 
 @router.get("/sessions/{session_id}/history")
 async def get_session_history(
     session_id: UUID,
-    user_id: str = Depends(get_current_user),
+    current_user: UserDB = Depends(get_current_user),
+    chat_service: ChatService = Depends(get_chat_service),
+    limit: int = 100,
+    offset: int = 0,
 ):
     """Get chat history for a session.
 
     Args:
         session_id: Session ID
-        user_id: Current user ID
+        current_user: Current user object
+        chat_service: Chat service instance
+        limit: Maximum number of messages to return
+        offset: Number of messages to skip
 
     Returns:
-        List of messages in the session
+        Session with message history
     """
-    # TODO: Implement session history retrieval from database
-    # For now, return empty history
+    # Get session (verifies access)
+    try:
+        session = await chat_service.get_session(session_id, user_id=current_user.id)
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Session not found or access denied",
+        )
+
+    # Get messages
+    messages = await chat_service.get_messages(session_id, limit=limit, offset=offset)
+
     return {
-        "session_id": str(session_id),
-        "messages": [],
-        "created_at": None,
-        "updated_at": None,
+        "session_id": str(session.id),
+        "messages": [
+            {
+                "id": msg.id,
+                "role": msg.role,
+                "content": msg.content,
+                "created_at": msg.created_at.isoformat(),
+                "metadata": msg.metadata,
+            }
+            for msg in messages
+        ],
+        "created_at": session.created_at.isoformat(),
+        "updated_at": session.updated_at.isoformat(),
+        "ended_at": session.ended_at.isoformat() if session.ended_at else None,
+        "metadata": session.metadata,
     }
+
+
+@router.get("/sessions")
+async def list_sessions(
+    current_user: UserDB = Depends(get_current_user),
+    chat_service: ChatService = Depends(get_chat_service),
+    limit: int = 20,
+):
+    """List active chat sessions for the current user.
+
+    Args:
+        current_user: Current user object
+        chat_service: Chat service instance
+        limit: Maximum number of sessions to return
+
+    Returns:
+        List of active sessions with statistics
+    """
+    sessions = await chat_service.get_active_sessions(current_user.id, limit=limit)
+
+    return {
+        "sessions": [
+            {
+                "id": str(session.id),
+                "created_at": session.created_at.isoformat(),
+                "updated_at": session.updated_at.isoformat(),
+                "message_count": session.message_count,
+                "last_message_at": session.last_message_at.isoformat()
+                if session.last_message_at
+                else None,
+                "metadata": session.metadata,
+            }
+            for session in sessions
+        ]
+    }
+
+
+@router.post("/sessions/{session_id}/end")
+async def end_session(
+    session_id: UUID,
+    current_user: UserDB = Depends(get_current_user),
+    chat_service: ChatService = Depends(get_chat_service),
+):
+    """End a chat session.
+
+    Args:
+        session_id: Session ID to end
+        current_user: Current user object
+        chat_service: Chat service instance
+
+    Returns:
+        Success message
+    """
+    # Verify session belongs to user
+    try:
+        await chat_service.get_session(session_id, user_id=current_user.id)
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Session not found or access denied",
+        )
+
+    # End the session
+    await chat_service.end_session(session_id)
+
+    return {"message": "Session ended successfully", "session_id": str(session_id)}

--- a/tripsage/api/services/chat_service.py
+++ b/tripsage/api/services/chat_service.py
@@ -1,0 +1,511 @@
+"""Chat service for managing sessions and messages.
+
+Handles chat session lifecycle, message persistence, and context management.
+"""
+
+import logging
+from datetime import datetime
+from typing import Any, Optional
+from uuid import UUID, uuid4
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tripsage.api.core.exceptions import NotFoundError, ValidationError
+from tripsage.models.db.chat import (
+    ChatMessageDB,
+    ChatSessionDB,
+    ChatSessionWithStats,
+    ChatToolCallDB,
+    MessageWithTokenEstimate,
+    RecentMessagesResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ChatService:
+    """Service for managing chat sessions and messages."""
+
+    def __init__(self, db: AsyncSession):
+        """Initialize chat service.
+
+        Args:
+            db: Database session
+        """
+        self.db = db
+
+    async def create_session(
+        self, user_id: int, metadata: Optional[dict[str, Any]] = None
+    ) -> ChatSessionDB:
+        """Create a new chat session.
+
+        Args:
+            user_id: ID of the user
+            metadata: Optional session metadata
+
+        Returns:
+            Created chat session
+        """
+        session_id = uuid4()
+        metadata = metadata or {}
+
+        query = text(
+            """
+            INSERT INTO chat_sessions (id, user_id, metadata)
+            VALUES (:id, :user_id, :metadata)
+            RETURNING id, user_id, created_at, updated_at, ended_at, metadata
+            """
+        )
+
+        result = await self.db.execute(
+            query, {"id": session_id, "user_id": user_id, "metadata": metadata}
+        )
+        row = result.fetchone()
+
+        if not row:
+            raise ValidationError("Failed to create chat session")
+
+        return ChatSessionDB(
+            id=row.id,
+            user_id=row.user_id,
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+            ended_at=row.ended_at,
+            metadata=row.metadata or {},
+        )
+
+    async def get_session(
+        self, session_id: UUID, user_id: Optional[int] = None
+    ) -> ChatSessionDB:
+        """Get a chat session by ID.
+
+        Args:
+            session_id: Session ID
+            user_id: Optional user ID for access control
+
+        Returns:
+            Chat session
+
+        Raises:
+            NotFoundError: If session not found
+        """
+        query = text(
+            """
+            SELECT id, user_id, created_at, updated_at, ended_at, metadata
+            FROM chat_sessions
+            WHERE id = :session_id
+            """
+        )
+        params = {"session_id": session_id}
+
+        if user_id is not None:
+            query = text(query.text + " AND user_id = :user_id")
+            params["user_id"] = user_id
+
+        result = await self.db.execute(query, params)
+        row = result.fetchone()
+
+        if not row:
+            raise NotFoundError(f"Chat session {session_id} not found")
+
+        return ChatSessionDB(
+            id=row.id,
+            user_id=row.user_id,
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+            ended_at=row.ended_at,
+            metadata=row.metadata or {},
+        )
+
+    async def get_active_sessions(
+        self, user_id: int, limit: int = 10
+    ) -> list[ChatSessionWithStats]:
+        """Get active sessions for a user.
+
+        Args:
+            user_id: User ID
+            limit: Maximum number of sessions to return
+
+        Returns:
+            List of active sessions with statistics
+        """
+        query = text(
+            """
+            SELECT 
+                cs.id,
+                cs.user_id,
+                cs.created_at,
+                cs.updated_at,
+                cs.ended_at,
+                cs.metadata,
+                COUNT(cm.id) as message_count,
+                MAX(cm.created_at) as last_message_at
+            FROM chat_sessions cs
+            LEFT JOIN chat_messages cm ON cs.id = cm.session_id
+            WHERE cs.user_id = :user_id AND cs.ended_at IS NULL
+            GROUP BY cs.id, cs.user_id, cs.created_at, cs.updated_at, 
+                     cs.ended_at, cs.metadata
+            ORDER BY cs.updated_at DESC
+            LIMIT :limit
+            """
+        )
+
+        result = await self.db.execute(query, {"user_id": user_id, "limit": limit})
+        rows = result.fetchall()
+
+        return [
+            ChatSessionWithStats(
+                id=row.id,
+                user_id=row.user_id,
+                created_at=row.created_at,
+                updated_at=row.updated_at,
+                ended_at=row.ended_at,
+                metadata=row.metadata or {},
+                message_count=row.message_count or 0,
+                last_message_at=row.last_message_at,
+            )
+            for row in rows
+        ]
+
+    async def add_message(
+        self,
+        session_id: UUID,
+        role: str,
+        content: str,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> ChatMessageDB:
+        """Add a message to a chat session.
+
+        Args:
+            session_id: Session ID
+            role: Message role (user/assistant/system)
+            content: Message content
+            metadata: Optional message metadata
+
+        Returns:
+            Created message
+
+        Raises:
+            ValidationError: If message validation fails
+        """
+        metadata = metadata or {}
+
+        # Validate message
+        try:
+            ChatMessageDB(
+                id=0,  # Dummy ID for validation
+                session_id=session_id,
+                role=role,
+                content=content,
+                created_at=datetime.utcnow(),
+                metadata=metadata,
+            )
+        except ValueError as e:
+            raise ValidationError(str(e)) from e
+
+        # Insert message
+        query = text(
+            """
+            INSERT INTO chat_messages (session_id, role, content, metadata)
+            VALUES (:session_id, :role, :content, :metadata)
+            RETURNING id, session_id, role, content, created_at, metadata
+            """
+        )
+
+        result = await self.db.execute(
+            query,
+            {
+                "session_id": session_id,
+                "role": role,
+                "content": content,
+                "metadata": metadata,
+            },
+        )
+        row = result.fetchone()
+
+        if not row:
+            raise ValidationError("Failed to create message")
+
+        # Update session updated_at
+        await self.db.execute(
+            text("UPDATE chat_sessions SET updated_at = NOW() WHERE id = :session_id"),
+            {"session_id": session_id},
+        )
+
+        return ChatMessageDB(
+            id=row.id,
+            session_id=row.session_id,
+            role=row.role,
+            content=row.content,
+            created_at=row.created_at,
+            metadata=row.metadata or {},
+        )
+
+    async def get_messages(
+        self, session_id: UUID, limit: Optional[int] = None, offset: int = 0
+    ) -> list[ChatMessageDB]:
+        """Get messages for a session.
+
+        Args:
+            session_id: Session ID
+            limit: Maximum number of messages
+            offset: Number of messages to skip
+
+        Returns:
+            List of messages
+        """
+        query = text(
+            """
+            SELECT id, session_id, role, content, created_at, metadata
+            FROM chat_messages
+            WHERE session_id = :session_id
+            ORDER BY created_at ASC
+            """
+        )
+        params = {"session_id": session_id}
+
+        if limit is not None:
+            query = text(query.text + " LIMIT :limit OFFSET :offset")
+            params.update({"limit": limit, "offset": offset})
+
+        result = await self.db.execute(query, params)
+        rows = result.fetchall()
+
+        return [
+            ChatMessageDB(
+                id=row.id,
+                session_id=row.session_id,
+                role=row.role,
+                content=row.content,
+                created_at=row.created_at,
+                metadata=row.metadata or {},
+            )
+            for row in rows
+        ]
+
+    async def get_recent_messages(
+        self, session_id: UUID, limit: int = 10, max_tokens: int = 8000
+    ) -> RecentMessagesResponse:
+        """Get recent messages within token limit.
+
+        Uses the database function to retrieve messages that fit within
+        the specified token limit for context window management.
+
+        Args:
+            session_id: Session ID
+            limit: Maximum number of messages to consider
+            max_tokens: Maximum total tokens to include
+
+        Returns:
+            Recent messages response with token information
+        """
+        query = text(
+            """
+            SELECT * FROM get_recent_messages(:session_id, :limit, :max_tokens)
+            ORDER BY created_at ASC
+            """
+        )
+
+        result = await self.db.execute(
+            query,
+            {"session_id": session_id, "limit": limit, "max_tokens": max_tokens},
+        )
+        rows = result.fetchall()
+
+        messages = [
+            MessageWithTokenEstimate(
+                id=row.id,
+                session_id=session_id,
+                role=row.role,
+                content=row.content,
+                created_at=row.created_at,
+                metadata=row.metadata or {},
+                estimated_tokens=row.estimated_tokens,
+            )
+            for row in rows
+        ]
+
+        total_tokens = sum(msg.estimated_tokens for msg in messages)
+
+        # Check if we got fewer messages than requested (indicating truncation)
+        truncated = len(messages) < limit
+
+        return RecentMessagesResponse(
+            messages=messages, total_tokens=total_tokens, truncated=truncated
+        )
+
+    async def add_tool_call(
+        self,
+        message_id: int,
+        tool_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> ChatToolCallDB:
+        """Add a tool call record.
+
+        Args:
+            message_id: Message ID that triggered the tool call
+            tool_id: Unique identifier for this tool call
+            tool_name: Name of the tool
+            arguments: Tool arguments
+
+        Returns:
+            Created tool call record
+        """
+        query = text(
+            """
+            INSERT INTO chat_tool_calls (message_id, tool_id, tool_name, arguments)
+            VALUES (:message_id, :tool_id, :tool_name, :arguments)
+            RETURNING id, message_id, tool_id, tool_name, arguments, result, 
+                      status, created_at, completed_at, error_message
+            """
+        )
+
+        result = await self.db.execute(
+            query,
+            {
+                "message_id": message_id,
+                "tool_id": tool_id,
+                "tool_name": tool_name,
+                "arguments": arguments,
+            },
+        )
+        row = result.fetchone()
+
+        if not row:
+            raise ValidationError("Failed to create tool call")
+
+        return ChatToolCallDB(
+            id=row.id,
+            message_id=row.message_id,
+            tool_id=row.tool_id,
+            tool_name=row.tool_name,
+            arguments=row.arguments or {},
+            result=row.result,
+            status=row.status,
+            created_at=row.created_at,
+            completed_at=row.completed_at,
+            error_message=row.error_message,
+        )
+
+    async def update_tool_call(
+        self,
+        tool_call_id: int,
+        status: str,
+        result: Optional[dict[str, Any]] = None,
+        error_message: Optional[str] = None,
+    ) -> ChatToolCallDB:
+        """Update a tool call with result or error.
+
+        Args:
+            tool_call_id: Tool call ID
+            status: New status
+            result: Tool result (if successful)
+            error_message: Error message (if failed)
+
+        Returns:
+            Updated tool call record
+        """
+        # Validate status
+        ChatToolCallDB(
+            id=tool_call_id,
+            message_id=0,
+            tool_id="",
+            tool_name="",
+            status=status,
+            created_at=datetime.utcnow(),
+        )
+
+        completed_at = datetime.utcnow() if status in {"completed", "failed"} else None
+
+        query = text(
+            """
+            UPDATE chat_tool_calls
+            SET status = :status,
+                result = :result,
+                error_message = :error_message,
+                completed_at = :completed_at
+            WHERE id = :id
+            RETURNING id, message_id, tool_id, tool_name, arguments, result, 
+                      status, created_at, completed_at, error_message
+            """
+        )
+
+        result_row = await self.db.execute(
+            query,
+            {
+                "id": tool_call_id,
+                "status": status,
+                "result": result,
+                "error_message": error_message,
+                "completed_at": completed_at,
+            },
+        )
+        row = result_row.fetchone()
+
+        if not row:
+            raise NotFoundError(f"Tool call {tool_call_id} not found")
+
+        return ChatToolCallDB(
+            id=row.id,
+            message_id=row.message_id,
+            tool_id=row.tool_id,
+            tool_name=row.tool_name,
+            arguments=row.arguments or {},
+            result=row.result,
+            status=row.status,
+            created_at=row.created_at,
+            completed_at=row.completed_at,
+            error_message=row.error_message,
+        )
+
+    async def end_session(self, session_id: UUID) -> ChatSessionDB:
+        """End a chat session.
+
+        Args:
+            session_id: Session ID
+
+        Returns:
+            Updated session
+
+        Raises:
+            NotFoundError: If session not found
+        """
+        query = text(
+            """
+            UPDATE chat_sessions
+            SET ended_at = NOW(), updated_at = NOW()
+            WHERE id = :session_id
+            RETURNING id, user_id, created_at, updated_at, ended_at, metadata
+            """
+        )
+
+        result = await self.db.execute(query, {"session_id": session_id})
+        row = result.fetchone()
+
+        if not row:
+            raise NotFoundError(f"Chat session {session_id} not found")
+
+        return ChatSessionDB(
+            id=row.id,
+            user_id=row.user_id,
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+            ended_at=row.ended_at,
+            metadata=row.metadata or {},
+        )
+
+    async def cleanup_old_sessions(self, days_old: int = 30) -> int:
+        """Clean up old ended sessions.
+
+        Args:
+            days_old: Age threshold in days
+
+        Returns:
+            Number of sessions deleted
+        """
+        query = text("SELECT cleanup_old_sessions(:days_old)")
+        result = await self.db.execute(query, {"days_old": days_old})
+        count = result.scalar()
+        return count or 0

--- a/tripsage/models/db/chat.py
+++ b/tripsage/models/db/chat.py
@@ -1,0 +1,146 @@
+"""Database models for chat functionality.
+
+These models represent the database schema for chat sessions and messages.
+They are separate from the API models to maintain clean separation of concerns.
+"""
+
+from datetime import datetime
+from typing import Any, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class ChatSessionDB(BaseModel):
+    """Database model for chat sessions."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID = Field(..., description="Session ID")
+    user_id: int = Field(..., description="User ID from users table")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+    ended_at: Optional[datetime] = Field(None, description="Session end timestamp")
+    metadata: dict[str, Any] = Field(
+        default_factory=dict, description="Session metadata"
+    )
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def ensure_dict(cls, v: Any) -> dict[str, Any]:
+        """Ensure metadata is a dictionary."""
+        if v is None:
+            return {}
+        if isinstance(v, dict):
+            return v
+        return {}
+
+
+class ChatMessageDB(BaseModel):
+    """Database model for chat messages."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int = Field(..., description="Message ID")
+    session_id: UUID = Field(..., description="Session ID")
+    role: str = Field(..., description="Message role (user/assistant/system)")
+    content: str = Field(..., description="Message content")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    metadata: dict[str, Any] = Field(
+        default_factory=dict, description="Message metadata"
+    )
+
+    @field_validator("role")
+    @classmethod
+    def validate_role(cls, v: str) -> str:
+        """Validate message role."""
+        valid_roles = {"user", "assistant", "system"}
+        if v not in valid_roles:
+            raise ValueError(f"Role must be one of {valid_roles}")
+        return v
+
+    @field_validator("content")
+    @classmethod
+    def validate_content_length(cls, v: str) -> str:
+        """Validate content length (32KB limit)."""
+        if len(v) > 32768:
+            raise ValueError("Message content exceeds 32KB limit")
+        return v
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def ensure_dict(cls, v: Any) -> dict[str, Any]:
+        """Ensure metadata is a dictionary."""
+        if v is None:
+            return {}
+        if isinstance(v, dict):
+            return v
+        return {}
+
+
+class ChatToolCallDB(BaseModel):
+    """Database model for tool calls within chat messages."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int = Field(..., description="Tool call database ID")
+    message_id: int = Field(..., description="Message ID that triggered this tool call")
+    tool_id: str = Field(
+        ..., description="Unique identifier for this tool call instance"
+    )
+    tool_name: str = Field(..., description="Name of the tool")
+    arguments: dict[str, Any] = Field(
+        default_factory=dict, description="Tool arguments"
+    )
+    result: Optional[dict[str, Any]] = Field(None, description="Tool result")
+    status: str = Field("pending", description="Tool call status")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    completed_at: Optional[datetime] = Field(None, description="Completion timestamp")
+    error_message: Optional[str] = Field(None, description="Error message if failed")
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str) -> str:
+        """Validate tool call status."""
+        valid_statuses = {"pending", "running", "completed", "failed"}
+        if v not in valid_statuses:
+            raise ValueError(f"Status must be one of {valid_statuses}")
+        return v
+
+    @field_validator("arguments", mode="before")
+    @classmethod
+    def ensure_dict_args(cls, v: Any) -> dict[str, Any]:
+        """Ensure arguments is a dictionary."""
+        if v is None:
+            return {}
+        if isinstance(v, dict):
+            return v
+        return {}
+
+
+class ChatSessionWithStats(ChatSessionDB):
+    """Chat session with additional statistics."""
+
+    message_count: int = Field(0, description="Total messages in session")
+    last_message_at: Optional[datetime] = Field(
+        None, description="Timestamp of last message"
+    )
+
+
+class MessageWithTokenEstimate(ChatMessageDB):
+    """Chat message with token estimation."""
+
+    estimated_tokens: int = Field(..., description="Estimated token count")
+
+
+# Response models for queries
+class RecentMessagesResponse(BaseModel):
+    """Response for recent messages query."""
+
+    messages: list[MessageWithTokenEstimate] = Field(
+        ..., description="Recent messages within token limit"
+    )
+    total_tokens: int = Field(..., description="Total estimated tokens")
+    truncated: bool = Field(
+        False, description="Whether messages were truncated due to token limit"
+    )


### PR DESCRIPTION
## Summary

This PR completes **Phase 1.2** of the AI Chat Integration by implementing chat session persistence and message history management, building on PR #120 which completed Phase 1.1.

## Changes

### 🗄️ Database Schema
- **Created new tables**:
  - `chat_sessions` - Stores chat session metadata with user association
  - `chat_messages` - Stores individual messages within sessions
  - `chat_tool_calls` - Tracks tool usage during conversations
- **Added performance indexes** on commonly queried fields
- **Implemented database functions**:
  - `get_recent_messages()` - Retrieves messages within token limits
  - `cleanup_old_sessions()` - Maintenance function for old sessions
- **Created views**:
  - `active_chat_sessions` - Shows currently active sessions with stats

### 🔧 Service Layer
- **ChatService class** for managing session lifecycle:
  - Create/retrieve/end sessions
  - Add/retrieve messages with metadata
  - Track tool calls with status updates
  - Context window management with token estimation
- **Token estimation logic** (4 chars ≈ 1 token)
- **Session cleanup capabilities**

### 🔌 API Integration
- **Updated chat endpoints** to use ChatService
- **Session persistence** across requests
- **Message history retrieval** for context
- **Session management endpoints**:
  - Continue existing sessions
  - Get session history
  - List active sessions
  - End sessions

### 🧪 Testing
- **Comprehensive test suite** for ChatService (17 test cases)
- **API endpoint tests** for session management (12 test cases)
- **Mock-based testing** for database interactions
- **Coverage of error scenarios and edge cases**

## Technical Details

- Uses UUID for session IDs for security and uniqueness
- Implements proper foreign key constraints with CASCADE deletes
- Adds update triggers for automatic timestamp management
- Follows KISS principle with straightforward SQL queries
- Maintains clean separation between DB models and API models

## Migration

```sql
-- Apply migration
psql -U your_user -d your_db -f migrations/20250522_01_add_chat_session_tables.sql

-- Rollback if needed
psql -U your_user -d your_db -f migrations/20250522_01_add_chat_session_tables_rollback.sql
```

## Next Steps

This completes Phase 1.2. The remaining phases are:
- Phase 2: Authentication & BYOK integration
- Phase 3: Tool calling & MCP integration  
- Phase 4: File handling & attachments processing

## Related Issues

- Completes Phase 1.2 from `tasks/TODO-INTEGRATION.md`
- Part of the AI Chat Integration epic
- Builds on PR #120 (Phase 1.1)

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Implement Phase 1.2 of AI Chat Integration by adding persistent chat sessions, message history storage, and session management capabilities across the service layer, database schema, and API endpoints.

New Features:
- Persist chat sessions and metadata with a dedicated chat_sessions table.
- Store and retrieve message history in chat_messages and expose history via API.
- Track and record tool calls per message in chat_tool_calls.
- Add API endpoints to create, continue, list active, retrieve history, and end chat sessions.

Enhancements:
- Introduce token estimation and context window management via get_recent_messages database function.
- Provide session cleanup support with cleanup_old_sessions maintenance function.

Build:
- Add SQL migrations to create chat_sessions, chat_messages, chat_tool_calls tables, related indexes, views, functions, and rollback scripts.

Tests:
- Add comprehensive unit tests for ChatService covering session lifecycle, messages, and tool calls.
- Add API integration tests for chat session endpoints, including creation, continuation, streaming, history, listing, and error cases.