### PR TITLE
fix(config): enforce feature-aware env contracts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,8 +42,8 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 # Optional: storage proxy URL (use on WSL if /storage/v1 returns 500 on 54321).
 SUPABASE_STORAGE_URL=
 # Public key (set ONE):
-# - Preferred (new): publishable key (sb_publishable_...)
-# - Legacy: anon key
+# - Canonical: publishable key (sb_publishable_...)
+# - Legacy fallback: anon key
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_...
 # NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
@@ -97,6 +97,7 @@ OPENWEATHERMAP_API_KEY=
 # ---------------------------------------------------------------------------
 # Payments
 # ---------------------------------------------------------------------------
+# Set all three when enabling payments; leave all unset when payments are disabled.
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
@@ -104,9 +105,10 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 # ---------------------------------------------------------------------------
 # Email / notifications
 # ---------------------------------------------------------------------------
+# Set all Resend values when enabling email notifications; leave all unset when disabled.
 RESEND_API_KEY=
-RESEND_FROM_EMAIL=noreply@example.com
-RESEND_FROM_NAME=TripSage
+RESEND_FROM_EMAIL=
+RESEND_FROM_NAME=
 COLLAB_WEBHOOK_URL=
 HMAC_SECRET=
 # Telemetry secrets (optional, but if set must be ≥32 chars for cryptographic security)
@@ -119,7 +121,10 @@ TELEMETRY_HASH_SECRET=
 # ---------------------------------------------------------------------------
 # Travel APIs
 # ---------------------------------------------------------------------------
-AMADEUS_CLIENT_ID="your_amadeus_client_id_here" # Amadeus API client ID for flight search
+# Set all Amadeus values when enabling Amadeus-backed flight search; leave all unset when disabled.
+AMADEUS_CLIENT_ID=
+AMADEUS_CLIENT_SECRET=
+AMADEUS_ENV=
 DUFFEL_ACCESS_TOKEN=
 DUFFEL_API_KEY=
 EPS_API_KEY=

--- a/.env.local.example
+++ b/.env.local.example
@@ -30,8 +30,8 @@ NEXT_PUBLIC_STREAMDOWN_ALLOWED_LINK_PREFIXES=
 # Local Supabase: run `pnpm supabase:start`, then `pnpm supabase:status` for values.
 NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
 # Supabase public key (client). Set ONE of:
-# - NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY (preferred, `sb_publishable_...`)
-# - NEXT_PUBLIC_SUPABASE_ANON_KEY (legacy name)
+# - NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY (canonical, `sb_publishable_...`)
+# - NEXT_PUBLIC_SUPABASE_ANON_KEY (legacy fallback)
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 # Optional: storage proxy URL (use on WSL if /storage/v1 returns 500 on 54321).
@@ -89,6 +89,7 @@ OPENWEATHERMAP_API_KEY=
 # ---------------------------------------------------------------------------
 # Payments
 # ---------------------------------------------------------------------------
+# Set all three when enabling payments; leave all unset when payments are disabled.
 STRIPE_SECRET_KEY=
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 STRIPE_WEBHOOK_SECRET=
@@ -96,9 +97,10 @@ STRIPE_WEBHOOK_SECRET=
 # ---------------------------------------------------------------------------
 # Email / notifications
 # ---------------------------------------------------------------------------
+# Set all Resend values when enabling email notifications; leave all unset when disabled.
 RESEND_API_KEY=
-RESEND_FROM_EMAIL=noreply@example.com
-RESEND_FROM_NAME=TripSage
+RESEND_FROM_EMAIL=
+RESEND_FROM_NAME=
 COLLAB_WEBHOOK_URL=
 HMAC_SECRET=
 MEM0_API_KEY=
@@ -106,7 +108,10 @@ MEM0_API_KEY=
 # ---------------------------------------------------------------------------
 # Travel APIs
 # ---------------------------------------------------------------------------
-AMADEUS_CLIENT_ID="your_amadeus_client_id_here" # Amadeus API client ID for flight search
+# Set all Amadeus values when enabling Amadeus-backed flight search; leave all unset when disabled.
+AMADEUS_CLIENT_ID=
+AMADEUS_CLIENT_SECRET=
+AMADEUS_ENV=
 DUFFEL_ACCESS_TOKEN=
 DUFFEL_API_KEY=
 EPS_API_KEY=

--- a/.env.test.example
+++ b/.env.test.example
@@ -15,10 +15,10 @@ NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces
 
 # ---- Supabase ------------------------------------------------------------
 # Supabase public key for tests. Set ONE of:
-# - NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY (preferred, `sb_publishable_...`)
-# - NEXT_PUBLIC_SUPABASE_ANON_KEY (legacy name)
-NEXT_PUBLIC_SUPABASE_ANON_KEY=anon-test-key
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
+# - NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY (canonical, `sb_publishable_...`)
+# - NEXT_PUBLIC_SUPABASE_ANON_KEY (legacy fallback)
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=publishable-test-key
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
 NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321
 SUPABASE_SERVICE_ROLE_KEY=service-role-test
 SUPABASE_JWT_SECRET=changeme-min-32-chars-test-secret-1
@@ -73,20 +73,23 @@ NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY=
 OPENWEATHERMAP_API_KEY=
 
 # ---- Payments --------------------------------------------------------------
+# Set all three when enabling payments; leave all unset when payments are disabled.
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 
 # ---- Email / notifications -------------------------------------------------
+# Set all Resend values when enabling email notifications; leave all unset when disabled.
 COLLAB_WEBHOOK_URL=
 HMAC_SECRET=
 RESEND_API_KEY=
-RESEND_FROM_EMAIL=noreply@test.local
-RESEND_FROM_NAME="TripSage QA"
+RESEND_FROM_EMAIL=
+RESEND_FROM_NAME=
 TELEMETRY_AI_DEMO_KEY=
 TELEMETRY_HASH_SECRET=
 
 # ---- Travel APIs -----------------------------------------------------------
+# Set all Amadeus values when enabling Amadeus-backed flight search; leave all unset when disabled.
 AMADEUS_CLIENT_ID=
 AMADEUS_CLIENT_SECRET=
 DUFFEL_ACCESS_TOKEN=
@@ -96,7 +99,7 @@ EPS_API_SECRET=
 EPS_BASE_URL=https://api.ean.com/2/rapid
 EPS_DEFAULT_CUSTOMER_IP=0.0.0.0
 EPS_DEFAULT_USER_AGENT="TripSage/1.0 (+https://tripsage.ai)"
-AMADEUS_ENV=test
+AMADEUS_ENV=
 
 # ---- Analytics (optional) --------------------------------------------------
 GOOGLE_ANALYTICS_ID=

--- a/README.md
+++ b/README.md
@@ -202,12 +202,13 @@ kubectl get pods -l app=tripsage-ai
 | Variable | Description | Required |
 | :--- | :--- | :--- |
 | `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL | ✅ |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase anonymous key | ✅ |
+| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | Supabase publishable key (`NEXT_PUBLIC_SUPABASE_ANON_KEY` remains a legacy fallback) | ✅ |
 | `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key | ✅ |
-| `AI_GATEWAY_API_KEY` | Vercel AI Gateway key | ✅ |
+| `AI_GATEWAY_API_KEY` | Vercel AI Gateway key (required only when AI demo/provider routes are enabled) | ⚠️ |
 | `DUFFEL_ACCESS_TOKEN` | Duffel API token for flights | ⚠️ |
-| `UPSTASH_REDIS_REST_URL` | Upstash Redis REST URL | ⚠️ |
-| `UPSTASH_REDIS_REST_TOKEN` | Upstash Redis REST token | ⚠️ |
+| `APP_BASE_URL` | Server origin for callbacks and absolute URLs | ✅ |
+| `UPSTASH_REDIS_REST_URL` | Upstash Redis REST URL | ✅ |
+| `UPSTASH_REDIS_REST_TOKEN` | Upstash Redis REST token | ✅ |
 | `NEXT_PUBLIC_STREAMDOWN_ALLOWED_LINK_PREFIXES` | Extra link prefix allowlist for markdown hardening (comma-separated) | ⚠️ |
 | `NEXT_PUBLIC_STREAMDOWN_ALLOWED_IMAGE_PREFIXES` | Image prefix allowlist for markdown hardening (comma-separated) | ⚠️ |
 
@@ -250,7 +251,7 @@ GET  /api/memory/context          # Get user context
 
 ```ts
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!)
+const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!)
 // authorize realtime with access token via RealtimeAuthProvider in app
 const channel = supabase.channel(`user:${userId}`, { config: { private: true } })
 channel.on('broadcast', { event: 'chat:message' }, ({ payload }) => console.log(payload))

--- a/docs/development/core/env-setup.md
+++ b/docs/development/core/env-setup.md
@@ -10,13 +10,13 @@ Notes:
 ## Core & Supabase
 
 - Core URLs (all usually `http://localhost:3000` during dev):
-  - `APP_BASE_URL`
+  - `APP_BASE_URL` (preferred server origin for callbacks and absolute URLs)
   - `NEXT_PUBLIC_APP_URL`
   - `NEXT_PUBLIC_SITE_URL`
   - `NEXT_PUBLIC_API_URL`
 - Supabase (Dashboard → Settings → API):
   - `NEXT_PUBLIC_SUPABASE_URL`
-  - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (preferred) or `NEXT_PUBLIC_SUPABASE_ANON_KEY` (legacy)
+  - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (canonical) or `NEXT_PUBLIC_SUPABASE_ANON_KEY` (legacy fallback)
   - `SUPABASE_SERVICE_ROLE_KEY`
   - `SUPABASE_JWT_SECRET`
   - Console: <https://supabase.com/dashboard>
