### PR TITLE
chore(deps): update tailwind-merge to 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "sonner": "^2.0.7",
     "streamdown": "^2.5.0",
     "stripe": "22.1.1",
-    "tailwind-merge": "^3.5.0",
+    "tailwind-merge": "^3.6.0",
     "use-stick-to-bottom": "^1.1.4",
     "web-vitals": "^5.2.0",
     "zod": "^4.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,8 +247,8 @@ importers:
         specifier: 22.1.1
         version: 22.1.1(@types/node@24.12.3)
       tailwind-merge:
-        specifier: ^3.5.0
-        version: 3.5.0
+        specifier: ^3.6.0
+        version: 3.6.0
       use-stick-to-bottom:
         specifier: ^1.1.4
         version: 1.1.4(react@19.2.6)
@@ -5782,8 +5782,8 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tailwind-merge@3.5.0:
-    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
   tailwindcss-animate@1.0.7:
     resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
@@ -11811,7 +11811,7 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
       remend: 1.3.0
-      tailwind-merge: 3.5.0
+      tailwind-merge: 3.6.0
       unified: 11.0.5
       unist-util-visit: 5.1.0
       unist-util-visit-parents: 6.0.2
@@ -11933,7 +11933,7 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tailwind-merge@3.5.0: {}
+  tailwind-merge@3.6.0: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@4.3.0):
     dependencies:


### PR DESCRIPTION
## Summary
- Updates `tailwind-merge` from `^3.5.0` to `^3.6.0`.
- Refreshes `pnpm-lock.yaml` so the direct dependency and `streamdown` resolve to `tailwind-merge@3.6.0`.
- Intentionally keeps `@types/node` on the current Node 24 line because this repo's runtime contract is Node `24.x`; `@types/node@25.x` would expose non-LTS Node 25 APIs to code that must run on Node 24.

Closes #732.
Parent: #731.

## Research evidence
- `tailwind-merge` v3.6.0 release: https://github.com/dcastil/tailwind-merge/releases/tag/v3.6.0
- `tailwind-merge` v3.5.0...v3.6.0 compare: https://github.com/dcastil/tailwind-merge/compare/v3.5.0...v3.6.0
- `tailwind-merge` v3.6.0 README states Tailwind v4.0-v4.3 support: https://github.com/dcastil/tailwind-merge/blob/v3.6.0/README.md
- Tailwind CSS v4.3 release notes: https://github.com/tailwindlabs/tailwindcss/releases/tag/v4.3.0
- Node previous releases page: https://nodejs.org/en/about/previous-releases
- Node Release WG schedule: https://github.com/nodejs/Release
- ADR-0017 in this repo keeps Node 24 LTS as the runtime baseline.

## Validation evidence
- `pnpm up tailwind-merge@^3.6.0`
- `rtk err pnpm outdated` showed only `@types/node 24.12.3 -> 25.6.2`, intentionally held for Node 24 LTS compatibility.
- `rtk err pnpm audit --audit-level high`
- `rtk err pnpm deps:report`
- `rtk err pnpm biome:fix`
- `rtk err pnpm type-check`
- `rtk test pnpm test:affected`
- `rtk err pnpm install --frozen-lockfile`
- `git diff --check -- package.json pnpm-lock.yaml`
- Pre-PR dependency-source reviewer: passed; confirmed Tailwind 4.3 compatibility and Node typings hold.
- Pre-PR diff reviewer: passed; no PR-blocking findings.

## Docs impact
- No repository docs changed. The Node typings hold is documented in this PR because it preserves existing ADR-0017/runtime policy rather than changing it.

## Provider/deploy notes
- No provider or deployment configuration changes.
- No screenshots: package/lockfile-only dependency update.

## Residual risk
- `tailwind-merge@3.6.0` was published recently, but the repo uses only the stable `twMerge` named export through `cn()`, v3.6.0 adds Tailwind 4.3 support, and both local validation plus pre-PR reviews passed.
