### PR TITLE
Potential fix for code scanning alert no. 137: Insecure randomness

### DIFF
--- a/frontend/src/test/trip-store-test-helpers.ts
+++ b/frontend/src/test/trip-store-test-helpers.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { vi } from "vitest";
+import { randomInt, randomUUID } from "crypto";
 
 // Global storage for mock data that persists across client instances
 const globalMockData: Record<string, any[]> = {
@@ -8,11 +9,11 @@ const globalMockData: Record<string, any[]> = {
 
 // Helper to generate trip data
 const generateTripData = (data: any) => {
-  const id = Date.now() + Math.floor(Math.random() * 1000);
+  const id = Date.now() + randomInt(0, 1000);
   const now = new Date().toISOString();
   return {
     id,
-    uuid_id: `uuid-${id}`,
+    uuid_id: randomUUID(),
     user_id: "test-user-id",
     title: data.title || data.name || "Untitled Trip",
     name: data.title || data.name || "Untitled Trip",


### PR DESCRIPTION
Potential fix for [https://github.com/BjornMelin/tripsage-ai/security/code-scanning/137](https://github.com/BjornMelin/tripsage-ai/security/code-scanning/137)

To fix the problem, we should replace any use of `Math.random()` that is being used for "UUID" or security-sensitive purposes with a cryptographically secure alternative. In Node.js environments, the standard way is to use the `crypto` module's `randomUUID()` method (from Node.js v14.17.0+), or alternatively, to generate random values via `crypto.randomBytes`. For browser-based environments, `window.crypto.getRandomValues` is used, but as this is a `.ts` file which appears in a Vite/Vitest context, Node.js methods should be preferred.  
Since the affected code is constructing a `uuid_id` as a string, the simplest and most robust fix is to use `crypto.randomUUID()` to provide a compliant, well-formatted and cryptographically secure UUID string. We'll import the node `crypto` module (`import { randomUUID } from "crypto";`) at the top, and update the construction of `uuid_id` to use `randomUUID()`.  
Additionally, since the `id` integer is also using `Math.random()` for generation, and this value is used as the primary key (`id`), we should make this deterministic and robust as well—possibly by using a counter or the timestamp alone, but to maintain current behavior with randomness, we can use `crypto.randomInt`. However, for test data where only uniqueness is needed, simply using incrementing IDs or timestamps is less error-prone. Here, for security and to maintain logic, let's switch the randomness to `crypto.randomInt`.  
Required edits:
- Add `import { randomInt, randomUUID } from "crypto";` at the top,
- Update `id` generation to use `Date.now() + randomInt(0, 1000)`,
- Update `uuid_id` to use `randomUUID()`.  
No external dependencies are needed—`crypto` is built into Node.js.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