@@ -80,6 +80,7 @@ These routes are cost-bearing/privileged and are disabled unless explicitly enab
   - `STRIPE_SECRET_KEY`
   - `STRIPE_WEBHOOK_SECRET` (<https://dashboard.stripe.com/webhooks>)
   - `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`
+  - Set all three when enabling payments; leave all unset when payments are disabled.
 
 ## Email / notifications
 
@@ -87,6 +88,7 @@ These routes are cost-bearing/privileged and are disabled unless explicitly enab
   - `RESEND_API_KEY`
   - `RESEND_FROM_EMAIL`
   - `RESEND_FROM_NAME`
+  - Set all three when enabling email notifications; leave all unset when email notifications are disabled.
 - Webhook signing:
   - `HMAC_SECRET` (generate a strong random string)
 
@@ -98,6 +100,7 @@ These routes are cost-bearing/privileged and are disabled unless explicitly enab
 - Amadeus Self-Service:
   - <https://developers.amadeus.com/get-started>
   - Variables: `AMADEUS_CLIENT_ID`, `AMADEUS_CLIENT_SECRET`, `AMADEUS_ENV` (`test`|`production`)
+  - Set all three when enabling Amadeus-backed travel search; leave all unset when disabled.
 - Google Places (New):
   - Enable Places API (New) + Photos in Google Cloud Console
   - Uses the same Google Maps Platform API keys (no separate Places API key required)

--- a/docs/development/core/local-supabase-rag-e2e.md
+++ b/docs/development/core/local-supabase-rag-e2e.md
@@ -33,7 +33,7 @@ pnpm supabase:reset:dev
 Then copy values from `pnpm supabase:status` into `.env.local`:
 
 - `NEXT_PUBLIC_SUPABASE_URL` → “Project URL”
-- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (preferred) **or** `NEXT_PUBLIC_SUPABASE_ANON_KEY` (legacy)
+- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (canonical) **or** `NEXT_PUBLIC_SUPABASE_ANON_KEY` (legacy fallback)
 - `SUPABASE_SERVICE_ROLE_KEY` → use the `sb_secret_...` value (server-only)
 - `SUPABASE_JWT_SECRET` → use the `JWT_SECRET` value (recommended; required for some non-test security flows)
 

--- a/docs/development/core/quick-start.md
+++ b/docs/development/core/quick-start.md
@@ -50,7 +50,7 @@ pnpm install
     Copy the printed local values into `.env.local`:
 
     - `NEXT_PUBLIC_SUPABASE_URL`
-    - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (preferred) or `NEXT_PUBLIC_SUPABASE_ANON_KEY` (legacy)
+    - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (canonical) or `NEXT_PUBLIC_SUPABASE_ANON_KEY` (legacy fallback)
     - `SUPABASE_SERVICE_ROLE_KEY` (use the `sb_secret_...` key from `pnpm supabase:status`)
     - (Recommended) `SUPABASE_JWT_SECRET` (use the `JWT_SECRET` value from `pnpm supabase:status`)
 
@@ -78,8 +78,8 @@ NEXT_PUBLIC_API_URL=http://localhost:3000
 # Supabase
 NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321
 # Set ONE of these public keys:
-# - Preferred: NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY (sb_publishable_...)
-# - Legacy: NEXT_PUBLIC_SUPABASE_ANON_KEY
+# - Canonical: NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY (sb_publishable_...)
+# - Legacy fallback: NEXT_PUBLIC_SUPABASE_ANON_KEY
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_...
 # NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=sb_secret_...

--- a/docs/operations/agent-frontend.md
+++ b/docs/operations/agent-frontend.md
@@ -21,7 +21,7 @@ All streaming endpoints return UI-compatible responses via `toUIMessageStreamRes
   - `UPSTASH_REDIS_REST_TOKEN`
 - Supabase SSR:
   - `NEXT_PUBLIC_SUPABASE_URL`
-  - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (preferred) or `NEXT_PUBLIC_SUPABASE_ANON_KEY` (legacy)
+  - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (canonical) or `NEXT_PUBLIC_SUPABASE_ANON_KEY` (legacy fallback)
 - QStash webhooks: `QSTASH_TOKEN`, `QSTASH_CURRENT_SIGNING_KEY`, `QSTASH_NEXT_SIGNING_KEY`
 - Model providers: BYOK or gateway keys (`OPENAI_API_KEY`, `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, `XAI_API_KEY`, `AI_GATEWAY_API_KEY`, `AI_GATEWAY_URL`)
 - Flights provider (Duffel): prefer `DUFFEL_ACCESS_TOKEN` (fallback `DUFFEL_API_KEY`)

--- a/docs/operations/deployment-guide.md
+++ b/docs/operations/deployment-guide.md
@@ -20,7 +20,7 @@ the CLI prebuilt deployment workflow after smoke checks pass.
 Copy the root `.env.example` to the target environment and fill the values (see [Environment Setup](../development/core/env-setup.md#environment-setup-guide-local-development) for how to obtain each key):
 
 - **Core URLs**: `APP_BASE_URL` (preferred server origin), `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_APP_NAME`, `NODE_ENV`
-- **Supabase**: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (canonical) or `NEXT_PUBLIC_SUPABASE_ANON_KEY` (legacy fallback), `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_JWT_SECRET` (Dashboard → Settings → API)
+- **Supabase**: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (canonical) or `NEXT_PUBLIC_SUPABASE_ANON_KEY` (legacy fallback), `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_JWT_SECRET` (Dashboard > Settings > API)
 - **Upstash/QStash**: `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `QSTASH_TOKEN`, `QSTASH_CURRENT_SIGNING_KEY`, `QSTASH_NEXT_SIGNING_KEY` (Upstash console)
 - **AI providers**: `AI_GATEWAY_API_KEY`, `AI_GATEWAY_URL`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, `XAI_API_KEY`, `EMBEDDINGS_API_KEY`
 - **Feature flags**: `ENABLE_AI_DEMO` (set to `"true"` to enable demo routes)

--- a/docs/operations/deployment-guide.md
+++ b/docs/operations/deployment-guide.md
@@ -19,16 +19,16 @@ the CLI prebuilt deployment workflow after smoke checks pass.
 
 Copy the root `.env.example` to the target environment and fill the values (see [Environment Setup](../development/core/env-setup.md#environment-setup-guide-local-development) for how to obtain each key):
 
-- **Core URLs**: `APP_BASE_URL`, `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_APP_NAME`, `NODE_ENV`
-- **Supabase**: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (preferred) or `NEXT_PUBLIC_SUPABASE_ANON_KEY` (legacy), `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_JWT_SECRET` (Dashboard → Settings → API)
+- **Core URLs**: `APP_BASE_URL` (preferred server origin), `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_APP_NAME`, `NODE_ENV`
+- **Supabase**: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (canonical) or `NEXT_PUBLIC_SUPABASE_ANON_KEY` (legacy fallback), `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_JWT_SECRET` (Dashboard → Settings → API)
 - **Upstash/QStash**: `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `QSTASH_TOKEN`, `QSTASH_CURRENT_SIGNING_KEY`, `QSTASH_NEXT_SIGNING_KEY` (Upstash console)
 - **AI providers**: `AI_GATEWAY_API_KEY`, `AI_GATEWAY_URL`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, `XAI_API_KEY`, `EMBEDDINGS_API_KEY`
 - **Feature flags**: `ENABLE_AI_DEMO` (set to `"true"` to enable demo routes)
 - **Telemetry**: `TELEMETRY_HASH_SECRET` (required in production; enables stable hashed identifiers in spans), `TELEMETRY_AI_DEMO_KEY` (required only if enabling `/api/telemetry/ai-demo`)
 - **Maps/Weather**: `GOOGLE_MAPS_SERVER_API_KEY`, `NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY`, `OPENWEATHERMAP_API_KEY`
-- **Payments**: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`
-- **Email/Notifications**: `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `RESEND_FROM_NAME`, `HMAC_SECRET`
-- **Travel APIs**: `DUFFEL_ACCESS_TOKEN`, `AMADEUS_CLIENT_ID`, `AMADEUS_CLIENT_SECRET`, `AMADEUS_ENV`
+- **Payments**: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` (required as a complete group when payments are enabled)
+- **Email/Notifications**: `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `RESEND_FROM_NAME`, `HMAC_SECRET` (`RESEND_*` required as a complete group when email notifications are enabled)
+- **Travel APIs**: `DUFFEL_ACCESS_TOKEN`, `AMADEUS_CLIENT_ID`, `AMADEUS_CLIENT_SECRET`, `AMADEUS_ENV` (`AMADEUS_*` required as a complete group when Amadeus is enabled)
 
 Keep root `.env.test.example` aligned for CI.
 

--- a/docs/operations/oauth-provider-setup-guide.md
+++ b/docs/operations/oauth-provider-setup-guide.md
@@ -49,8 +49,8 @@ Set these in `.env` (local) and your deployment platform:
 
 ```bash
 NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-key # preferred (sb_publishable_...)
-# Legacy support: set NEXT_PUBLIC_SUPABASE_ANON_KEY instead of publishable key
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-key # canonical (sb_publishable_...)
+# Legacy fallback: set NEXT_PUBLIC_SUPABASE_ANON_KEY only if publishable key is unavailable
 APP_BASE_URL=https://your-domain.com          # also set as Supabase Auth "Site URL"
 NEXT_PUBLIC_APP_URL=https://your-domain.com
 NEXT_PUBLIC_SITE_URL=https://your-domain.com

--- a/docs/operations/runbooks/byok-gateway-operator.md
+++ b/docs/operations/runbooks/byok-gateway-operator.md
@@ -21,8 +21,8 @@ Operational checklist for user BYOK, Vault, and team Gateway fallback.
 ```bash
 # Supabase (required)
 NEXT_PUBLIC_SUPABASE_URL=...
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=... # preferred (sb_publishable_...)
-# Legacy support: set NEXT_PUBLIC_SUPABASE_ANON_KEY instead of publishable key
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=... # canonical (sb_publishable_...)
+# Legacy fallback: set NEXT_PUBLIC_SUPABASE_ANON_KEY only if publishable key is unavailable
 SUPABASE_SERVICE_ROLE_KEY=...
 
 # Team Gateway fallback (optional)

--- a/docs/operations/runbooks/database-ops.md
+++ b/docs/operations/runbooks/database-ops.md
@@ -47,7 +47,7 @@ Local sign-up confirmation:
 
 ### Required Environment Variables
 
-- `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (preferred) or `NEXT_PUBLIC_SUPABASE_ANON_KEY` (legacy)
+- `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (canonical) or `NEXT_PUBLIC_SUPABASE_ANON_KEY` (legacy fallback)
 - `SUPABASE_SERVICE_ROLE_KEY` (server only)
 - `AI_GATEWAY_API_KEY`, `AI_GATEWAY_URL` (team fallback)
 - Optional user-provided BYOK keys via Vault

--- a/docs/runbooks/deployment-vercel.md
+++ b/docs/runbooks/deployment-vercel.md
@@ -31,11 +31,11 @@ Vercel project production environment:
 - Origin:
   - A valid HTTPS origin in one of `APP_BASE_URL`, `NEXT_PUBLIC_SITE_URL`,
     `NEXT_PUBLIC_BASE_URL`, or `NEXT_PUBLIC_APP_URL`
-  - `NEXT_PUBLIC_SITE_URL` as a valid HTTPS origin while QStash enqueue code
-    uses it for callback URL construction
+  - `APP_BASE_URL` is preferred for server-side callbacks, including QStash
+    enqueue URL construction
 - Supabase:
   - `NEXT_PUBLIC_SUPABASE_URL`
-  - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` preferred, or
+  - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` canonical, or
     `NEXT_PUBLIC_SUPABASE_ANON_KEY` as legacy fallback
   - `SUPABASE_SERVICE_ROLE_KEY`
   - `SUPABASE_JWT_SECRET`
@@ -52,6 +52,14 @@ Vercel project production environment:
   - If `ENABLE_AI_DEMO=true`, at least one of `AI_GATEWAY_API_KEY`,
     `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, or
     `XAI_API_KEY`
+  - If `ENABLE_AI_DEMO=true`, also set `TELEMETRY_AI_DEMO_KEY`
+- Feature-aware optional groups:
+  - If any Stripe variable is configured, set `STRIPE_SECRET_KEY`,
+    `STRIPE_WEBHOOK_SECRET`, and `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`
+  - If any Resend variable is configured, set `RESEND_API_KEY`,
+    `RESEND_FROM_EMAIL`, and `RESEND_FROM_NAME`
+  - If any Amadeus variable is configured, set `AMADEUS_CLIENT_ID`,
+    `AMADEUS_CLIENT_SECRET`, and `AMADEUS_ENV`
 
 Use Vercel project environment variables for app secrets. Do not mirror app
 provider secrets into GitHub unless a separate GitHub-hosted task explicitly

--- a/docs/runbooks/supabase.md
+++ b/docs/runbooks/supabase.md
@@ -32,7 +32,7 @@ After `pnpm supabase:start`, get local URLs/keys via:
 Populate `.env.local` with at least:
 
 - `NEXT_PUBLIC_SUPABASE_URL`
-- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (preferred) or `NEXT_PUBLIC_SUPABASE_ANON_KEY` (legacy)
+- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (canonical) or `NEXT_PUBLIC_SUPABASE_ANON_KEY` (legacy fallback)
 - `SUPABASE_SERVICE_ROLE_KEY` (server-only; use the `sb_secret_…` key printed by `pnpm supabase:status`; never `NEXT_PUBLIC_*`)
 - (Recommended) `SUPABASE_JWT_SECRET` (use `JWT_SECRET` from `pnpm supabase:status` for local non-test flows like MFA)
 

--- a/docs/specs/active/0110-spec-deployment-and-operations.md
+++ b/docs/specs/active/0110-spec-deployment-and-operations.md
@@ -33,7 +33,7 @@ For operational runbooks (monitoring, alerting, incident response, secret rotati
 - Required environment variables:
   - Supabase:
     - NEXT_PUBLIC_SUPABASE_URL
-    - NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY (preferred) or NEXT_PUBLIC_SUPABASE_ANON_KEY (legacy)
+    - NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY (canonical) or NEXT_PUBLIC_SUPABASE_ANON_KEY (legacy fallback)
     - SUPABASE_SERVICE_ROLE_KEY
   - Upstash:
     - UPSTASH_REDIS_REST_URL

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -47,8 +47,10 @@ export default defineConfig({
       NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL ?? baseURL,
       NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL ?? baseURL,
       NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL ?? baseURL,
-      NEXT_PUBLIC_SUPABASE_ANON_KEY:
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "anon-test-key",
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY:
+        process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ??
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+        "publishable-test-key",
       // Allow dev server to boot in local/e2e without real Supabase credentials.
       NEXT_PUBLIC_SUPABASE_URL:
         process.env.NEXT_PUBLIC_SUPABASE_URL ?? "http://127.0.0.1:54329",

--- a/playwright.prod.config.ts
+++ b/playwright.prod.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
       NEXT_PUBLIC_APP_URL: baseUrl,
       NEXT_PUBLIC_BASE_URL: baseUrl,
       NEXT_PUBLIC_SITE_URL: baseUrl,
-      NEXT_PUBLIC_SUPABASE_ANON_KEY: "anon-test-key",
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "publishable-test-key",
       NEXT_PUBLIC_SUPABASE_URL: "http://127.0.0.1:54329",
       NEXT_TELEMETRY_DISABLED: "1",
       NODE_ENV: "production",

--- a/scripts/verify-production-env.mjs
+++ b/scripts/verify-production-env.mjs
@@ -18,6 +18,69 @@ const ORIGIN_KEYS = [
   "NEXT_PUBLIC_APP_URL",
 ];
 const URL_KEYS = ["NEXT_PUBLIC_SUPABASE_URL", "UPSTASH_REDIS_REST_URL"];
+const SUPABASE_PUBLIC_KEYS = [
+  "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
+  "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+];
+
+const valueValidators = new Map([
+  ["AMADEUS_CLIENT_ID", [minLength(10)]],
+  ["AMADEUS_CLIENT_SECRET", [minLength(16)]],
+  ["AMADEUS_ENV", [oneOf(["production", "test"])]],
+  ["HMAC_SECRET", [minLength(32)]],
+  ["NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY", [startsWithOneOf(["pk_live_", "pk_test_"])]],
+  ["QSTASH_CURRENT_SIGNING_KEY", [minLength(32)]],
+  ["QSTASH_NEXT_SIGNING_KEY", [minLength(32)]],
+  ["QSTASH_TOKEN", [minLength(20)]],
+  ["RESEND_API_KEY", [startsWithOneOf(["re_"])]],
+  ["RESEND_FROM_EMAIL", [validEmail()]],
+  ["STRIPE_SECRET_KEY", [startsWithOneOf(["sk_live_", "sk_test_"])]],
+  ["STRIPE_WEBHOOK_SECRET", [startsWithOneOf(["whsec_"])]],
+  ["SUPABASE_JWT_SECRET", [minLength(32)]],
+  ["SUPABASE_SERVICE_ROLE_KEY", [minLength(30)]],
+  ["TELEMETRY_AI_DEMO_KEY", [minLength(32)]],
+  ["TELEMETRY_HASH_SECRET", [minLength(32)]],
+  ["UPSTASH_REDIS_REST_TOKEN", [minLength(20)]],
+]);
+
+function minLength(length) {
+  return (value) =>
+    value.length >= length ? null : `must be at least ${length} characters`;
+}
+
+function oneOf(values) {
+  return (value) =>
+    values.includes(value) ? null : `must be one of ${values.join(", ")}`;
+}
+
+function startsWithOneOf(prefixes) {
+  return (value) =>
+    prefixes.some((prefix) => value.startsWith(prefix))
+      ? null
+      : `must start with ${prefixes.join(" or ")}`;
+}
+
+function validEmail() {
+  return (value) =>
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value) ? null : "must be an email";
+}
+
+function isPlaceholderValue(value) {
+  const lower = value.toLowerCase();
+  return (
+    lower.startsWith("your-") ||
+    lower.startsWith("your_") ||
+    lower.startsWith("changeme") ||
+    lower.startsWith("replace-") ||
+    lower.startsWith("replace_") ||
+    lower.includes("placeholder") ||
+    lower.includes("example") ||
+    lower.includes("...") ||
+    lower === "null" ||
+    lower === "undefined" ||
+    /^0+$/.test(lower)
+  );
+}
 
 function readArg(name, fallback) {
   const index = process.argv.indexOf(name);
@@ -28,7 +91,9 @@ function readArg(name, fallback) {
 }
 
 function envValue(name) {
-  return process.env[name]?.trim() ?? "";
+  const value = process.env[name]?.trim() ?? "";
+  if (!value || value.toLowerCase() === "undefined") return "";
+  return value;
 }
 
 function hasEnv(name) {
@@ -37,6 +102,10 @@ function hasEnv(name) {
 
 function hasAny(names) {
   return names.some((name) => hasEnv(name));
+}
+
+function hasAll(names) {
+  return names.every((name) => hasEnv(name));
 }
 
 function hasValidUrl(name, { requireHttps }) {
@@ -78,6 +147,42 @@ function missing(names) {
   return names.filter((name) => !hasEnv(name));
 }
 
+function invalidValues(names) {
+  return names.flatMap((name) => {
+    const value = envValue(name);
+    if (!value) return [];
+    if (isPlaceholderValue(value)) {
+      return [{ name, reason: "placeholder value is not allowed" }];
+    }
+
+    const validators = valueValidators.get(name) ?? [];
+    if (validators.length === 0) return [];
+
+    const reason = validators.map((validator) => validator(value)).find(Boolean);
+    return reason ? [{ name, reason }] : [];
+  });
+}
+
+function hasValidAny(names) {
+  return names.some((name) => hasEnv(name) && invalidValues([name]).length === 0);
+}
+
+function addRequiredGroupCheck(name, names, options = {}) {
+  const enabled = options.enabled ?? isProduction;
+  const absent = enabled ? missing(names) : [];
+  const invalid = enabled ? invalidValues(names) : [];
+  checks.push(
+    makeCheck(name, !enabled || (absent.length === 0 && invalid.length === 0), {
+      enabled,
+      enabledBy: options.enabledBy,
+      invalid,
+      missing: absent,
+      required: names,
+      requiredWhen: options.requiredWhen ?? "production",
+    })
+  );
+}
+
 const environment = readArg("--environment", "production");
 const isProduction = environment === "production";
 const requireHttps = isProduction;
@@ -97,32 +202,38 @@ checks.push(
   )
 );
 
-const requiredProduction = [
-  "NEXT_PUBLIC_SUPABASE_URL",
-  "SUPABASE_SERVICE_ROLE_KEY",
-  "SUPABASE_JWT_SECRET",
-  "TELEMETRY_HASH_SECRET",
-  "HMAC_SECRET",
-];
+addRequiredGroupCheck(
+  "supabase_core_contract",
+  ["NEXT_PUBLIC_SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "SUPABASE_JWT_SECRET"],
+  { requiredWhen: "production" }
+);
 
-if (isProduction) {
-  const absent = missing(requiredProduction);
-  checks.push(
-    makeCheck("required_production_env", absent.length === 0, {
-      missing: absent,
-      required: requiredProduction,
-    })
-  );
-}
+checks.push(
+  makeCheck("supabase_public_key", !isProduction || hasValidAny(SUPABASE_PUBLIC_KEYS), {
+    accepted: SUPABASE_PUBLIC_KEYS,
+    invalid: invalidValues(SUPABASE_PUBLIC_KEYS),
+    preferred: "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
+    requiredWhen: "production",
+  })
+);
+
+addRequiredGroupCheck("telemetry_core_contract", ["TELEMETRY_HASH_SECRET"], {
+  requiredWhen: "production",
+});
+
+addRequiredGroupCheck("webhook_hmac_contract", ["HMAC_SECRET"], {
+  requiredWhen: "production",
+});
 
 checks.push(
   makeCheck(
     "qstash_origin_contract",
-    !isProduction || hasValidUrl("NEXT_PUBLIC_SITE_URL", { requireHttps: true }),
+    !isProduction || ORIGIN_KEYS.some((name) => hasValidUrl(name, { requireHttps })),
     {
+      accepted: ORIGIN_KEYS,
+      preferred: "APP_BASE_URL",
       reason:
-        "QStash enqueue code resolves callback origins from NEXT_PUBLIC_SITE_URL.",
-      required: ["NEXT_PUBLIC_SITE_URL"],
+        "QStash enqueue code resolves callback origins through the server-origin contract.",
       requiredWhen: "production",
     }
   )
@@ -137,38 +248,71 @@ checks.push(
   })
 );
 
-checks.push(
-  makeCheck(
-    "supabase_public_key",
-    hasAny(["NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "NEXT_PUBLIC_SUPABASE_ANON_KEY"]),
-    {
-      accepted: [
-        "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
-        "NEXT_PUBLIC_SUPABASE_ANON_KEY",
-      ],
-    }
-  )
-);
+const upstashRedisRequired = ["UPSTASH_REDIS_REST_URL", "UPSTASH_REDIS_REST_TOKEN"];
+addRequiredGroupCheck("upstash_redis_contract", upstashRedisRequired, {
+  requiredWhen: "production",
+});
 
-const upstashRequired = [
+const qstashRequired = [
+  "QSTASH_TOKEN",
+  "QSTASH_CURRENT_SIGNING_KEY",
+  "QSTASH_NEXT_SIGNING_KEY",
+];
+addRequiredGroupCheck("qstash_delivery_contract", qstashRequired, {
+  requiredWhen: "production",
+});
+
+const stripeRequired = [
+  "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY",
+  "STRIPE_SECRET_KEY",
+  "STRIPE_WEBHOOK_SECRET",
+];
+addRequiredGroupCheck("stripe_feature_contract", stripeRequired, {
+  enabled: hasAny(stripeRequired),
+  enabledBy: "any Stripe key is configured",
+  requiredWhen: "feature enabled",
+});
+
+const resendRequired = ["RESEND_API_KEY", "RESEND_FROM_EMAIL", "RESEND_FROM_NAME"];
+addRequiredGroupCheck("resend_feature_contract", resendRequired, {
+  enabled: hasAny(resendRequired),
+  enabledBy: "any Resend email variable is configured",
+  requiredWhen: "feature enabled",
+});
+
+const amadeusRequired = ["AMADEUS_CLIENT_ID", "AMADEUS_CLIENT_SECRET", "AMADEUS_ENV"];
+addRequiredGroupCheck("amadeus_feature_contract", amadeusRequired, {
+  enabled: hasAny(amadeusRequired),
+  enabledBy: "any Amadeus variable is configured",
+  requiredWhen: "feature enabled",
+});
+
+const legacyUpstashRequired = [
   "UPSTASH_REDIS_REST_URL",
   "UPSTASH_REDIS_REST_TOKEN",
   "QSTASH_TOKEN",
   "QSTASH_CURRENT_SIGNING_KEY",
   "QSTASH_NEXT_SIGNING_KEY",
 ];
-const upstashMissing = missing(upstashRequired);
 checks.push(
-  makeCheck("upstash_qstash_contract", !isProduction || upstashMissing.length === 0, {
-    missing: upstashMissing,
+  makeCheck("upstash_qstash_contract", !isProduction || hasAll(legacyUpstashRequired), {
+    deprecatedBy: ["upstash_redis_contract", "qstash_delivery_contract"],
+    missing: isProduction ? missing(legacyUpstashRequired) : [],
     requiredWhen: "production",
   })
 );
 
 const aiDemoEnabled = process.env.ENABLE_AI_DEMO === "true";
+addRequiredGroupCheck("ai_demo_telemetry_contract", ["TELEMETRY_AI_DEMO_KEY"], {
+  enabled: aiDemoEnabled,
+  enabledBy: "ENABLE_AI_DEMO=true",
+  requiredWhen: "feature enabled",
+});
+
 checks.push(
-  makeCheck("ai_provider_contract", !aiDemoEnabled || hasAny(PROVIDER_KEYS), {
+  makeCheck("ai_provider_contract", !aiDemoEnabled || hasValidAny(PROVIDER_KEYS), {
     enabledBy: "ENABLE_AI_DEMO=true",
+    invalid: invalidValues(PROVIDER_KEYS),
     providers: PROVIDER_KEYS,
   })
 );

--- a/scripts/verify-production-env.mjs
+++ b/scripts/verify-production-env.mjs
@@ -68,10 +68,7 @@ function validEmail() {
 }
 
 function supabaseLegacyAnonKey() {
-  return (value) =>
-    isJwtLike(value) || value.startsWith("sb_publishable_")
-      ? null
-      : "must be a Supabase publishable key or legacy anon JWT";
+  return (value) => (isJwtLike(value) ? null : "must be a legacy Supabase anon JWT");
 }
 
 function isJwtLike(value) {

--- a/scripts/verify-production-env.mjs
+++ b/scripts/verify-production-env.mjs
@@ -28,6 +28,8 @@ const valueValidators = new Map([
   ["AMADEUS_CLIENT_SECRET", [minLength(16)]],
   ["AMADEUS_ENV", [oneOf(["production", "test"])]],
   ["HMAC_SECRET", [minLength(32)]],
+  ["NEXT_PUBLIC_SUPABASE_ANON_KEY", [supabaseLegacyAnonKey()]],
+  ["NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", [startsWithOneOf(["sb_publishable_"])]],
   ["NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY", [startsWithOneOf(["pk_live_", "pk_test_"])]],
   ["QSTASH_CURRENT_SIGNING_KEY", [minLength(32)]],
   ["QSTASH_NEXT_SIGNING_KEY", [minLength(32)]],
@@ -63,6 +65,21 @@ function startsWithOneOf(prefixes) {
 function validEmail() {
   return (value) =>
     /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value) ? null : "must be an email";
+}
+
+function supabaseLegacyAnonKey() {
+  return (value) =>
+    isJwtLike(value) || value.startsWith("sb_publishable_")
+      ? null
+      : "must be a Supabase publishable key or legacy anon JWT";
+}
+
+function isJwtLike(value) {
+  const parts = value.split(".");
+  return (
+    parts.length === 3 &&
+    parts.every((part) => part.length > 0 && /^[A-Za-z0-9_-]+$/.test(part))
+  );
 }
 
 function isPlaceholderValue(value) {
@@ -208,13 +225,30 @@ addRequiredGroupCheck(
   { requiredWhen: "production" }
 );
 
+const supabasePublicKeyName = hasEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY")
+  ? "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY"
+  : "NEXT_PUBLIC_SUPABASE_ANON_KEY";
+const supabasePublicKeyMissing = hasEnv(supabasePublicKeyName)
+  ? []
+  : [supabasePublicKeyName];
+const supabasePublicKeyInvalid = hasEnv(supabasePublicKeyName)
+  ? invalidValues([supabasePublicKeyName])
+  : [];
+
 checks.push(
-  makeCheck("supabase_public_key", !isProduction || hasValidAny(SUPABASE_PUBLIC_KEYS), {
-    accepted: SUPABASE_PUBLIC_KEYS,
-    invalid: invalidValues(SUPABASE_PUBLIC_KEYS),
-    preferred: "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
-    requiredWhen: "production",
-  })
+  makeCheck(
+    "supabase_public_key",
+    !isProduction ||
+      (supabasePublicKeyMissing.length === 0 && supabasePublicKeyInvalid.length === 0),
+    {
+      accepted: SUPABASE_PUBLIC_KEYS,
+      active: supabasePublicKeyName,
+      invalid: supabasePublicKeyInvalid,
+      missing: supabasePublicKeyMissing,
+      preferred: "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
+      requiredWhen: "production",
+    }
+  )
 );
 
 addRequiredGroupCheck("telemetry_core_contract", ["TELEMETRY_HASH_SECRET"], {

--- a/src/domain/schemas/env.ts
+++ b/src/domain/schemas/env.ts
@@ -174,9 +174,10 @@ const nextEnvSchema = z.object({
 
 // Supabase configuration
 const supabaseEnvSchema = z.object({
-  NEXT_PUBLIC_SUPABASE_ANON_KEY: z
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().optional(),
+  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: z
     .string()
-    .min(1, { error: "Supabase anonymous key is required" }),
+    .min(1, { error: "Supabase publishable key is required" }),
   NEXT_PUBLIC_SUPABASE_URL: z.url({ error: "Invalid Supabase URL" }),
   SUPABASE_JWT_SECRET: supabaseJwtSecretSchema,
   SUPABASE_SERVICE_ROLE_KEY: apiKeySchema("SUPABASE_SERVICE_ROLE_KEY", 30),
@@ -320,8 +321,10 @@ export const envSchema = z
 
         // Required variables in production
         const requiredInProduction = [
+          "HMAC_SECRET",
+          "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
           "NEXT_PUBLIC_SUPABASE_URL",
-          "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+          "SUPABASE_JWT_SECRET",
           "TELEMETRY_HASH_SECRET",
         ];
 
@@ -329,11 +332,6 @@ export const envSchema = z
           if (!data[key as keyof typeof data]) {
             return false;
           }
-        }
-
-        // Security requirements in production
-        if (!data.SUPABASE_JWT_SECRET) {
-          return false;
         }
       }
 
@@ -358,7 +356,8 @@ export const clientEnvSchema = z.object({
   NEXT_PUBLIC_SITE_URL: z.url().optional(),
   NEXT_PUBLIC_STREAMDOWN_ALLOWED_IMAGE_PREFIXES: z.string().optional(),
   NEXT_PUBLIC_STREAMDOWN_ALLOWED_LINK_PREFIXES: z.string().optional(),
-  NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(1),
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().optional(),
+  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: z.string().min(1),
   NEXT_PUBLIC_SUPABASE_URL: z.url(),
 });
 

--- a/src/domain/schemas/env.ts
+++ b/src/domain/schemas/env.ts
@@ -175,9 +175,7 @@ const nextEnvSchema = z.object({
 // Supabase configuration
 const supabaseEnvSchema = z.object({
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().optional(),
-  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: z
-    .string()
-    .min(1, { error: "Supabase publishable key is required" }),
+  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: z.string().optional(),
   NEXT_PUBLIC_SUPABASE_URL: z.url({ error: "Invalid Supabase URL" }),
   SUPABASE_JWT_SECRET: supabaseJwtSecretSchema,
   SUPABASE_SERVICE_ROLE_KEY: apiKeySchema("SUPABASE_SERVICE_ROLE_KEY", 30),
@@ -319,10 +317,16 @@ export const envSchema = z
           return false;
         }
 
+        const hasSupabasePublicKey =
+          data.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ||
+          data.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+        if (!hasSupabasePublicKey) {
+          return false;
+        }
+
         // Required variables in production
         const requiredInProduction = [
           "HMAC_SECRET",
-          "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
           "NEXT_PUBLIC_SUPABASE_URL",
           "SUPABASE_JWT_SECRET",
           "TELEMETRY_HASH_SECRET",
@@ -343,23 +347,32 @@ export const envSchema = z
   );
 
 // Client-side environment schema (only NEXT_PUBLIC_ variables)
-export const clientEnvSchema = z.object({
-  NEXT_PUBLIC_API_URL: z.url().optional(),
-  NEXT_PUBLIC_APP_NAME: z.string().default("TripSage"),
-  NEXT_PUBLIC_APP_URL: z.url().optional(),
-  NEXT_PUBLIC_BASE_PATH: z.string().optional(),
-  NEXT_PUBLIC_BASE_URL: z.url().optional(),
-  NEXT_PUBLIC_FALLBACK_HOTEL_IMAGE: z.string().optional(),
-  NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY: z.string().optional(),
-  NEXT_PUBLIC_OTEL_CLIENT_ENABLED: z.enum(["true", "false"]).optional(),
-  NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT: z.url().optional(),
-  NEXT_PUBLIC_SITE_URL: z.url().optional(),
-  NEXT_PUBLIC_STREAMDOWN_ALLOWED_IMAGE_PREFIXES: z.string().optional(),
-  NEXT_PUBLIC_STREAMDOWN_ALLOWED_LINK_PREFIXES: z.string().optional(),
-  NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().optional(),
-  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: z.string().min(1),
-  NEXT_PUBLIC_SUPABASE_URL: z.url(),
-});
+export const clientEnvSchema = z
+  .object({
+    NEXT_PUBLIC_API_URL: z.url().optional(),
+    NEXT_PUBLIC_APP_NAME: z.string().default("TripSage"),
+    NEXT_PUBLIC_APP_URL: z.url().optional(),
+    NEXT_PUBLIC_BASE_PATH: z.string().optional(),
+    NEXT_PUBLIC_BASE_URL: z.url().optional(),
+    NEXT_PUBLIC_FALLBACK_HOTEL_IMAGE: z.string().optional(),
+    NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY: z.string().optional(),
+    NEXT_PUBLIC_OTEL_CLIENT_ENABLED: z.enum(["true", "false"]).optional(),
+    NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT: z.url().optional(),
+    NEXT_PUBLIC_SITE_URL: z.url().optional(),
+    NEXT_PUBLIC_STREAMDOWN_ALLOWED_IMAGE_PREFIXES: z.string().optional(),
+    NEXT_PUBLIC_STREAMDOWN_ALLOWED_LINK_PREFIXES: z.string().optional(),
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().optional(),
+    NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: z.string().optional(),
+    NEXT_PUBLIC_SUPABASE_URL: z.url(),
+  })
+  .refine(
+    (data) =>
+      data.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || data.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      error: "Supabase publishable key is required",
+      path: ["NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY"],
+    }
+  );
 
 // Type exports
 export type ServerEnv = z.infer<typeof envSchema>;

--- a/src/lib/env/__tests__/client.test.ts
+++ b/src/lib/env/__tests__/client.test.ts
@@ -15,7 +15,7 @@ describe("env/client", () => {
   describe("getClientEnv", () => {
     it("should return validated client environment", async () => {
       vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
-      vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
+      vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "test-publishable-key");
       vi.stubEnv("NEXT_PUBLIC_APP_NAME", "TestApp");
 
       // Re-import to get fresh validation
@@ -24,25 +24,25 @@ describe("env/client", () => {
 
       const env = freshGetClientEnv();
       expect(env.NEXT_PUBLIC_SUPABASE_URL).toBe("https://test.supabase.co");
-      expect(env.NEXT_PUBLIC_SUPABASE_ANON_KEY).toBe("test-anon-key");
+      expect(env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY).toBe("test-publishable-key");
       expect(env.NEXT_PUBLIC_APP_NAME).toBe("TestApp");
     });
 
-    it("should accept publishable Supabase key as a fallback for anon key", async () => {
+    it("should accept legacy anon Supabase key as a migration fallback", async () => {
       vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
-      vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "test-publishable-key");
+      vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
 
       vi.resetModules();
       const { getClientEnv: freshGetClientEnv } = await import("../client");
 
       const env = freshGetClientEnv();
       expect(env.NEXT_PUBLIC_SUPABASE_URL).toBe("https://test.supabase.co");
-      expect(env.NEXT_PUBLIC_SUPABASE_ANON_KEY).toBe("test-publishable-key");
+      expect(env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY).toBe("test-anon-key");
     });
 
     it("should throw on missing required variables in production", async () => {
       vi.stubEnv("NODE_ENV", "production");
-      // Missing NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY
+      // Missing NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
 
       vi.resetModules();
       await expect(async () => {
@@ -74,7 +74,7 @@ describe("env/client", () => {
 
       const env = freshGetClientEnv();
       expect(env.NEXT_PUBLIC_APP_NAME).toBe("TripSage");
-      expect(env.NEXT_PUBLIC_SUPABASE_ANON_KEY).toBe("");
+      expect(env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY).toBe("");
       expect(env.NEXT_PUBLIC_SUPABASE_URL).toBe("");
     });
 
@@ -87,7 +87,7 @@ describe("env/client", () => {
 
       const env = freshGetClientEnv();
       expect(env.NEXT_PUBLIC_APP_NAME).toBe("TripSage");
-      expect(env.NEXT_PUBLIC_SUPABASE_ANON_KEY).toBe("");
+      expect(env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY).toBe("");
       expect(env.NEXT_PUBLIC_SUPABASE_URL).toBe("");
     });
   });
@@ -95,7 +95,7 @@ describe("env/client", () => {
   describe("getClientEnvVar", () => {
     it("should return environment variable value", async () => {
       vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
-      vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
+      vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "test-publishable-key");
 
       vi.resetModules();
       const { getClientEnvVar: freshGetClientEnvVar } = await import("../client");
@@ -106,7 +106,7 @@ describe("env/client", () => {
 
     it("should throw when variable is missing", async () => {
       vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
-      vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
+      vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "test-publishable-key");
       // Missing NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY
 
       vi.resetModules();
@@ -121,7 +121,7 @@ describe("env/client", () => {
   describe("getClientEnvVarWithFallback", () => {
     it("should return environment variable value when present", async () => {
       vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
-      vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
+      vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "test-publishable-key");
 
       vi.resetModules();
       const { getClientEnvVarWithFallback: freshGetClientEnvVarWithFallback } =
@@ -136,7 +136,7 @@ describe("env/client", () => {
 
     it("should return fallback when variable is missing", async () => {
       vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
-      vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
+      vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "test-publishable-key");
 
       vi.resetModules();
       const { getClientEnvVarWithFallback: freshGetClientEnvVarWithFallback } =
@@ -153,7 +153,7 @@ describe("env/client", () => {
   describe("getGoogleMapsBrowserKey", () => {
     it("should return Google Maps browser API key when configured", async () => {
       vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
-      vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
+      vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "test-publishable-key");
       vi.stubEnv("NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY", "test-browser-key");
 
       vi.resetModules();
@@ -167,7 +167,7 @@ describe("env/client", () => {
 
     it("should return undefined when key is not configured", async () => {
       vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
-      vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
+      vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "test-publishable-key");
       // Missing NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY
 
       vi.resetModules();
@@ -183,7 +183,7 @@ describe("env/client", () => {
   describe("publicEnv", () => {
     it("should export frozen public environment object", async () => {
       vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
-      vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
+      vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "test-publishable-key");
 
       vi.resetModules();
       const { publicEnv: freshPublicEnv } = await import("../client");

--- a/src/lib/env/__tests__/server.test.ts
+++ b/src/lib/env/__tests__/server.test.ts
@@ -13,7 +13,7 @@ describe("env/server", () => {
     // Set up required env vars for tests
     vi.stubEnv("NODE_ENV", "test");
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "test-publishable-key");
     __resetServerEnvCacheForTest();
     vi.resetModules();
   });
@@ -53,12 +53,12 @@ describe("env/server", () => {
       );
     });
 
-    it("should accept publishable Supabase key as a fallback for anon key", () => {
-      Reflect.deleteProperty(process.env, "NEXT_PUBLIC_SUPABASE_ANON_KEY");
-      vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "test-publishable-key");
+    it("should accept legacy anon Supabase key as a migration fallback", () => {
+      Reflect.deleteProperty(process.env, "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY");
+      vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key");
 
       const env = getServerEnv();
-      expect(env.NEXT_PUBLIC_SUPABASE_ANON_KEY).toBe("test-publishable-key");
+      expect(env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY).toBe("test-anon-key");
     });
 
     it("should throw on invalid environment", () => {

--- a/src/lib/env/client.ts
+++ b/src/lib/env/client.ts
@@ -36,7 +36,7 @@ function normalizeOptionalEnvVar(value: string | undefined): string | undefined 
 function validateClientEnv(): ClientEnv {
   // Avoid enumerating process.env in client bundles; Next.js inlines env var
   // accesses but does not guarantee process.env is enumerable in the browser.
-  const resolvedSupabaseKey =
+  const resolvedSupabasePublishableKey =
     normalizeOptionalEnvVar(process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY) ??
     normalizeOptionalEnvVar(process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
 
@@ -56,7 +56,10 @@ function validateClientEnv(): ClientEnv {
       process.env.NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT
     ),
     NEXT_PUBLIC_SITE_URL: normalizeOptionalEnvVar(process.env.NEXT_PUBLIC_SITE_URL),
-    NEXT_PUBLIC_SUPABASE_ANON_KEY: resolvedSupabaseKey,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: normalizeOptionalEnvVar(
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    ),
+    NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: resolvedSupabasePublishableKey,
     NEXT_PUBLIC_SUPABASE_URL: normalizeOptionalEnvVar(
       process.env.NEXT_PUBLIC_SUPABASE_URL
     ),
@@ -84,7 +87,7 @@ function validateClientEnv(): ClientEnv {
           NEXT_PUBLIC_APP_NAME: "TripSage",
           NEXT_PUBLIC_OTEL_CLIENT_ENABLED: undefined,
           NEXT_PUBLIC_OTEL_EXPORTER_OTLP_ENDPOINT: undefined,
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: "",
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "",
           NEXT_PUBLIC_SUPABASE_URL: "",
         };
       }

--- a/src/lib/env/server.ts
+++ b/src/lib/env/server.ts
@@ -89,8 +89,8 @@ function parseServerEnv(): ServerEnv {
   try {
     const envForParse = { ...process.env };
 
-    // Supabase renamed "anon" to "publishable" keys; support both to reduce DX drift.
-    // Prefer publishable key when available, but ignore obvious placeholder values.
+    // Supabase renamed "anon" to "publishable" keys; support the legacy name as a
+    // migration shim while keeping the validated runtime shape on the new name.
     const publishableKey = normalizeOptionalEnvVar(
       envForParse.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
     );
@@ -105,7 +105,7 @@ function parseServerEnv(): ServerEnv {
           : undefined;
 
     if (resolvedSupabaseKey) {
-      envForParse.NEXT_PUBLIC_SUPABASE_ANON_KEY = resolvedSupabaseKey;
+      envForParse.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = resolvedSupabaseKey;
     }
 
     const nodeEnvRaw =

--- a/src/lib/memory/__tests__/upstash-adapter.test.ts
+++ b/src/lib/memory/__tests__/upstash-adapter.test.ts
@@ -27,7 +27,8 @@ const { createUpstashMemoryAdapter } = await import("../upstash-adapter");
 describe("createUpstashMemoryAdapter", () => {
   beforeEach(() => {
     beforeEachHook();
-    envStore.NEXT_PUBLIC_SITE_URL = "https://example.test";
+    envStore.APP_BASE_URL = "https://example.test";
+    envStore.NEXT_PUBLIC_SITE_URL = undefined;
     envStore.QSTASH_TOKEN = TEST_QSTASH_TOKEN;
     envStore.UPSTASH_REDIS_REST_TOKEN = TEST_REDIS_TOKEN;
     envStore.UPSTASH_REDIS_REST_URL = TEST_REDIS_URL;

--- a/src/lib/qstash/__tests__/client.test.ts
+++ b/src/lib/qstash/__tests__/client.test.ts
@@ -11,9 +11,14 @@ const mockSpan = vi.hoisted(() => ({
 }));
 
 const GET_ENV_FALLBACK = vi.hoisted(() => vi.fn());
+const GET_REQUIRED_SERVER_ORIGIN = vi.hoisted(() => vi.fn(() => "https://example.com"));
 
 vi.mock("@/lib/env/server", () => ({
   getServerEnvVarWithFallback: (...args: unknown[]) => GET_ENV_FALLBACK(...args),
+}));
+
+vi.mock("@/lib/url/server-origin", () => ({
+  getRequiredServerOrigin: () => GET_REQUIRED_SERVER_ORIGIN(),
 }));
 
 vi.mock("@/lib/telemetry/span", async (importOriginal) => {
@@ -32,20 +37,18 @@ describe("enqueueJob", () => {
 
   beforeEach(() => {
     resetUpstashMocks();
+    GET_REQUIRED_SERVER_ORIGIN.mockReturnValue("https://example.com");
   });
 
   afterEach(async () => {
     const { setQStashClientFactoryForTests } = await import("@/lib/qstash/client");
     setQStashClientFactoryForTests(null);
     GET_ENV_FALLBACK.mockReset();
+    GET_REQUIRED_SERVER_ORIGIN.mockReset();
     mockSpan.setAttribute.mockReset();
   });
 
   it("passes label, flowControl, and failureCallback to publishJSON", async () => {
-    GET_ENV_FALLBACK.mockImplementation((key: string) =>
-      key === "NEXT_PUBLIC_SITE_URL" ? "https://example.com" : ""
-    );
-
     const { enqueueJob, setQStashClientFactoryForTests } = await import(
       "@/lib/qstash/client"
     );
@@ -60,6 +63,7 @@ describe("enqueueJob", () => {
 
     const messages = qstash.__getMessages();
     expect(messages).toHaveLength(1);
+    expect(messages[0]?.url).toBe("https://example.com/api/jobs/test");
     expect(messages[0]?.label).toBe("tripsage:test");
     expect(messages[0]?.flowControl).toEqual({ key: "tenant-1", parallelism: 2 });
     expect(messages[0]?.failureCallback).toBe("https://example.com/failure");
@@ -68,10 +72,6 @@ describe("enqueueJob", () => {
   });
 
   it("records telemetry attributes for label, flow control, and failure callback", async () => {
-    GET_ENV_FALLBACK.mockImplementation((key: string) =>
-      key === "NEXT_PUBLIC_SITE_URL" ? "https://example.com" : ""
-    );
-
     const { enqueueJob, setQStashClientFactoryForTests } = await import(
       "@/lib/qstash/client"
     );
@@ -92,5 +92,39 @@ describe("enqueueJob", () => {
       "qstash.has_failure_callback",
       true
     );
+  });
+
+  it("throws when the server-origin contract cannot resolve a callback origin", async () => {
+    GET_REQUIRED_SERVER_ORIGIN.mockImplementation(() => {
+      throw new Error("Server origin not configured");
+    });
+
+    const { enqueueJob, setQStashClientFactoryForTests } = await import(
+      "@/lib/qstash/client"
+    );
+    setQStashClientFactoryForTests(() => new qstash.Client({ token: "test" }));
+
+    await expect(
+      enqueueJob("test-job", { ok: true }, "/api/jobs/test")
+    ).rejects.toThrow("Server origin not configured");
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("qstash.missing_origin", true);
+  });
+
+  it.each([
+    "https://evil.example/api/jobs/test",
+    "//evil.example/api/jobs/test",
+  ])("rejects off-origin job path %s", async (path) => {
+    const { enqueueJob, setQStashClientFactoryForTests } = await import(
+      "@/lib/qstash/client"
+    );
+    setQStashClientFactoryForTests(() => new qstash.Client({ token: "test" }));
+
+    await expect(enqueueJob("test-job", { ok: true }, path)).rejects.toThrow(
+      "QStash job path must be a same-origin absolute path"
+    );
+
+    expect(qstash.__getMessages()).toHaveLength(0);
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("qstash.invalid_path", true);
   });
 });

--- a/src/lib/qstash/client.ts
+++ b/src/lib/qstash/client.ts
@@ -124,6 +124,11 @@ function parseDelayToSeconds(delay: string): number {
   return exhaustiveCheck;
 }
 
+/**
+ * Resolve a QStash worker path against the trusted server origin.
+ *
+ * @throws Error if the path is not a same-origin absolute path or resolves off-origin.
+ */
 function toQstashCallbackUrl(path: string, origin: string): string {
   const originUrl = new URL(origin);
   if (!path.startsWith("/") || path.startsWith("//")) {

--- a/src/lib/qstash/client.ts
+++ b/src/lib/qstash/client.ts
@@ -7,6 +7,7 @@ import "server-only";
 import { Client } from "@upstash/qstash";
 import { getServerEnvVarWithFallback } from "@/lib/env/server";
 import { recordTelemetryEvent, withTelemetrySpan } from "@/lib/telemetry/span";
+import { getRequiredServerOrigin } from "@/lib/url/server-origin";
 import { QSTASH_RETRY_CONFIG } from "./config";
 
 // ===== TYPES =====
@@ -123,6 +124,20 @@ function parseDelayToSeconds(delay: string): number {
   return exhaustiveCheck;
 }
 
+function toQstashCallbackUrl(path: string, origin: string): string {
+  const originUrl = new URL(origin);
+  if (!path.startsWith("/") || path.startsWith("//")) {
+    throw new Error("QStash job path must be a same-origin absolute path");
+  }
+
+  const callbackUrl = new URL(path, originUrl);
+  if (callbackUrl.origin !== originUrl.origin) {
+    throw new Error("QStash job path must resolve to the configured server origin");
+  }
+
+  return callbackUrl.toString();
+}
+
 // ===== JOB ENQUEUE =====
 
 /**
@@ -208,19 +223,28 @@ export async function enqueueJob(
         return null;
       }
 
-      // Get origin for building full URL
-      const origin = getServerEnvVarWithFallback("NEXT_PUBLIC_SITE_URL", "");
-      if (!origin) {
+      let origin: string;
+      try {
+        origin = getRequiredServerOrigin();
+      } catch (error) {
         span.setAttribute("qstash.missing_origin", true);
         recordTelemetryEvent("qstash.missing_origin", {
           attributes: { jobType, path },
           level: "warning",
         });
-        throw new Error(
-          "NEXT_PUBLIC_SITE_URL is not configured; cannot enqueue QStash job"
-        );
+        throw error;
       }
-      const url = `${origin}${path}`;
+      let url: string;
+      try {
+        url = toQstashCallbackUrl(path, origin);
+      } catch (error) {
+        span.setAttribute("qstash.invalid_path", true);
+        recordTelemetryEvent("qstash.invalid_path", {
+          attributes: { jobType, path },
+          level: "warning",
+        });
+        throw error;
+      }
       span.setAttribute("qstash.url", url);
 
       // Deduplication is caller-controlled; random IDs defeat dedup purpose

--- a/src/lib/supabase/__tests__/client.dom.test.ts
+++ b/src/lib/supabase/__tests__/client.dom.test.ts
@@ -5,7 +5,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // Mock env module to prevent validation errors during tests
 vi.mock("@/lib/env/client", () => ({
   getClientEnv: () => ({
-    NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "",
+    NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY:
+      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? "",
     NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
   }),
   getClientEnvVar: (key: string) => process.env[key] ?? "",
@@ -13,7 +14,7 @@ vi.mock("@/lib/env/client", () => ({
 
 describe("Supabase Browser Client", () => {
   const mockSupabaseUrl = "https://test.supabase.co";
-  const mockSupabaseAnonKey = "test-anon-key";
+  const mockSupabasePublishableKey = "test-publishable-key";
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -21,7 +22,7 @@ describe("Supabase Browser Client", () => {
     vi.resetModules();
     // Reset environment variables
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "");
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "");
   });
 
   // Dynamic import to get fresh module after resetModules
@@ -32,7 +33,7 @@ describe("Supabase Browser Client", () => {
 
   it("should create a browser client with valid environment variables", async () => {
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", mockSupabaseUrl);
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", mockSupabaseAnonKey);
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", mockSupabasePublishableKey);
 
     const createClient = await getClient();
     const client = createClient();
@@ -41,15 +42,15 @@ describe("Supabase Browser Client", () => {
 
   it("should handle missing NEXT_PUBLIC_SUPABASE_URL gracefully in tests", async () => {
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "");
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", mockSupabaseAnonKey);
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", mockSupabasePublishableKey);
 
     const createClient = await getClient();
     expect(() => createClient()).not.toThrow();
   });
 
-  it("should handle missing NEXT_PUBLIC_SUPABASE_ANON_KEY gracefully in tests", async () => {
+  it("should handle missing NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY gracefully in tests", async () => {
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", mockSupabaseUrl);
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "");
 
     const createClient = await getClient();
     expect(() => createClient()).not.toThrow();
@@ -57,7 +58,7 @@ describe("Supabase Browser Client", () => {
 
   it("should handle both environment variables missing gracefully in tests", async () => {
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "");
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "");
 
     const createClient = await getClient();
     expect(() => createClient()).not.toThrow();
@@ -65,7 +66,7 @@ describe("Supabase Browser Client", () => {
 
   it("should handle undefined environment variables gracefully in tests", async () => {
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", undefined);
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", undefined);
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", undefined);
 
     const createClient = await getClient();
     expect(() => createClient()).not.toThrow();
@@ -76,7 +77,7 @@ describe("Supabase Browser Client", () => {
     const prodKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test-key";
 
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", prodUrl);
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", prodKey);
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", prodKey);
 
     const createClient = await getClient();
     const client = createClient();
@@ -85,10 +86,10 @@ describe("Supabase Browser Client", () => {
 
   it("should handle local development environment variables", async () => {
     const localUrl = "http://localhost:54321";
-    const localKey = "local-anon-key";
+    const localKey = "local-publishable-key";
 
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", localUrl);
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", localKey);
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", localKey);
 
     const createClient = await getClient();
     const client = createClient();
@@ -97,7 +98,7 @@ describe("Supabase Browser Client", () => {
 
   it("should create a usable client instance on each call", async () => {
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", mockSupabaseUrl);
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", mockSupabaseAnonKey);
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", mockSupabasePublishableKey);
 
     const createClient = await getClient();
     const client1 = createClient();
@@ -108,7 +109,7 @@ describe("Supabase Browser Client", () => {
 
   it("should handle client creation errors from createBrowserClient", async () => {
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", mockSupabaseUrl);
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", mockSupabaseAnonKey);
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", mockSupabasePublishableKey);
 
     const createClient = await getClient();
     expect(() => createClient()).not.toThrow();
@@ -116,10 +117,10 @@ describe("Supabase Browser Client", () => {
 
   it("should validate URL format by passing it to createBrowserClient", async () => {
     const invalidUrl = "not-a-url";
-    const validKey = "test-anon-key";
+    const validKey = "test-publishable-key";
 
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", invalidUrl);
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", validKey);
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", validKey);
 
     const createClient = await getClient();
     const client = createClient();
@@ -128,7 +129,7 @@ describe("Supabase Browser Client", () => {
 
   it("should handle empty string but defined environment variables gracefully in tests", async () => {
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "");
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", mockSupabaseAnonKey);
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", mockSupabasePublishableKey);
 
     const createClient = await getClient();
     expect(() => createClient()).not.toThrow();
@@ -136,7 +137,7 @@ describe("Supabase Browser Client", () => {
 
   it("should handle client with complex auth methods", async () => {
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", mockSupabaseUrl);
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", mockSupabaseAnonKey);
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", mockSupabasePublishableKey);
 
     const createClient = await getClient();
     const client = createClient();

--- a/src/lib/supabase/__tests__/factory.spec.ts
+++ b/src/lib/supabase/__tests__/factory.spec.ts
@@ -52,7 +52,7 @@ const telemetryHashSecretValue = vi.hoisted(() => "telemetry-test-secret");
 
 vi.mock("@/lib/env/server", () => ({
   getServerEnv: vi.fn(() => ({
-    NEXT_PUBLIC_SUPABASE_ANON_KEY: "test-anon-key",
+    NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "test-publishable-key",
     NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",
     [telemetryHashSecretKey]: telemetryHashSecretValue,
   })),
@@ -68,7 +68,7 @@ vi.mock("@/lib/env/server", () => ({
 
 vi.mock("@/lib/env/client", () => ({
   getClientEnv: vi.fn(() => ({
-    NEXT_PUBLIC_SUPABASE_ANON_KEY: "test-anon-key",
+    NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "test-publishable-key",
     NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",
   })),
 }));
@@ -132,7 +132,7 @@ describe("Supabase Factory", () => {
 
       expect(mockCreateServerClient).toHaveBeenCalledWith(
         "https://test.supabase.co",
-        "test-anon-key",
+        "test-publishable-key",
         expect.objectContaining({
           cookies: expect.any(Object),
         })
@@ -280,7 +280,7 @@ describe("Supabase Factory", () => {
 
       expect(mockCreateServerClient).toHaveBeenCalledWith(
         "https://test.supabase.co",
-        "test-anon-key",
+        "test-publishable-key",
         expect.objectContaining({
           cookies: expect.any(Object),
         })
@@ -302,7 +302,7 @@ describe("Supabase Factory", () => {
 
       expect(mockCreateServerClient).toHaveBeenCalledWith(
         "https://test.supabase.co",
-        "test-anon-key",
+        "test-publishable-key",
         expect.objectContaining({
           cookies: expect.any(Object),
         })
@@ -353,7 +353,7 @@ describe("Supabase Factory", () => {
       expect(mockEnv).toHaveBeenCalled();
       expect(mockCreateServerClient).toHaveBeenCalledWith(
         "https://test.supabase.co",
-        "test-anon-key",
+        "test-publishable-key",
         expect.any(Object)
       );
     });

--- a/src/lib/supabase/__tests__/server.test.ts
+++ b/src/lib/supabase/__tests__/server.test.ts
@@ -31,14 +31,14 @@ vi.mock("@/lib/env/client", () => ({
     NEXT_PUBLIC_BASE_PATH: undefined,
     NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY: undefined,
     NEXT_PUBLIC_SITE_URL: undefined,
-    NEXT_PUBLIC_SUPABASE_ANON_KEY: "test-anon-key",
+    NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "test-publishable-key",
     NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",
   })),
 }));
 
 describe("Supabase Server Client", () => {
   const mockSupabaseUrl = "https://test.supabase.co";
-  const mockSupabaseAnonKey = "test-anon-key";
+  const mockSupabasePublishableKey = "test-publishable-key";
 
   beforeEach(async () => {
     vi.resetAllMocks();
@@ -46,7 +46,7 @@ describe("Supabase Server Client", () => {
 
     // Set environment variables
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", mockSupabaseUrl);
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", mockSupabaseAnonKey);
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", mockSupabasePublishableKey);
 
     // Dynamically import after setting env vars
     const serverModule = await import("../server");
@@ -78,7 +78,7 @@ describe("Supabase Server Client", () => {
     expect(cookies).toHaveBeenCalled();
     expect(createServerClient).toHaveBeenCalledWith(
       mockSupabaseUrl,
-      mockSupabaseAnonKey,
+      mockSupabasePublishableKey,
       expect.objectContaining({
         cookies: expect.objectContaining({
           getAll: expect.any(Function),
@@ -146,7 +146,7 @@ describe("Supabase Server Client", () => {
   it("should throw an error when environment variables are missing", async () => {
     // Clear environment variables
     Reflect.deleteProperty(process.env, "NEXT_PUBLIC_SUPABASE_URL");
-    Reflect.deleteProperty(process.env, "NEXT_PUBLIC_SUPABASE_ANON_KEY");
+    Reflect.deleteProperty(process.env, "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY");
 
     // Re-import module with missing env vars
     vi.resetModules();

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -48,10 +48,12 @@ export function getBrowserClient(): TypedSupabaseClient | null {
   }
 
   const supabaseUrl = getClientEnvVar("NEXT_PUBLIC_SUPABASE_URL");
-  const supabaseAnonKey = getClientEnvVar("NEXT_PUBLIC_SUPABASE_ANON_KEY");
+  const supabasePublishableKey = getClientEnvVar(
+    "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY"
+  );
 
   // Allow the app to boot in dev/build placeholder mode without crashing.
-  if (!supabaseUrl || !supabaseAnonKey) {
+  if (!supabaseUrl || !supabasePublishableKey) {
     if (process.env.NODE_ENV === "development") {
       console.warn(
         "[supabase/client] Supabase env vars missing (NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY or NEXT_PUBLIC_SUPABASE_ANON_KEY). " +
@@ -61,7 +63,7 @@ export function getBrowserClient(): TypedSupabaseClient | null {
     return null;
   }
 
-  client = createBrowserClient<Database>(supabaseUrl, supabaseAnonKey);
+  client = createBrowserClient<Database>(supabaseUrl, supabasePublishableKey);
   return client;
 }
 
@@ -108,12 +110,14 @@ export function createClient(): TypedSupabaseClient | null {
   }
 
   const supabaseUrl = getClientEnvVar("NEXT_PUBLIC_SUPABASE_URL");
-  const supabaseAnonKey = getClientEnvVar("NEXT_PUBLIC_SUPABASE_ANON_KEY");
+  const supabasePublishableKey = getClientEnvVar(
+    "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY"
+  );
 
-  if (!supabaseUrl || !supabaseAnonKey) {
+  if (!supabaseUrl || !supabasePublishableKey) {
     return null;
   }
 
   // Intentionally create a fresh client (used by utility code that expects non-singleton behavior)
-  return createBrowserClient<Database>(supabaseUrl, supabaseAnonKey);
+  return createBrowserClient<Database>(supabaseUrl, supabasePublishableKey);
 }

--- a/src/lib/supabase/factory.ts
+++ b/src/lib/supabase/factory.ts
@@ -64,6 +64,24 @@ export interface GetCurrentUserResult {
 const cookieLogger = createServerLogger("supabase.cookies");
 let didWarnCookieAdapterFailure = false;
 
+type SupabasePublicEnv = Partial<
+  Record<
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY" | "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
+    string
+  >
+>;
+
+function getEffectiveSupabasePublicKey(env: SupabasePublicEnv): string {
+  const publicKey =
+    env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!publicKey) {
+    throw new Error(
+      "Supabase public key missing: set NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY or legacy NEXT_PUBLIC_SUPABASE_ANON_KEY."
+    );
+  }
+  return publicKey;
+}
+
 function warnCookieAdapterFailureOnce(
   operation: "getAll" | "setAll",
   error: unknown
@@ -109,10 +127,12 @@ export function createServerSupabaseClient(
   const env = getServerEnv();
 
   const createClient = () => {
+    const supabasePublicKey = getEffectiveSupabasePublicKey(env);
+
     // Use @supabase/ssr for proper SSR cookie handling
     return createSsrServerClient<Database>(
       env.NEXT_PUBLIC_SUPABASE_URL,
-      env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY,
+      supabasePublicKey,
       {
         cookies: createCookieMethods(cookies),
       }
@@ -168,10 +188,12 @@ export function createMiddlewareSupabase(
   const env = getClientEnv();
 
   const createClient = () => {
+    const supabasePublicKey = getEffectiveSupabasePublicKey(env);
+
     // Use @supabase/ssr for proper SSR cookie handling
     return createSsrServerClient<Database>(
       env.NEXT_PUBLIC_SUPABASE_URL,
-      env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY,
+      supabasePublicKey,
       {
         cookies: createCookieMethods(cookies),
       }

--- a/src/lib/supabase/factory.ts
+++ b/src/lib/supabase/factory.ts
@@ -112,7 +112,7 @@ export function createServerSupabaseClient(
     // Use @supabase/ssr for proper SSR cookie handling
     return createSsrServerClient<Database>(
       env.NEXT_PUBLIC_SUPABASE_URL,
-      env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+      env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY,
       {
         cookies: createCookieMethods(cookies),
       }
@@ -171,7 +171,7 @@ export function createMiddlewareSupabase(
     // Use @supabase/ssr for proper SSR cookie handling
     return createSsrServerClient<Database>(
       env.NEXT_PUBLIC_SUPABASE_URL,
-      env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+      env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY,
       {
         cookies: createCookieMethods(cookies),
       }

--- a/src/scripts/__tests__/verify-production-env.test.ts
+++ b/src/scripts/__tests__/verify-production-env.test.ts
@@ -1,0 +1,193 @@
+/** @vitest-environment node */
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+type EnvCheck = {
+  details: Record<string, unknown>;
+  name: string;
+  status: "failed" | "passed";
+};
+
+type EnvSummary = {
+  checks: EnvCheck[];
+  environment: string;
+  status: "failed" | "passed";
+};
+
+const scriptPath = path.join(process.cwd(), "scripts/verify-production-env.mjs");
+const longSecret = "a".repeat(32);
+const validRedisUrl = "https://upstash-valid.test";
+
+const productionEnv = {
+  APP_BASE_URL: "https://app.example.com",
+  HMAC_SECRET: longSecret,
+  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "sb_publishable_test",
+  NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",
+  NODE_ENV: "production",
+  QSTASH_CURRENT_SIGNING_KEY: longSecret,
+  QSTASH_NEXT_SIGNING_KEY: longSecret,
+  QSTASH_TOKEN: longSecret,
+  SUPABASE_JWT_SECRET: longSecret,
+  SUPABASE_SERVICE_ROLE_KEY: longSecret,
+  TELEMETRY_HASH_SECRET: longSecret,
+  UPSTASH_REDIS_REST_TOKEN: longSecret,
+  UPSTASH_REDIS_REST_URL: validRedisUrl,
+} satisfies NodeJS.ProcessEnv;
+
+function runVerifier(overrides: Partial<NodeJS.ProcessEnv> = {}) {
+  const env: NodeJS.ProcessEnv = { ...productionEnv, ...overrides };
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) {
+      Reflect.deleteProperty(env, key);
+    }
+  }
+
+  const result = spawnSync(
+    process.execPath,
+    [scriptPath, "--environment", "production"],
+    {
+      encoding: "utf8",
+      env,
+    }
+  );
+
+  return {
+    ...result,
+    summary: JSON.parse(result.stdout) as EnvSummary,
+  };
+}
+
+function check(summary: EnvSummary, name: string): EnvCheck {
+  const found = summary.checks.find((item) => item.name === name);
+  if (!found) {
+    throw new Error(`Missing env check: ${name}`);
+  }
+  return found;
+}
+
+describe("verify-production-env", () => {
+  it("passes minimal production env while disabled optional feature groups stay disabled", () => {
+    const result = runVerifier();
+
+    expect(result.status).toBe(0);
+    expect(result.summary.status).toBe("passed");
+    expect(check(result.summary, "qstash_origin_contract").status).toBe("passed");
+    expect(check(result.summary, "stripe_feature_contract").details.enabled).toBe(
+      false
+    );
+    expect(check(result.summary, "resend_feature_contract").details.enabled).toBe(
+      false
+    );
+    expect(check(result.summary, "amadeus_feature_contract").details.enabled).toBe(
+      false
+    );
+  });
+
+  it("fails partial optional feature groups when any Stripe variable enables payments", () => {
+    const result = runVerifier({ STRIPE_SECRET_KEY: "sk_test" });
+
+    expect(result.status).toBe(1);
+    expect(result.summary.status).toBe("failed");
+    expect(check(result.summary, "stripe_feature_contract")).toMatchObject({
+      status: "failed",
+    });
+  });
+
+  it("fails QStash when no server-origin variable is configured", () => {
+    const result = runVerifier({
+      APP_BASE_URL: undefined,
+      NEXT_PUBLIC_APP_URL: undefined,
+      NEXT_PUBLIC_BASE_URL: undefined,
+      NEXT_PUBLIC_SITE_URL: undefined,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.summary.status).toBe("failed");
+    expect(check(result.summary, "qstash_origin_contract")).toMatchObject({
+      status: "failed",
+    });
+  });
+
+  it("fails values that runtime env schema would reject", () => {
+    const result = runVerifier({
+      HMAC_SECRET: "short",
+      QSTASH_CURRENT_SIGNING_KEY: "short",
+      QSTASH_NEXT_SIGNING_KEY: "short",
+      QSTASH_TOKEN: "short",
+      SUPABASE_JWT_SECRET: "short",
+      SUPABASE_SERVICE_ROLE_KEY: "short",
+      TELEMETRY_HASH_SECRET: "short",
+    });
+
+    expect(result.status).toBe(1);
+    expect(check(result.summary, "supabase_core_contract").details.invalid).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "SUPABASE_SERVICE_ROLE_KEY" }),
+        expect.objectContaining({ name: "SUPABASE_JWT_SECRET" }),
+      ])
+    );
+    expect(check(result.summary, "webhook_hmac_contract").details.invalid).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "HMAC_SECRET" })])
+    );
+    expect(check(result.summary, "telemetry_core_contract").details.invalid).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "TELEMETRY_HASH_SECRET" }),
+      ])
+    );
+    expect(check(result.summary, "qstash_delivery_contract").details.invalid).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "QSTASH_TOKEN" }),
+        expect.objectContaining({ name: "QSTASH_CURRENT_SIGNING_KEY" }),
+        expect.objectContaining({ name: "QSTASH_NEXT_SIGNING_KEY" }),
+      ])
+    );
+  });
+
+  it("treats literal undefined public keys as absent", () => {
+    const result = runVerifier({ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "undefined" });
+
+    expect(result.status).toBe(1);
+    expect(check(result.summary, "supabase_public_key")).toMatchObject({
+      status: "failed",
+    });
+  });
+
+  it("rejects placeholder public and feature-enabling keys", () => {
+    const result = runVerifier({
+      AI_GATEWAY_API_KEY: "placeholder",
+      ENABLE_AI_DEMO: "true",
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "sb_publishable_...",
+      TELEMETRY_AI_DEMO_KEY: "telemetry_ai_demo_key_0123456789abc",
+      UPSTASH_REDIS_REST_TOKEN: "placeholder",
+    });
+
+    expect(result.status).toBe(1);
+    expect(check(result.summary, "supabase_public_key").details.invalid).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY" }),
+      ])
+    );
+    expect(check(result.summary, "upstash_redis_contract").details.invalid).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "UPSTASH_REDIS_REST_TOKEN" }),
+      ])
+    );
+    expect(check(result.summary, "ai_provider_contract").details.invalid).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "AI_GATEWAY_API_KEY" })])
+    );
+  });
+
+  it("requires telemetry auth and one provider when the AI demo is enabled", () => {
+    const result = runVerifier({ ENABLE_AI_DEMO: "true" });
+
+    expect(result.status).toBe(1);
+    expect(check(result.summary, "ai_demo_telemetry_contract")).toMatchObject({
+      status: "failed",
+    });
+    expect(check(result.summary, "ai_provider_contract")).toMatchObject({
+      status: "failed",
+    });
+  });
+});

--- a/src/scripts/__tests__/verify-production-env.test.ts
+++ b/src/scripts/__tests__/verify-production-env.test.ts
@@ -55,9 +55,20 @@ function runVerifier(overrides: Partial<NodeJS.ProcessEnv> = {}) {
     }
   );
 
+  let summary: EnvSummary;
+  try {
+    summary = JSON.parse(result.stdout) as EnvSummary;
+  } catch (error) {
+    throw new Error(
+      `Failed to parse verify-production-env output: ${
+        error instanceof Error ? error.message : String(error)
+      }\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+    );
+  }
+
   return {
     ...result,
-    summary: JSON.parse(result.stdout) as EnvSummary,
+    summary,
   };
 }
 

--- a/src/scripts/__tests__/verify-production-env.test.ts
+++ b/src/scripts/__tests__/verify-production-env.test.ts
@@ -18,6 +18,8 @@ type EnvSummary = {
 
 const scriptPath = path.join(process.cwd(), "scripts/verify-production-env.mjs");
 const longSecret = "a".repeat(32);
+const legacyAnonJwt =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiJ9.signature";
 const validRedisUrl = "https://upstash-valid.test";
 
 const productionEnv = {
@@ -146,7 +148,10 @@ describe("verify-production-env", () => {
   });
 
   it("treats literal undefined public keys as absent", () => {
-    const result = runVerifier({ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "undefined" });
+    const result = runVerifier({
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: undefined,
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "undefined",
+    });
 
     expect(result.status).toBe(1);
     expect(check(result.summary, "supabase_public_key")).toMatchObject({
@@ -177,6 +182,41 @@ describe("verify-production-env", () => {
     expect(check(result.summary, "ai_provider_contract").details.invalid).toEqual(
       expect.arrayContaining([expect.objectContaining({ name: "AI_GATEWAY_API_KEY" })])
     );
+  });
+
+  it("fails malformed publishable key even when a legacy fallback is configured", () => {
+    const result = runVerifier({
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: legacyAnonJwt,
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "not-a-publishable-key",
+    });
+
+    expect(result.status).toBe(1);
+    expect(check(result.summary, "supabase_public_key")).toMatchObject({
+      details: {
+        active: "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
+        invalid: [
+          expect.objectContaining({
+            name: "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
+          }),
+        ],
+      },
+      status: "failed",
+    });
+  });
+
+  it("accepts a legacy anon JWT only when publishable key is absent", () => {
+    const result = runVerifier({
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: legacyAnonJwt,
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: undefined,
+    });
+
+    expect(result.status).toBe(0);
+    expect(check(result.summary, "supabase_public_key")).toMatchObject({
+      details: {
+        active: "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+      },
+      status: "passed",
+    });
   });
 
   it("requires telemetry auth and one provider when the AI demo is enabled", () => {

--- a/src/test/helpers/env.ts
+++ b/src/test/helpers/env.ts
@@ -13,7 +13,7 @@ export function stubRateLimitDisabled(): void {
   vi.stubEnv?.("UPSTASH_REDIS_REST_TOKEN", "");
   // Provide minimal Supabase env to satisfy server env validation in routes
   vi.stubEnv?.("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
-  vi.stubEnv?.("NEXT_PUBLIC_SUPABASE_ANON_KEY", "anon-test-key");
+  vi.stubEnv?.("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "publishable-test-key");
   vi.stubEnv?.("SUPABASE_SERVICE_ROLE_KEY", "srk-test-key");
 }
 
@@ -25,7 +25,7 @@ export function stubRateLimitEnabled(): void {
   vi.stubEnv?.("UPSTASH_REDIS_REST_TOKEN", "test-token");
   // Provide minimal Supabase env to satisfy server env validation in routes
   vi.stubEnv?.("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
-  vi.stubEnv?.("NEXT_PUBLIC_SUPABASE_ANON_KEY", "anon-test-key");
+  vi.stubEnv?.("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "publishable-test-key");
   vi.stubEnv?.("SUPABASE_SERVICE_ROLE_KEY", "srk-test-key");
 }
 

--- a/src/test/helpers/supabase-test-client.ts
+++ b/src/test/helpers/supabase-test-client.ts
@@ -16,7 +16,10 @@ import type { Database } from "@/lib/supabase/database.types";
  */
 export function createTestBrowserClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "http://localhost:54321";
-  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "test-anon-key";
+  const key =
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ??
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+    "test-publishable-key";
 
   return createBrowserClient<Database>(url, key, {
     isSingleton: false,

--- a/src/test/setup-node.ts
+++ b/src/test/setup-node.ts
@@ -30,7 +30,7 @@ if (typeof process !== "undefined" && process.env) {
   const env = process.env as Record<string, string | undefined>;
   env.NODE_ENV ||= "test";
   env.NEXT_PUBLIC_SUPABASE_URL ||= MSW_SUPABASE_URL;
-  env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||= "test-anon-key";
+  env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ||= "test-publishable-key";
   // SECURITY: Simulate Vercel environment in tests so proxy headers (X-Forwarded-For,
   // X-Real-IP) are trusted. In production, Vercel sets this automatically.
   // Tests that need to verify untrusted proxy behavior should explicitly unset this.


### PR DESCRIPTION
## Summary

- Canonicalizes Supabase public env usage on `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` while preserving `NEXT_PUBLIC_SUPABASE_ANON_KEY` as a migration fallback.
- Moves QStash job callback construction onto the server-origin contract and rejects absolute/protocol-relative off-origin job paths.
- Reworks `deploy:check-env` into feature-aware production contracts with placeholder/weak-value rejection for Supabase, Upstash/QStash, telemetry, AI demo, Stripe, Resend, and Amadeus.
- Aligns env templates and operator docs with all-or-none optional feature groups and the preferred `APP_BASE_URL` server origin.

Closes #734.
Resolves #573.

## Validation

- `pnpm biome:fix`
- `pnpm type-check`
- `pnpm check:zod-v4`
- `pnpm check:api-route-errors`
- `pnpm check:no-secrets`
- `pnpm test:affected`
- `pnpm test:pr`
- `pnpm exec vitest run src/lib/env/__tests__/client.test.ts src/lib/env/__tests__/server.test.ts src/lib/qstash/__tests__/client.test.ts src/lib/memory/__tests__/upstash-adapter.test.ts src/lib/supabase/__tests__/client.dom.test.ts src/lib/supabase/__tests__/server.test.ts src/lib/supabase/__tests__/factory.spec.ts src/scripts/__tests__/verify-production-env.test.ts` (8 files, 80 tests)
- Production-shaped `pnpm deploy:check-env -- --environment production`
- Placeholder rejection probe for Supabase public key, Upstash token, and AI provider key
- `.env.test.example` sourced through `node scripts/verify-production-env.mjs --environment test`
- Production-shaped `pnpm build`

## Pre-PR Review

- Runtime reviewer: prior QStash origin and deploy verifier findings resolved; no remaining blocking runtime findings.
- Security reviewer: placeholder rejection, `.env.test.example`, and QStash same-origin findings resolved; no remaining blocking security findings.
- Vercel/deploy reviewer: deployment verifier/runtime alignment, QStash path guard, and template alignment resolved; no remaining blocking deploy findings.

## Docs Impact

- Updated README, deployment runbooks, environment setup docs, Supabase docs, OAuth/BYOK operator docs, and deployment spec references.
- Updated `.env.example`, `.env.local.example`, and `.env.test.example` to use publishable Supabase naming and all-or-none optional feature groups.

## Provider / Deploy Notes

- Vercel production env should set `APP_BASE_URL` as the preferred server origin.
- Supabase fresh setups should set `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`; `NEXT_PUBLIC_SUPABASE_ANON_KEY` remains supported as a fallback only.
- Optional Stripe, Resend, and Amadeus feature groups now fail deploy validation when partially configured.
- `ENABLE_AI_DEMO=true` requires `TELEMETRY_AI_DEMO_KEY` and at least one valid provider key.

## Screenshots

- Not applicable; this is config/backend/deploy contract work with no UI surface.

## Residual Risks

- Existing production environments that only define legacy `NEXT_PUBLIC_SUPABASE_ANON_KEY` still work through the migration shim, but operators should migrate to `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`.
- Any external automation that copied partial optional env template values must now either remove the group or provide the full group.
