### PR TITLE
refactor(upstash): modernize QStash Redis and rate-limit contracts

### DIFF
--- a/docs/api/internal/jobs.md
+++ b/docs/api/internal/jobs.md
@@ -14,7 +14,36 @@ Background job endpoints delivered by Upstash QStash.
   - Any **non-2xx** response triggers a retry (until QStash retry limit is reached).
   - Retry delay behavior is configured on publish via `Upstash-Retry-Delay` (see `src/lib/qstash/client.ts`).
   - **Non-retryable** failures return `489` with `Upstash-NonRetryable-Error: true` (QStash forwards to DLQ if configured).
-- **DLQ operations**: Use the Upstash Console to **republish** or **delete** DLQ messages.
+- **Publishing contract**: every publish through `enqueueJob()`/`tryEnqueueJob()`
+  must include a deterministic `deduplicationId` and a canonical `label` from
+  `QSTASH_JOB_LABELS`; the helper always sends the configured retry count and
+  retry-delay expression.
+- **DLQ operations**: Filter by `label`, message URL, or `Upstash-Message-Id` in
+  the Upstash Console or the QStash DLQ API, then **republish** after fixing the
+  root cause or **delete** when the payload is obsolete/non-replayable.
+- **Production degradation**: job enqueue failures on production webhook paths
+  must fail closed. Local/test-only in-process fallbacks must be explicitly gated.
+
+## Job ownership and publish labels
+
+| Job | Owner | Worker | Publish label | Dedup key shape |
+| --- | --- | --- | --- | --- |
+| Attachment ingest | File webhook | `/api/jobs/attachments-ingest` | `tripsage:attachments-ingest` | `attachments-ingest:<attachmentId>` |
+| RAG index | Attachment ingest | `/api/jobs/rag-index` | `tripsage:rag-index` | `rag-index:attachment:<attachmentId>` |
+| Memory sync | Memory adapter | `/api/jobs/memory-sync` | `tripsage:memory-sync` | `memory-sync:<sync-idempotency-key>` |
+| Collaborator notifications | Trip webhook | `/api/jobs/notify-collaborators` | `tripsage:notify-collaborators` | `notify:<eventKey>` |
+
+## Local QStash development
+
+Use the shared mocks for unit tests. For local integration, set
+`UPSTASH_USE_EMULATOR=1`, point `UPSTASH_REDIS_REST_URL` at the Redis REST
+emulator, and set `UPSTASH_QSTASH_DEV_URL` to the QStash dev server endpoint.
+`UPSTASH_EMULATOR_URL` remains a legacy Redis alias only.
+
+Live smoke tests use production-compatible env names for credentials:
+`UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, and `QSTASH_TOKEN`.
+Set `UPSTASH_QSTASH_SMOKE_TARGET_URL` to a disposable request-bin style URL
+before running `UPSTASH_SMOKE=1 pnpm test:upstash:smoke`.
 
 ---
 

--- a/docs/api/internal/webhooks.md
+++ b/docs/api/internal/webhooks.md
@@ -202,7 +202,7 @@ Postgres real-time change event payload:
 | ----- | ---- | ----------- |
 | `ok` | boolean | Indicates if the webhook was processed successfully |
 | `enqueued` | boolean | Indicates if the event was enqueued to QStash (only present when `true`) |
-| `fallback` | boolean | Indicates if fallback in-process processing was used (only present when `true`) |
+| `fallback` | boolean | Indicates if local/test-only fallback in-process processing was used (only present when `true`) |
 | `skipped` | boolean | Indicates if the event was skipped due to wrong table (only present when `true`) |
 | `duplicate` | boolean | Indicates if the event was a duplicate (only present when `true`) |
 
@@ -243,7 +243,8 @@ This webhook is triggered by Supabase Postgres triggers when `trip_collaborators
 2. Skips events for tables other than `trip_collaborators`
 3. Enforces idempotency using Upstash Redis (duplicate events return `{duplicate: true, ok: true}`)
 4. Enqueues notification jobs to QStash worker (`/api/jobs/notify-collaborators`) when `QSTASH_TOKEN` is configured
-5. Falls back to in-process notification processing if QStash is not available
+5. Fails closed with 503 in production if QStash enqueue fails so Supabase can retry
+6. Falls back to in-process notification processing only in local/test environments where QStash is intentionally absent
 
 Events for other tables are silently skipped with `{ok: true, skipped: true}`.
 

--- a/docs/architecture/decisions/adr-0041-webhook-notifications-qstash-and-resend.md
+++ b/docs/architecture/decisions/adr-0041-webhook-notifications-qstash-and-resend.md
@@ -43,8 +43,9 @@ downstream collaborator webhooks.
     `tryReserveKey` for idempotency.
   - If `QSTASH_TOKEN` is configured, publishes a JSON job `{ eventKey, payload }` to
     `/api/jobs/notify-collaborators` via QStash and returns HTTP 200 immediately.
-  - If `QSTASH_TOKEN` is not configured (development/test), falls back to using
-    `after()` with a fire-and-forget call to the same notification logic.
+  - If QStash enqueue fails in production, returns a 503 so Supabase retries the
+    webhook. Development/test may use an explicitly gated `after()` fallback for
+    local loops without QStash credentials.
 
 - `/api/jobs/notify-collaborators` is a Node runtime worker route that:
   - Verifies the `Upstash-Signature` header with QStash signing keys.

--- a/docs/architecture/decisions/adr-0054-upstash-testing-harness.md
+++ b/docs/architecture/decisions/adr-0054-upstash-testing-harness.md
@@ -17,8 +17,8 @@ Recent Vitest runs (`--pool=threads`) exposed brittle, duplicated Upstash mocks 
 We will adopt a three-tier Upstash testing strategy:
 
 1. **Unit-fast tier (default):** Shared in-memory stubs for `@upstash/redis` and `@upstash/ratelimit`, plus centralized MSW handlers for REST/QStash endpoints. Every suite will import the shared helper with a single `reset()` per test; use `vi.doMock` (not `vi.mock`) to stay thread-safe with hoisted evaluation under `--pool=threads`.
-2. **Local integration tier (optional):** Deterministic emulators (`upstash-redis-local` or equivalent REST-compatible server; QStash CLI dev server) started once per Vitest worker to validate HTTP contracts (auth headers, TTL, 429s) without external network.
-3. **Live contract smoke (gated):** A tiny serialized suite that hits real Upstash (Redis, Ratelimit, QStash publish/verify) only when `UPSTASH_SMOKE=1` and secrets are present. Defaults to skipped in CI/PRs.
+2. **Local integration tier (optional):** Deterministic emulators (`upstash-redis-local` or equivalent REST-compatible server; QStash CLI dev server) started once per Vitest worker to validate HTTP contracts (auth headers, TTL, 429s) without external network. Prefer runtime Redis env names (`UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`) pointed at the emulator; `UPSTASH_EMULATOR_URL` is a legacy Redis alias.
+3. **Live contract smoke (gated):** A tiny serialized suite that hits real Upstash (Redis, Ratelimit, QStash publish) only when `UPSTASH_SMOKE=1` and secrets are present. Use runtime credential names (`UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `QSTASH_TOKEN`) plus `UPSTASH_QSTASH_SMOKE_TARGET_URL` for the disposable publish destination. Defaults to skipped in CI/PRs.
 
 Decision framework scoring (target ≥9/10 composite):
 

--- a/docs/architecture/decisions/adr-0067-upstash-redis-qstash-rate-limit-and-jobs.md
+++ b/docs/architecture/decisions/adr-0067-upstash-redis-qstash-rate-limit-and-jobs.md
@@ -1,6 +1,6 @@
 # ADR-0067: Upstash Redis + QStash for caching, rate limits, and background jobs
 
-**Version**: 1.0.0  
+**Version**: 1.1.0
 **Status**: Accepted  
 **Date**: 2026-01-05  
 **Category**: backend + ops  
@@ -16,6 +16,10 @@ TripSage needs:
 
 ## Decision
 
+- QStash, Redis, and Ratelimit remain the canonical production stack for this
+  release. Do not introduce `@upstash/workflow`, `@vercel/queue`, or another
+  durable execution layer until production telemetry proves it removes more
+  custom orchestration than it adds.
 - Use Upstash Redis for:
   - ephemeral caching (TTL, namespaced keys)
   - rate limiting via `@upstash/ratelimit`
@@ -25,12 +29,39 @@ TripSage needs:
 - Require idempotency for every job handler:
   - idempotency key required
   - “already processed” short-circuit stored in Redis or DB
+- Build all `@upstash/ratelimit` instances through `src/lib/ratelimit/upstash.ts`.
+  Surfaces keep their own degraded-mode policy:
+  - API routes: `withApiGuards({ degradedMode })`, defaulting high-cost and
+    security-sensitive routes to fail closed.
+  - Webhooks and jobs: fail closed by default.
+  - AI tools: fail open on unavailable limiter infrastructure but emit telemetry.
+- Publish all QStash jobs through `src/lib/qstash/client.ts` with:
+  - deterministic `deduplicationId`
+  - canonical `label` from `QSTASH_JOB_LABELS`
+  - explicit retry count and retry delay expression
+  - optional flow control and failure callback where the job owner needs them
+
+## Decision Matrix
+
+| Option | Solution leverage (35%) | App value (30%) | Maintenance (25%) | Adaptability (10%) | Weighted |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Keep Upstash Redis + QStash + Ratelimit and harden contracts | 9.4 | 9.1 | 9.2 | 8.8 | 9.2 |
+| Adopt Upstash Workflow for this release | 8.4 | 7.6 | 6.8 | 8.5 | 7.7 |
+| Adopt Vercel Queues/Workflow now | 8.0 | 7.4 | 6.5 | 8.8 | 7.5 |
+| Custom Redis queues | 4.5 | 5.0 | 3.0 | 4.0 | 4.2 |
+
+The hardened-current-stack option wins because it preserves the serverless
+provider fit while deleting duplicate rate-limit construction and tightening
+publish contracts. Workflow products stay viable future options, but they are
+not a net simplification for the current job graph.
 
 ## Consequences
 
 - Minimal infrastructure, serverless-friendly.
 - Built-in retry behavior and signatures for jobs.
 - Requires disciplined implementation of handler verification and idempotency.
+- Production webhook/job paths cannot silently downgrade critical background
+  work to in-process best-effort execution.
 
 ## References
 
@@ -39,6 +70,9 @@ Upstash RateLimit docs: https://upstash.com/docs/redis/sdks/ratelimit-ts/overvie
 RateLimit getting started: https://upstash.com/docs/redis/sdks/ratelimit-ts/gettingstarted
 Upstash QStash local development: https://upstash.com/docs/qstash/howto/local-development
 QStash retry behavior: https://upstash.com/docs/qstash/features/retry
+QStash deduplication: https://upstash.com/docs/qstash/features/deduplication
+QStash flow control: https://upstash.com/docs/qstash/features/flowcontrol
+QStash DLQ operations: https://upstash.com/docs/qstash/api-reference/dlq/bulk-retry-dlq-messages
 NPM @upstash/ratelimit: https://www.npmjs.com/package/@upstash/ratelimit
 NPM @upstash/redis: https://www.npmjs.com/package/@upstash/redis
 NPM @upstash/qstash: https://www.npmjs.com/package/@upstash/qstash

--- a/docs/development/backend/rate-limiting.md
+++ b/docs/development/backend/rate-limiting.md
@@ -6,6 +6,11 @@ TripSage uses Upstash Redis + `@upstash/ratelimit` for server-side throttling:
 - **Webhooks**: enforced in `src/lib/webhooks/rate-limit.ts` and applied by `src/lib/webhooks/handler.ts`.
 - **AI tools**: enforced in `src/ai/lib/tool-factory.ts` (`createAiTool({ guardrails: { rateLimit: ... } })`).
 
+All `@upstash/ratelimit` instances are constructed through
+`src/lib/ratelimit/upstash.ts`. That module owns limiter caching, sliding-window
+construction, timeout normalization, and Redis-unavailable detection. Surface
+modules own only response shape and degraded-mode policy.
+
 ## Degraded-mode policy (fail-open vs fail-closed)
 
 Some endpoints are privileged or cost-bearing and must **fail closed** if rate limiting cannot be enforced (missing Redis config, Redis unavailable, enforcement errors).
@@ -49,6 +54,8 @@ Always obtain Redis via `getRedis()`:
 
 - `src/lib/redis.ts` exports `getRedis()` with a test injection hook.
 - Do not call `Redis.fromEnv()` in application code.
+- Do not construct `Ratelimit` directly in feature code; call
+  `checkUpstashRateLimit()` from `src/lib/ratelimit/upstash.ts`.
 
 ## Client IP extraction (canonical)
 
@@ -103,5 +110,11 @@ Prefer existing Upstash test harness utilities:
 - Shared mocks/stubs: `src/test/upstash/*`
 - MSW handlers: `src/test/msw/handlers/upstash.ts`
 - API route rate limiting can be overridden via `setRateLimitFactoryForTests()` in `src/lib/api/factory.ts`.
+- Optional emulator integration uses `UPSTASH_USE_EMULATOR=1` plus
+  `UPSTASH_REDIS_REST_URL` for Redis and `UPSTASH_QSTASH_DEV_URL` for the
+  QStash dev server.
+- Live smoke tests use runtime credential names (`UPSTASH_REDIS_REST_URL`,
+  `UPSTASH_REDIS_REST_TOKEN`, `QSTASH_TOKEN`) plus
+  `UPSTASH_QSTASH_SMOKE_TARGET_URL` as the disposable publish target.
 
 See [Testing](../testing/testing.md#decision-table) for the current test tiers and mock setup guidance.

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -127,8 +127,8 @@ Organize handlers by domain; compose with `composeHandlers`. Cover success + err
 
 - **Unit:** `setupUpstashMocks()` from `@/test/upstash/redis-mock`; call `redis.__reset()` and `ratelimit.__reset()` in `beforeEach`.
 - **HTTP:** `@/test/msw/handlers/upstash.ts` for pipeline/ratelimit/QStash.
-- **Emulator:** `UPSTASH_USE_EMULATOR=1` + `UPSTASH_EMULATOR_URL` + `UPSTASH_QSTASH_DEV_URL`; helper in `@/test/upstash/emulator.ts`.
-- **Smoke:** `pnpm test:upstash:smoke` with `UPSTASH_SMOKE=1`.
+- **Emulator:** `UPSTASH_USE_EMULATOR=1` + `UPSTASH_REDIS_REST_URL` (Redis REST emulator; `UPSTASH_EMULATOR_URL` is a legacy alias) + `UPSTASH_QSTASH_DEV_URL`; helper in `@/test/upstash/emulator.ts`.
+- **Smoke:** `pnpm test:upstash:smoke` with `UPSTASH_SMOKE=1`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `QSTASH_TOKEN`, and a disposable `UPSTASH_QSTASH_SMOKE_TARGET_URL`.
 
 ## AI SDK v6 Tests
 

--- a/docs/specs/active/0107-spec-jobs-and-webhooks.md
+++ b/docs/specs/active/0107-spec-jobs-and-webhooks.md
@@ -59,11 +59,16 @@ Jobs (QStash workers):
     - This disables retries and forwards the message to the configured DLQ.
 
 - When publishing jobs, set an explicit retry delay expression (via `Upstash-Retry-Delay`) so failures reach DLQ promptly instead of waiting hours/days on the QStash default backoff.
+- Production webhook paths must not silently downgrade critical QStash jobs to
+  in-process best-effort work. Any local/test fallback must be explicitly gated
+  by environment.
 
 ## Deduplication (publishing)
 
 - Prefer explicit deduplication keys when publishing jobs:
   - `Upstash-Deduplication-Id` (stable key derived from the business operation).
+- `src/lib/qstash/client.ts` rejects publishes without a non-empty deterministic
+  `deduplicationId`.
 - Optionally enable content-based deduplication for idempotent bodies:
   - `Upstash-Content-Based-Deduplication: true`
 
@@ -71,6 +76,8 @@ Jobs (QStash workers):
 
 - Apply QStash labels for log filtering, DLQ queries, and cancellation.
 - Convention: `tripsage:<job-type>` (see `QSTASH_JOB_LABELS` in `src/lib/qstash/config.ts`).
+- `src/lib/qstash/client.ts` rejects publishes without a canonical non-empty
+  label.
 
 ## Flow control
 

--- a/src/__tests__/contracts/upstash.smoke.integration.test.ts
+++ b/src/__tests__/contracts/upstash.smoke.integration.test.ts
@@ -15,11 +15,11 @@ describe("Upstash live smoke", () => {
 
   const redisUrl = process.env.UPSTASH_REDIS_REST_URL;
   const redisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
-  const qstashUrl = process.env.UPSTASH_QSTASH_URL;
-  const qstashToken = process.env.UPSTASH_QSTASH_TOKEN;
+  const qstashTargetUrl = process.env.UPSTASH_QSTASH_SMOKE_TARGET_URL;
+  const qstashToken = process.env.QSTASH_TOKEN;
 
   const haveRedis = !!redisUrl && !!redisToken;
-  const haveQstash = !!qstashUrl && !!qstashToken;
+  const haveQstash = !!qstashTargetUrl && !!qstashToken;
 
   it.skipIf(!enabled || !haveRedis)(
     "hits Redis set/get and ratelimit",
@@ -47,10 +47,13 @@ describe("Upstash live smoke", () => {
   it.skipIf(!enabled || !haveQstash)(
     "publishes QStash message",
     async () => {
-      const qstashUrl = required("UPSTASH_QSTASH_URL");
-      const qstashToken = required("UPSTASH_QSTASH_TOKEN");
+      const qstashTargetUrl = required("UPSTASH_QSTASH_SMOKE_TARGET_URL");
+      const qstashToken = required("QSTASH_TOKEN");
+      const publishUrl = `https://qstash.upstash.io/v2/publish/${encodeURIComponent(
+        qstashTargetUrl
+      )}`;
 
-      const res = await fetch(qstashUrl, {
+      const res = await fetch(publishUrl, {
         body: JSON.stringify({ hello: "world" }),
         headers: {
           Authorization: `Bearer ${qstashToken}`,

--- a/src/ai/lib/tool-factory.ts
+++ b/src/ai/lib/tool-factory.ts
@@ -12,7 +12,6 @@ import {
   type ToolErrorCode,
 } from "@ai/tools/server/errors";
 import type { AgentWorkflowKind } from "@schemas/agents";
-import { Ratelimit } from "@upstash/ratelimit";
 import type { FlexibleSchema, JSONValue, Tool, ToolExecutionOptions } from "ai";
 import { asSchema } from "ai";
 import { headers } from "next/headers";
@@ -25,7 +24,7 @@ import {
   normalizeRateLimitResetToMs,
 } from "@/lib/ratelimit/headers";
 import { hashIdentifier, normalizeIdentifier } from "@/lib/ratelimit/identifier";
-import { getRedis } from "@/lib/redis";
+import { checkUpstashRateLimit, type RateLimitWindow } from "@/lib/ratelimit/upstash";
 import {
   type Span,
   type TelemetrySpanAttributes,
@@ -103,9 +102,6 @@ function toJsonValue(value: unknown): JSONValue {
     );
   }
 }
-
-/** Type alias for rate limit window duration accepted by Upstash Ratelimit. */
-type RateLimitWindow = Parameters<typeof Ratelimit.slidingWindow>[1];
 
 /**
  * Signature for tool execution functions that receive validated input and call options.
@@ -254,18 +250,6 @@ export type CreateAiToolOptions<InputValue, OutputValue> = ToolOptions<
 type CacheLookupResult<OutputValue> =
   | { hit: true; value: OutputValue }
   | { hit: false };
-
-/**
- * Cache of Ratelimit instances by configuration key.
- *
- * Design decision: Upstash Ratelimit instances are stateless Redis clients,
- * so reusing them across requests is safe and reduces instantiation overhead.
- * Each unique (prefix, limit, window) combination gets its own cached instance.
- * The cache key format is `${namespace}:${limit}:${window}` to ensure distinct
- * configurations don't share limiters.
- */
-const rateLimiterCache = new Map<string, InstanceType<typeof Ratelimit>>();
-const MAX_RATE_LIMITER_CACHE_SIZE = 128;
 
 /**
  * Builds lifecycle hooks object from options, including only defined hooks.
@@ -628,45 +612,31 @@ async function enforceRateLimit<InputValue>(
     ? toHashedLimiterIdentifier(override)
     : await getRateLimitIdentifier();
 
-  const redis = getRedis();
-  if (!redis) {
-    span.addEvent("ratelimit_skipped", { reason: "redis_unavailable" });
+  const limiterNamespace = config.prefix ?? `ratelimit:tool:${toolName}`;
+  const result = await checkUpstashRateLimit({
+    analytics: false,
+    dynamicLimits: true,
+    identifier,
+    limit: config.limit,
+    prefix: limiterNamespace,
+    window: config.window as RateLimitWindow,
+  });
+  if (result.status === "unavailable") {
+    span.addEvent("ratelimit_skipped", { reason: result.reason });
     return;
   }
+  if (result.status === "pass") return;
 
-  const limiterNamespace = config.prefix ?? `ratelimit:tool:${toolName}`;
-  const limiterKey = `${limiterNamespace}:${config.limit}:${config.window}`;
-  let limiter = rateLimiterCache.get(limiterKey);
-  if (!limiter) {
-    limiter = new Ratelimit({
-      analytics: false,
-      dynamicLimits: true,
-      limiter: Ratelimit.slidingWindow(config.limit, config.window as RateLimitWindow),
-      prefix: limiterNamespace,
-      redis,
-    });
-    if (rateLimiterCache.size >= MAX_RATE_LIMITER_CACHE_SIZE) {
-      const oldestKey = rateLimiterCache.keys().next().value;
-      if (oldestKey) {
-        rateLimiterCache.delete(oldestKey);
-      }
-    }
-    rateLimiterCache.set(limiterKey, limiter);
-  }
-
-  const result = await limiter.limit(identifier);
   // Validate rate limit result structure using schema
   const validatedResult: RateLimitResult = rateLimitResultSchema.parse({
-    limit: result.limit,
-    remaining: result.remaining,
+    limit: result.result.limit,
+    remaining: result.result.remaining,
     reset:
-      typeof result.reset === "number"
-        ? normalizeRateLimitResetToMs(result.reset)
+      typeof result.result.reset === "number"
+        ? normalizeRateLimitResetToMs(result.result.reset)
         : undefined,
-    success: result.success,
+    success: result.result.success,
   });
-
-  if (validatedResult.success) return;
 
   const subjectType = identifier.startsWith("user:")
     ? "user"

--- a/src/ai/tools/server/web-search-batch.ts
+++ b/src/ai/tools/server/web-search-batch.ts
@@ -16,12 +16,11 @@ import {
 } from "@ai/tools/schemas/web-search-batch";
 import { createToolError, TOOL_ERROR_CODES } from "@ai/tools/server/errors";
 import { normalizeWebSearchResults } from "@ai/tools/server/web-search-normalize";
-import { Ratelimit } from "@upstash/ratelimit";
 import type { ToolExecutionOptions } from "ai";
 import { z } from "zod";
 import { hashInputForCache } from "@/lib/cache/hash";
 import { hashIdentifier, normalizeIdentifier } from "@/lib/ratelimit/identifier";
-import { getRedis } from "@/lib/redis";
+import { checkUpstashRateLimit } from "@/lib/ratelimit/upstash";
 import { createServerLogger } from "@/lib/telemetry/logger";
 import { webSearch } from "./web-search";
 
@@ -47,25 +46,32 @@ async function resolveToolResult(result: unknown): Promise<unknown> {
   return await Promise.resolve(result);
 }
 
-/**
- * Build Upstash rate limiter for batch web search tool.
- *
- * Returns undefined if Upstash env vars are missing. Uses sliding window:
- * 20 requests per minute per user.
- *
- * @returns Rate limiter instance or undefined if not configured.
- */
-
-function buildToolRateLimiter(): InstanceType<typeof Ratelimit> | undefined {
-  const redis = getRedis();
-  if (!redis) return undefined;
-  return new Ratelimit({
+async function enforceBatchRateLimit(userId: string): Promise<void> {
+  const identifier = `user:${hashIdentifier(normalizeIdentifier(userId))}`;
+  const result = await checkUpstashRateLimit({
     analytics: true,
     dynamicLimits: true,
-    limiter: Ratelimit.slidingWindow(20, "1 m"),
+    ephemeralCache: false,
+    identifier,
+    limit: 20,
     prefix: "ratelimit:tools:web-search-batch",
-    redis,
+    window: "1 m",
   });
+
+  if (result.status === "unavailable") {
+    webSearchBatchLogger.error("rate_limiter_unavailable", {
+      reason: result.reason,
+    });
+    return;
+  }
+  if (result.status === "limited") {
+    throw createToolError(TOOL_ERROR_CODES.webSearchRateLimited, undefined, {
+      limit: result.result.limit,
+      remaining: result.result.remaining,
+      reset: result.result.reset,
+      success: false,
+    });
+  }
 }
 
 /**
@@ -94,13 +100,8 @@ export const webSearchBatch = createAiTool({
     const started = Date.now();
     // Optional top-level rate limiting (in addition to per-query limits)
     try {
-      const rl = buildToolRateLimiter();
-      if (rl && userId) {
-        const identifier = `user:${hashIdentifier(normalizeIdentifier(userId))}`;
-        const rr = await rl.limit(identifier);
-        if (!rr.success) {
-          throw createToolError(TOOL_ERROR_CODES.webSearchRateLimited, undefined, rr);
-        }
+      if (userId) {
+        await enforceBatchRateLimit(userId);
       }
     } catch (e) {
       if (

--- a/src/app/api/hooks/trips/__tests__/route.test.ts
+++ b/src/app/api/hooks/trips/__tests__/route.test.ts
@@ -1,6 +1,6 @@
 /** @vitest-environment node */
 
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QSTASH_JOB_LABELS } from "@/lib/qstash/config";
 import type { WebhookPayload } from "@/lib/webhooks/payload";
 import { createMockNextRequest, getMockCookiesForTest } from "@/test/helpers/route";
@@ -205,6 +205,10 @@ describe("POST /api/hooks/trips", () => {
     supabaseFactory = () => createSupabaseStub();
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   const loadRoute = async (): Promise<TripsRouteModule> => {
     return await import("../route");
   };
@@ -314,6 +318,33 @@ describe("POST /api/hooks/trips", () => {
       expect.objectContaining({ table: "trip_collaborators" }),
       "event-key-1"
     );
+  });
+
+  it("fails closed in production when QStash enqueue fails", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    tryEnqueueJobMock.mockResolvedValue({ error: null, success: false });
+    parseAndVerifyMock.mockResolvedValue({
+      ok: true,
+      payload: {
+        oldRecord: null,
+        record: { id: "1", trip_id: 77 },
+        table: "trip_collaborators",
+        type: "INSERT",
+      },
+    });
+    tryReserveKeyMock.mockResolvedValue(true);
+
+    const { POST } = await loadRoute();
+    const res = await POST(makeRequest({}));
+    const json = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(json).toMatchObject({
+      code: "SERVICE_UNAVAILABLE",
+      error: "internal_error",
+    });
+    expect(afterCallbacks).toHaveLength(0);
+    expect(sendCollaboratorNotificationsMock).not.toHaveBeenCalled();
   });
 
   afterAll(() => {

--- a/src/app/api/hooks/trips/route.ts
+++ b/src/app/api/hooks/trips/route.ts
@@ -13,6 +13,7 @@ import type { Database } from "@/lib/supabase/database.types";
 import { getMaybeSingle } from "@/lib/supabase/typed-helpers";
 import { createServerLogger } from "@/lib/telemetry/logger";
 import { recordErrorOnSpan, withTelemetrySpan } from "@/lib/telemetry/span";
+import { WebhookServiceUnavailableError } from "@/lib/webhooks/errors";
 import { createWebhookHandler } from "@/lib/webhooks/handler";
 
 type TripCollaboratorRow = Database["public"]["Tables"]["trip_collaborators"]["Row"];
@@ -76,7 +77,14 @@ export const POST = createWebhookHandler({
       return { enqueued: true };
     }
 
-    // Fallback: fire-and-forget via after() if QStash unavailable
+    if (process.env.NODE_ENV === "production") {
+      span.setAttribute("qstash.unavailable", true);
+      throw new WebhookServiceUnavailableError("qstash_unavailable", {
+        cause: result.error ?? undefined,
+      });
+    }
+
+    // Local/test fallback: keep developer loops usable when QStash is intentionally absent.
     after(async () => {
       try {
         await withTelemetrySpan(

--- a/src/app/api/jobs/attachments-ingest/_handler.ts
+++ b/src/app/api/jobs/attachments-ingest/_handler.ts
@@ -25,9 +25,10 @@ export interface AttachmentsIngestDeps {
     jobType: string,
     payload: unknown,
     path: string,
-    options?: EnqueueJobOptions
+    options: EnqueueJobOptions
   ) => Promise<
-    { success: true; messageId: string } | { success: false; error: Error | null }
+    | { success: true; messageId: string; deduplicated?: boolean }
+    | { success: false; error: Error | null }
   >;
 }
 

--- a/src/lib/api/factory.ts
+++ b/src/lib/api/factory.ts
@@ -8,7 +8,6 @@ import type { AgentDependencies } from "@ai/agents/types";
 import { buildTimeoutConfigFromSeconds } from "@ai/timeout";
 import type { AgentConfig, AgentType } from "@schemas/configuration";
 import type { User } from "@supabase/supabase-js";
-import { Ratelimit } from "@upstash/ratelimit";
 import type { Agent, ToolSet } from "ai";
 import { cookies } from "next/headers";
 import type { NextRequest, NextResponse } from "next/server";
@@ -29,7 +28,11 @@ import { type ApiMetric, fireAndForgetMetric } from "@/lib/metrics/api-metrics";
 import { applyRateLimitHeaders } from "@/lib/ratelimit/headers";
 import { hashIdentifier, normalizeIdentifier } from "@/lib/ratelimit/identifier";
 import { ROUTE_RATE_LIMITS, type RouteRateLimitKey } from "@/lib/ratelimit/routes";
-import { getRedis } from "@/lib/redis";
+import {
+  checkUpstashRateLimit,
+  type DegradedMode,
+  parseRateLimitWindowMs,
+} from "@/lib/ratelimit/upstash";
 import {
   assertHumanOrThrow,
   BOT_DETECTED_RESPONSE,
@@ -48,7 +51,7 @@ import { withTelemetrySpan } from "@/lib/telemetry/span";
 
 const apiFactoryLogger = createServerLogger("api.factory");
 
-export type DegradedMode = "fail_closed" | "fail_open";
+export type { DegradedMode } from "@/lib/ratelimit/upstash";
 
 const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
@@ -246,28 +249,6 @@ function getRateLimitConfig(
   return ROUTE_RATE_LIMITS[key] || null;
 }
 
-function parseRateLimitWindowMs(window: string): number | null {
-  const parts = window.trim().split(/\s+/);
-  if (parts.length !== 2) return null;
-  const value = Number(parts[0]);
-  const unit = parts[1];
-  if (!Number.isFinite(value) || value <= 0) return null;
-  const unitMs =
-    unit === "ms"
-      ? 1
-      : unit === "s"
-        ? 1000
-        : unit === "m"
-          ? 60_000
-          : unit === "h"
-            ? 3_600_000
-            : unit === "d"
-              ? 86_400_000
-              : null;
-  if (!unitMs) return null;
-  return Math.floor(value * unitMs);
-}
-
 /**
  * Determine the degraded mode for a rate limit key when Redis is unavailable.
  *
@@ -382,28 +363,6 @@ export async function enforceRateLimit(
     return null;
   }
 
-  const redis = getRedis();
-  if (!redis && !rateLimitFactory) {
-    if (options.degradedMode === "fail_closed") {
-      return errorResponse({
-        error: "rate_limit_unavailable",
-        reason: "Rate limiting unavailable",
-        status: 503,
-      });
-    }
-
-    emitOperationalAlertOncePerWindow({
-      attributes: {
-        degradedMode: "fail_open",
-        rateLimitKey,
-        reason: "redis_unavailable",
-      },
-      event: "ratelimit.degraded",
-      windowMs: parseRateLimitWindowMs(config.window) ?? 60_000,
-    });
-    return null;
-  }
-
   try {
     if (rateLimitFactory) {
       const { success, remaining, reset, limit, reason } = await rateLimitFactory(
@@ -431,29 +390,42 @@ export async function enforceRateLimit(
       return null;
     }
 
-    // At this point, rateLimitFactory is falsy, so redis must be defined
-    if (!redis) {
-      return null; // Should not reach here due to earlier check, but satisfy TypeScript
-    }
-
-    const limiter = new Ratelimit({
+    const result = await checkUpstashRateLimit({
       analytics: false,
       dynamicLimits: true,
       ephemeralCache: false,
-      limiter: Ratelimit.slidingWindow(
-        config.limit,
-        config.window as Parameters<typeof Ratelimit.slidingWindow>[1]
-      ),
+      identifier,
+      limit: config.limit,
       prefix: `ratelimit:route:${String(rateLimitKey)}`,
-      redis,
+      window: config.window,
     });
 
-    const { success, remaining, reset, reason } = await limiter.limit(identifier);
-    if (reason === "timeout") {
+    if (result.status === "unavailable") {
       const windowMs = parseRateLimitWindowMs(config.window) ?? 60_000;
-      return handleRateLimitTimeout(rateLimitKey, windowMs, options.degradedMode);
+      if (result.reason === "timeout") {
+        return handleRateLimitTimeout(rateLimitKey, windowMs, options.degradedMode);
+      }
+      if (options.degradedMode === "fail_closed") {
+        return errorResponse({
+          err: result.error,
+          error: "rate_limit_unavailable",
+          reason: "Rate limiting unavailable",
+          status: 503,
+        });
+      }
+      emitOperationalAlertOncePerWindow({
+        attributes: {
+          degradedMode: "fail_open",
+          rateLimitKey,
+          reason: result.reason,
+        },
+        event: "ratelimit.degraded",
+        windowMs,
+      });
+      return null;
     }
-    if (!success) {
+
+    if (result.status === "limited") {
       const response = errorResponse({
         error: "rate_limit_exceeded",
         reason: "Too many requests",
@@ -461,9 +433,9 @@ export async function enforceRateLimit(
       });
       applyRateLimitHeaders(response.headers, {
         limit: config.limit,
-        remaining,
-        reset,
-        success,
+        remaining: result.result.remaining,
+        reset: result.result.reset,
+        success: result.result.success,
       });
       return response;
     }

--- a/src/lib/memory/__tests__/upstash-adapter.test.ts
+++ b/src/lib/memory/__tests__/upstash-adapter.test.ts
@@ -106,7 +106,7 @@ describe("createUpstashMemoryAdapter", () => {
         userId: "user-456",
       },
     });
-    expect(messages[0]?.deduplicationId).toBeUndefined();
+    expect(messages[0]?.deduplicationId).toBe("memory-sync:incr-sync:session-123");
     expect(messages[1]?.body).toEqual({
       idempotencyKey: "full-sync:session-123",
       payload: {
@@ -115,6 +115,6 @@ describe("createUpstashMemoryAdapter", () => {
         userId: "user-456",
       },
     });
-    expect(messages[1]?.deduplicationId).toBeUndefined();
+    expect(messages[1]?.deduplicationId).toBe("memory-sync:full-sync:session-123");
   });
 });

--- a/src/lib/memory/upstash-adapter.ts
+++ b/src/lib/memory/upstash-adapter.ts
@@ -86,6 +86,7 @@ async function handleSyncSession(
       },
       "/api/jobs/memory-sync",
       {
+        deduplicationId: `memory-sync:${idempotencyKey}`,
         delay: isFull ? undefined : 5,
         label: QSTASH_JOB_LABELS.MEMORY_SYNC,
       }

--- a/src/lib/qstash/__tests__/client.test.ts
+++ b/src/lib/qstash/__tests__/client.test.ts
@@ -1,6 +1,8 @@
 /** @vitest-environment node */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QSTASH_JOB_LABELS } from "@/lib/qstash/config";
+import { unsafeCast } from "@/test/helpers/unsafe-cast";
 import { installUpstashMocks, resetUpstashMocks } from "@/test/upstash";
 
 const mockSpan = vi.hoisted(() => ({
@@ -55,18 +57,22 @@ describe("enqueueJob", () => {
     setQStashClientFactoryForTests(() => new qstash.Client({ token: "test" }));
 
     const result = await enqueueJob("test-job", { ok: true }, "/api/jobs/test", {
+      deduplicationId: "test-job:123",
       failureCallback: "https://example.com/failure",
       flowControl: { key: "tenant-1", parallelism: 2 },
-      label: "tripsage:test",
+      label: QSTASH_JOB_LABELS.NOTIFY_COLLABORATORS,
       timeout: 30,
     });
 
     const messages = qstash.__getMessages();
     expect(messages).toHaveLength(1);
     expect(messages[0]?.url).toBe("https://example.com/api/jobs/test");
-    expect(messages[0]?.label).toBe("tripsage:test");
+    expect(messages[0]?.deduplicationId).toBe("test-job:123");
+    expect(messages[0]?.label).toBe(QSTASH_JOB_LABELS.NOTIFY_COLLABORATORS);
     expect(messages[0]?.flowControl).toEqual({ key: "tenant-1", parallelism: 2 });
     expect(messages[0]?.failureCallback).toBe("https://example.com/failure");
+    expect(messages[0]?.retries).toBe(5);
+    expect(messages[0]?.retryDelay).toBe("10000 * pow(2, retried)");
     expect(messages[0]?.timeout).toBe(30);
     expect(result?.messageId).toBe("qstash-mock-1");
   });
@@ -78,12 +84,20 @@ describe("enqueueJob", () => {
     setQStashClientFactoryForTests(() => new qstash.Client({ token: "test" }));
 
     await enqueueJob("test-job", { ok: true }, "/api/jobs/test", {
+      deduplicationId: "test-job:tenant-42",
       failureCallback: "https://example.com/failure",
       flowControl: { key: "tenant-42", rate: 5 },
-      label: "tripsage:test",
+      label: QSTASH_JOB_LABELS.NOTIFY_COLLABORATORS,
     });
 
-    expect(mockSpan.setAttribute).toHaveBeenCalledWith("qstash.label", "tripsage:test");
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      "qstash.dedup_id",
+      "test-job:tenant-42"
+    );
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      "qstash.label",
+      QSTASH_JOB_LABELS.NOTIFY_COLLABORATORS
+    );
     expect(mockSpan.setAttribute).toHaveBeenCalledWith(
       "qstash.flow_control_key",
       "tenant-42"
@@ -105,7 +119,10 @@ describe("enqueueJob", () => {
     setQStashClientFactoryForTests(() => new qstash.Client({ token: "test" }));
 
     await expect(
-      enqueueJob("test-job", { ok: true }, "/api/jobs/test")
+      enqueueJob("test-job", { ok: true }, "/api/jobs/test", {
+        deduplicationId: "test-job:origin",
+        label: QSTASH_JOB_LABELS.NOTIFY_COLLABORATORS,
+      })
     ).rejects.toThrow("Server origin not configured");
 
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("qstash.missing_origin", true);
@@ -120,11 +137,74 @@ describe("enqueueJob", () => {
     );
     setQStashClientFactoryForTests(() => new qstash.Client({ token: "test" }));
 
-    await expect(enqueueJob("test-job", { ok: true }, path)).rejects.toThrow(
-      "QStash job path must be a same-origin absolute path"
-    );
+    await expect(
+      enqueueJob("test-job", { ok: true }, path, {
+        deduplicationId: "test-job:invalid-path",
+        label: QSTASH_JOB_LABELS.NOTIFY_COLLABORATORS,
+      })
+    ).rejects.toThrow("QStash job path must be a same-origin absolute path");
 
     expect(qstash.__getMessages()).toHaveLength(0);
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("qstash.invalid_path", true);
+  });
+
+  it("rejects publishes without a deterministic deduplication id", async () => {
+    const { enqueueJob, setQStashClientFactoryForTests } = await import(
+      "@/lib/qstash/client"
+    );
+    setQStashClientFactoryForTests(() => new qstash.Client({ token: "test" }));
+
+    await expect(
+      enqueueJob(
+        "test-job",
+        { ok: true },
+        "/api/jobs/test",
+        unsafeCast({
+          deduplicationId: " ",
+          label: QSTASH_JOB_LABELS.NOTIFY_COLLABORATORS,
+        })
+      )
+    ).rejects.toThrow("QStash job publish requires a deterministic deduplicationId");
+
+    expect(qstash.__getMessages()).toHaveLength(0);
+  });
+
+  it("rejects publishes without a canonical label", async () => {
+    const { enqueueJob, setQStashClientFactoryForTests } = await import(
+      "@/lib/qstash/client"
+    );
+    setQStashClientFactoryForTests(() => new qstash.Client({ token: "test" }));
+
+    await expect(
+      enqueueJob(
+        "test-job",
+        { ok: true },
+        "/api/jobs/test",
+        unsafeCast({ deduplicationId: "test-job:no-label", label: " " })
+      )
+    ).rejects.toThrow("QStash job publish requires a canonical label");
+
+    expect(qstash.__getMessages()).toHaveLength(0);
+  });
+
+  it("rejects publishes with a non-canonical label", async () => {
+    const { enqueueJob, setQStashClientFactoryForTests } = await import(
+      "@/lib/qstash/client"
+    );
+    setQStashClientFactoryForTests(() => new qstash.Client({ token: "test" }));
+
+    await expect(
+      enqueueJob(
+        "test-job",
+        { ok: true },
+        "/api/jobs/test",
+        unsafeCast({
+          deduplicationId: "test-job:unknown-label",
+          label: "tripsage:unknown",
+        })
+      )
+    ).rejects.toThrow("QStash job publish requires a canonical label");
+
+    expect(qstash.__getMessages()).toHaveLength(0);
   });
 });

--- a/src/lib/qstash/client.ts
+++ b/src/lib/qstash/client.ts
@@ -8,7 +8,7 @@ import { Client } from "@upstash/qstash";
 import { getServerEnvVarWithFallback } from "@/lib/env/server";
 import { recordTelemetryEvent, withTelemetrySpan } from "@/lib/telemetry/span";
 import { getRequiredServerOrigin } from "@/lib/url/server-origin";
-import { QSTASH_RETRY_CONFIG } from "./config";
+import { QSTASH_JOB_LABELS, QSTASH_RETRY_CONFIG, type QStashJobLabel } from "./config";
 
 // ===== TYPES =====
 
@@ -149,12 +149,12 @@ function toQstashCallbackUrl(path: string, origin: string): string {
  * Options for enqueuing a job.
  */
 export interface EnqueueJobOptions {
-  /** Deduplication ID to prevent duplicate jobs (optional) */
-  deduplicationId?: string;
+  /** Deterministic deduplication ID derived from the business operation */
+  deduplicationId: string;
+  /** Canonical label for log filtering and DLQ queries */
+  label: QStashJobLabel;
   /** Enable content-based deduplication at publish time (optional) */
   contentBasedDeduplication?: boolean;
-  /** Label for log filtering and DLQ queries */
-  label?: string;
   /** Flow control options for rate limiting by key */
   flowControl?: FlowControlOptions;
   /** URL invoked when all retries are exhausted */
@@ -169,6 +169,18 @@ export interface EnqueueJobOptions {
   retryDelay?: string;
   /** Additional headers to pass to QStash publish */
   headers?: Record<string, string>;
+}
+
+function assertPublishContract(options: EnqueueJobOptions): void {
+  if (!options.deduplicationId.trim()) {
+    throw new Error("QStash job publish requires a deterministic deduplicationId");
+  }
+  if (
+    !options.label.trim() ||
+    !Object.values(QSTASH_JOB_LABELS).includes(options.label)
+  ) {
+    throw new Error("QStash job publish requires a canonical label");
+  }
 }
 
 /**
@@ -191,7 +203,7 @@ export interface EnqueueJobResult {
  * @param jobType - Type identifier for the job (used in telemetry)
  * @param payload - Job payload to deliver
  * @param path - Worker endpoint path (e.g., "/api/jobs/notify-collaborators")
- * @param options - Optional enqueue configuration
+ * @param options - Required publish contract plus optional enqueue configuration
  * @returns EnqueueJobResult with messageId, or null if QStash unavailable
  *
  * @example
@@ -199,7 +211,11 @@ export interface EnqueueJobResult {
  * const result = await enqueueJob(
  *   "notify-collaborators",
  *   { eventKey, payload },
- *   "/api/jobs/notify-collaborators"
+ *   "/api/jobs/notify-collaborators",
+ *   {
+ *     deduplicationId: `notify:${eventKey}`,
+ *     label: QSTASH_JOB_LABELS.NOTIFY_COLLABORATORS,
+ *   }
  * );
  * if (result) {
  *   console.log("Enqueued:", result.messageId);
@@ -210,7 +226,7 @@ export async function enqueueJob(
   jobType: string,
   payload: unknown,
   path: string,
-  options: EnqueueJobOptions = {}
+  options: EnqueueJobOptions
 ): Promise<EnqueueJobResult | null> {
   return await withTelemetrySpan(
     "qstash.enqueue",
@@ -222,6 +238,8 @@ export async function enqueueJob(
       },
     },
     async (span) => {
+      assertPublishContract(options);
+
       const client = getQstashClient();
       if (!client) {
         span.setAttribute("qstash.unavailable", true);
@@ -252,21 +270,14 @@ export async function enqueueJob(
       }
       span.setAttribute("qstash.url", url);
 
-      // Deduplication is caller-controlled; random IDs defeat dedup purpose
       const deduplicationId = options.deduplicationId;
-      if (deduplicationId) {
-        span.setAttribute("qstash.dedup_id", deduplicationId);
-      } else {
-        span.setAttribute("qstash.dedup_id_missing", true);
-      }
+      span.setAttribute("qstash.dedup_id", deduplicationId);
 
       if (options.contentBasedDeduplication) {
         span.setAttribute("qstash.content_based_dedup", true);
       }
 
-      if (options.label) {
-        span.setAttribute("qstash.label", options.label);
-      }
+      span.setAttribute("qstash.label", options.label);
 
       if (options.flowControl?.key) {
         span.setAttribute("qstash.flow_control_key", options.flowControl.key);
@@ -328,14 +339,14 @@ export async function enqueueJob(
  * @param jobType - Type identifier for the job
  * @param payload - Job payload to deliver
  * @param path - Worker endpoint path
- * @param options - Optional enqueue configuration
+ * @param options - Required publish contract plus optional enqueue configuration
  * @returns Object with success status and optional error/messageId
  */
 export async function tryEnqueueJob(
   jobType: string,
   payload: unknown,
   path: string,
-  options: EnqueueJobOptions = {}
+  options: EnqueueJobOptions
 ): Promise<
   | { success: true; messageId: string; deduplicated?: boolean }
   | { success: false; error: Error | null }

--- a/src/lib/ratelimit/__tests__/upstash.test.ts
+++ b/src/lib/ratelimit/__tests__/upstash.test.ts
@@ -1,0 +1,138 @@
+/** @vitest-environment node */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const redisRef = vi.hoisted<{ current: unknown | undefined }>(() => ({
+  current: {},
+}));
+const constructorMock = vi.hoisted(() => vi.fn());
+const limitMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/redis", () => ({
+  getRedis: () => redisRef.current,
+}));
+
+vi.mock("@upstash/ratelimit", () => {
+  class Ratelimit {
+    static slidingWindow(tokens: number, window: string) {
+      return { tokens, window };
+    }
+
+    constructor(options: unknown) {
+      constructorMock(options);
+    }
+
+    limit(identifier: string) {
+      return limitMock(identifier);
+    }
+  }
+
+  return { Ratelimit };
+});
+
+async function loadModule() {
+  const mod = await import("../upstash");
+  mod.resetUpstashRateLimiterCacheForTests();
+  return mod;
+}
+
+describe("checkUpstashRateLimit", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    redisRef.current = {};
+    constructorMock.mockReset();
+    limitMock.mockReset();
+    limitMock.mockResolvedValue({
+      limit: 10,
+      pending: Promise.resolve(),
+      remaining: 9,
+      reset: Date.now() + 60_000,
+      success: true,
+    });
+  });
+
+  it("reports unavailable when Redis is not configured", async () => {
+    redisRef.current = undefined;
+    const { checkUpstashRateLimit } = await loadModule();
+
+    await expect(
+      checkUpstashRateLimit({
+        identifier: "ip:unknown",
+        limit: 10,
+        prefix: "ratelimit:test",
+        window: "1 m",
+      })
+    ).resolves.toEqual({
+      reason: "redis_unavailable",
+      status: "unavailable",
+    });
+
+    expect(constructorMock).not.toHaveBeenCalled();
+  });
+
+  it("maps Upstash timeout results to unavailable", async () => {
+    limitMock.mockResolvedValue({
+      limit: 10,
+      pending: Promise.resolve(),
+      reason: "timeout",
+      remaining: 10,
+      reset: Date.now() + 60_000,
+      success: true,
+    });
+    const { checkUpstashRateLimit } = await loadModule();
+
+    const result = await checkUpstashRateLimit({
+      identifier: "user:123",
+      limit: 10,
+      prefix: "ratelimit:test",
+      window: "1 m",
+    });
+
+    expect(result).toMatchObject({
+      reason: "timeout",
+      status: "unavailable",
+    });
+  });
+
+  it("returns limited results without applying surface policy", async () => {
+    limitMock.mockResolvedValue({
+      limit: 2,
+      pending: Promise.resolve(),
+      reason: "cacheBlock",
+      remaining: 0,
+      reset: Date.now() + 60_000,
+      success: false,
+    });
+    const { checkUpstashRateLimit } = await loadModule();
+
+    const result = await checkUpstashRateLimit({
+      identifier: "user:123",
+      limit: 2,
+      prefix: "ratelimit:test",
+      window: "1 m",
+    });
+
+    expect(result).toMatchObject({
+      result: { limit: 2, reason: "cacheBlock", remaining: 0, success: false },
+      status: "limited",
+    });
+  });
+
+  it("caches equivalent limiter definitions", async () => {
+    const { checkUpstashRateLimit } = await loadModule();
+    const options = {
+      analytics: true,
+      dynamicLimits: true,
+      ephemeralCache: false as const,
+      identifier: "user:123",
+      limit: 10,
+      prefix: "ratelimit:test",
+      window: "1 m",
+    };
+
+    await checkUpstashRateLimit(options);
+    await checkUpstashRateLimit(options);
+
+    expect(constructorMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/ratelimit/upstash.ts
+++ b/src/lib/ratelimit/upstash.ts
@@ -1,0 +1,167 @@
+/**
+ * @fileoverview Shared Upstash Ratelimit construction and enforcement primitives.
+ */
+
+import "server-only";
+
+import { Ratelimit } from "@upstash/ratelimit";
+import { getRedis } from "@/lib/redis";
+
+export type DegradedMode = "fail_closed" | "fail_open";
+
+export type RateLimitWindow = Parameters<typeof Ratelimit.slidingWindow>[1];
+
+export type UpstashRateLimitResult = {
+  limit: number;
+  reason?: "cacheBlock" | "denyList" | "timeout";
+  remaining: number;
+  reset: number;
+  success: boolean;
+};
+
+export type UpstashRateLimitUnavailableReason =
+  | "enforcement_error"
+  | "redis_unavailable"
+  | "timeout";
+
+export type UpstashRateLimitCheck =
+  | {
+      status: "pass";
+      result: UpstashRateLimitResult;
+    }
+  | {
+      status: "limited";
+      result: UpstashRateLimitResult;
+    }
+  | {
+      status: "unavailable";
+      reason: UpstashRateLimitUnavailableReason;
+      error?: unknown;
+      result?: UpstashRateLimitResult;
+    };
+
+export interface CheckUpstashRateLimitOptions {
+  analytics?: boolean;
+  dynamicLimits?: boolean;
+  ephemeralCache?: Map<string, number> | false;
+  identifier: string;
+  limit: number;
+  prefix: string;
+  timeout?: number;
+  window: RateLimitWindow | string;
+}
+
+type RatelimitInstance = InstanceType<typeof Ratelimit>;
+
+const MAX_RATE_LIMITER_CACHE_SIZE = 128;
+const rateLimiterCache = new Map<string, RatelimitInstance>();
+
+export function parseRateLimitWindowMs(window: string): number | null {
+  const parts = window.trim().split(/\s+/);
+  if (parts.length !== 2) return null;
+  const value = Number(parts[0]);
+  const unit = parts[1];
+  if (!Number.isFinite(value) || value <= 0) return null;
+  const unitMs =
+    unit === "ms"
+      ? 1
+      : unit === "s"
+        ? 1000
+        : unit === "m"
+          ? 60_000
+          : unit === "h"
+            ? 3_600_000
+            : unit === "d"
+              ? 86_400_000
+              : null;
+  if (!unitMs) return null;
+  return Math.floor(value * unitMs);
+}
+
+function getCacheKey(options: CheckUpstashRateLimitOptions): string {
+  return [
+    options.prefix,
+    options.limit,
+    options.window,
+    options.analytics === true ? "analytics" : "no-analytics",
+    options.dynamicLimits === true ? "dynamic" : "static",
+    options.ephemeralCache === false ? "no-ephemeral" : "ephemeral",
+    options.timeout ?? "default-timeout",
+  ].join(":");
+}
+
+function rememberLimiter(key: string, limiter: RatelimitInstance): RatelimitInstance {
+  if (rateLimiterCache.size >= MAX_RATE_LIMITER_CACHE_SIZE) {
+    const oldestKey = rateLimiterCache.keys().next().value;
+    if (oldestKey) {
+      rateLimiterCache.delete(oldestKey);
+    }
+  }
+  rateLimiterCache.set(key, limiter);
+  return limiter;
+}
+
+function getRateLimiter(
+  options: CheckUpstashRateLimitOptions
+): RatelimitInstance | null {
+  const redis = getRedis();
+  if (!redis) return null;
+
+  const key = getCacheKey(options);
+  const cached = rateLimiterCache.get(key);
+  if (cached) return cached;
+
+  return rememberLimiter(
+    key,
+    new Ratelimit({
+      analytics: options.analytics ?? false,
+      dynamicLimits: options.dynamicLimits ?? true,
+      ephemeralCache: options.ephemeralCache,
+      limiter: Ratelimit.slidingWindow(
+        options.limit,
+        options.window as RateLimitWindow
+      ),
+      prefix: options.prefix,
+      redis,
+      timeout: options.timeout,
+    })
+  );
+}
+
+export async function checkUpstashRateLimit(
+  options: CheckUpstashRateLimitOptions
+): Promise<UpstashRateLimitCheck> {
+  const limiter = getRateLimiter(options);
+  if (!limiter) {
+    return { reason: "redis_unavailable", status: "unavailable" };
+  }
+
+  try {
+    const result = await limiter.limit(options.identifier);
+    const normalizedResult: UpstashRateLimitResult = {
+      limit: result.limit,
+      reason: result.reason,
+      remaining: result.remaining,
+      reset: result.reset,
+      success: result.success,
+    };
+
+    if (normalizedResult.reason === "timeout") {
+      return {
+        reason: "timeout",
+        result: normalizedResult,
+        status: "unavailable",
+      };
+    }
+
+    return normalizedResult.success
+      ? { result: normalizedResult, status: "pass" }
+      : { result: normalizedResult, status: "limited" };
+  } catch (error) {
+    return { error, reason: "enforcement_error", status: "unavailable" };
+  }
+}
+
+export function resetUpstashRateLimiterCacheForTests(): void {
+  rateLimiterCache.clear();
+}

--- a/src/lib/webhooks/handler.ts
+++ b/src/lib/webhooks/handler.ts
@@ -131,7 +131,10 @@ export interface WebhookHandlerConfig<T extends WebhookHandlerResult> {
  *   tableFilter: "trip_collaborators",
  *   async handle(payload, eventKey, span, req) {
  *     // Custom processing logic
- *     const result = await enqueueJob("notify", { eventKey, payload }, "/api/jobs/notify");
+ *     const result = await enqueueJob("notify", { eventKey, payload }, "/api/jobs/notify", {
+ *       deduplicationId: `notify:${eventKey}`,
+ *       label: QSTASH_JOB_LABELS.NOTIFY_COLLABORATORS,
+ *     });
  *     return { enqueued: !!result };
  *   },
  * });

--- a/src/lib/webhooks/rate-limit.ts
+++ b/src/lib/webhooks/rate-limit.ts
@@ -4,13 +4,11 @@
 
 import "server-only";
 
-import { Ratelimit } from "@upstash/ratelimit";
 import { NextResponse } from "next/server";
-import type { DegradedMode } from "@/lib/api/factory";
 import { getClientIpFromHeaders } from "@/lib/http/ip";
 import { createRateLimitHeaders as createStandardRateLimitHeaders } from "@/lib/ratelimit/headers";
 import { hashIdentifier } from "@/lib/ratelimit/identifier";
-import { getRedis } from "@/lib/redis";
+import { checkUpstashRateLimit, type DegradedMode } from "@/lib/ratelimit/upstash";
 import { emitOperationalAlertOncePerWindow } from "@/lib/telemetry/degraded-mode";
 import { warnRedisUnavailable } from "@/lib/telemetry/redis";
 import { sanitizePathnameForTelemetry } from "@/lib/telemetry/route-key";
@@ -87,15 +85,29 @@ export async function checkWebhookRateLimitWithPolicy(
 ): Promise<RateLimitResult> {
   const degradedMode = options.degradedMode ?? "fail_closed";
   const route = sanitizePathnameForTelemetry(new URL(req.url).pathname);
-  const redis = getRedis();
-  if (!redis) {
-    warnRedisUnavailable(REDIS_FEATURE);
+
+  const ip = getClientIp(req);
+  const identifier = ip === "unknown" ? "ip:unknown" : `ip:${hashIdentifier(ip)}`;
+  const result = await checkUpstashRateLimit({
+    analytics: true,
+    dynamicLimits: true,
+    ephemeralCache: false,
+    identifier,
+    limit: 100,
+    prefix: "webhook:rl",
+    window: "1 m",
+  });
+
+  if (result.status === "unavailable") {
+    if (result.reason === "redis_unavailable") {
+      warnRedisUnavailable(REDIS_FEATURE);
+    }
     if (degradedMode === "fail_open") {
       emitOperationalAlertOncePerWindow({
         attributes: {
           degradedMode: "fail_open",
           feature: REDIS_FEATURE,
-          reason: "redis_unavailable",
+          reason: result.reason,
           route,
         },
         event: "ratelimit.degraded",
@@ -103,36 +115,8 @@ export async function checkWebhookRateLimitWithPolicy(
       });
       return { reason: "limiter_unavailable", success: true };
     }
-    return { reason: "limiter_unavailable", success: false };
-  }
 
-  const rateLimiter = new Ratelimit({
-    analytics: true,
-    dynamicLimits: true,
-    limiter: Ratelimit.slidingWindow(100, "1 m"),
-    prefix: "webhook:rl",
-    redis,
-  });
-
-  const ip = getClientIp(req);
-  const identifier = ip === "unknown" ? "ip:unknown" : `ip:${hashIdentifier(ip)}`;
-  try {
-    const { success, reset, remaining, limit, reason } =
-      await rateLimiter.limit(identifier);
-    if (reason === "timeout") {
-      if (degradedMode === "fail_open") {
-        emitOperationalAlertOncePerWindow({
-          attributes: {
-            degradedMode: "fail_open",
-            feature: REDIS_FEATURE,
-            reason: "timeout",
-            route,
-          },
-          event: "ratelimit.degraded",
-          windowMs: 60_000,
-        });
-        return { reason: "limiter_unavailable", success: true };
-      }
+    if (result.reason === "timeout") {
       recordTelemetryEvent("webhook.rate_limit_timeout", {
         attributes: {
           feature: REDIS_FEATURE,
@@ -140,34 +124,35 @@ export async function checkWebhookRateLimitWithPolicy(
         },
         level: "error",
       });
-      return { reason: "limiter_unavailable", success: false };
-    }
-    if (!success) return { limit, reason: "rate_limited", remaining, reset, success };
-    return { limit, remaining, reset, success };
-  } catch (error) {
-    if (degradedMode === "fail_open") {
-      emitOperationalAlertOncePerWindow({
+    } else if (result.reason === "enforcement_error") {
+      recordTelemetryEvent("webhook.rate_limit_error", {
         attributes: {
-          degradedMode: "fail_open",
+          error: result.error instanceof Error ? result.error.message : "unknown_error",
           feature: REDIS_FEATURE,
-          reason: "enforcement_error",
           route,
         },
-        event: "ratelimit.degraded",
-        windowMs: 60_000,
+        level: "error",
       });
-      return { reason: "limiter_unavailable", success: true };
     }
-    recordTelemetryEvent("webhook.rate_limit_error", {
-      attributes: {
-        error: error instanceof Error ? error.message : "unknown_error",
-        feature: REDIS_FEATURE,
-        route,
-      },
-      level: "error",
-    });
     return { reason: "limiter_unavailable", success: false };
   }
+
+  if (result.status === "limited") {
+    return {
+      limit: result.result.limit,
+      reason: "rate_limited",
+      remaining: result.result.remaining,
+      reset: result.result.reset,
+      success: false,
+    };
+  }
+
+  return {
+    limit: result.result.limit,
+    remaining: result.result.remaining,
+    reset: result.result.reset,
+    success: true,
+  };
 }
 
 /**

--- a/src/lib/webhooks/rate-limit.ts
+++ b/src/lib/webhooks/rate-limit.ts
@@ -22,7 +22,7 @@ const REDIS_FEATURE = "webhooks.rate_limit";
 export interface RateLimitResult {
   /** Whether the request is allowed */
   success: boolean;
-  /** Why the check failed (only set when success === false) */
+  /** Why the check failed, or why fail-open degraded mode allowed the request */
   reason?: "limiter_unavailable" | "rate_limited";
   /** Unix timestamp (ms) when the rate limit window resets */
   reset?: number;

--- a/src/test/upstash/emulator.ts
+++ b/src/test/upstash/emulator.ts
@@ -2,8 +2,10 @@
  * @fileoverview Optional Upstash emulator helpers.
  *
  * Reads and validates Upstash emulator config from env vars. No-op unless
- * UPSTASH_USE_EMULATOR=1. When enabled, requires UPSTASH_EMULATOR_URL and
- * UPSTASH_QSTASH_DEV_URL to be set; throws if missing.
+ * UPSTASH_USE_EMULATOR=1. When enabled, prefer runtime Redis env
+ * (UPSTASH_REDIS_REST_URL) pointed at the emulator; UPSTASH_EMULATOR_URL is
+ * accepted as a legacy alias. QStash dev server still uses UPSTASH_QSTASH_DEV_URL
+ * because production QStash publishes through the managed service endpoint.
  */
 
 type EmulatorConfig = {
@@ -17,7 +19,7 @@ export function getEmulatorConfig(): EmulatorConfig {
   return {
     enabled,
     qstashUrl: process.env.UPSTASH_QSTASH_DEV_URL,
-    redisUrl: process.env.UPSTASH_EMULATOR_URL,
+    redisUrl: process.env.UPSTASH_REDIS_REST_URL ?? process.env.UPSTASH_EMULATOR_URL,
   };
 }
 
@@ -27,7 +29,7 @@ export function startUpstashEmulators(): EmulatorConfig {
 
   if (!config.redisUrl) {
     throw new Error(
-      "UPSTASH_USE_EMULATOR=1 but UPSTASH_EMULATOR_URL is not set; provide http://host:port"
+      "UPSTASH_USE_EMULATOR=1 but UPSTASH_REDIS_REST_URL is not set; provide the Redis REST emulator URL (UPSTASH_EMULATOR_URL is accepted as a legacy alias)"
     );
   }
 


### PR DESCRIPTION
Closes #737

## Summary
- centralize Upstash Ratelimit construction in `src/lib/ratelimit/upstash.ts` and route API, webhook, AI tool, and batch search checks through the shared primitive
- require deterministic QStash `deduplicationId` plus canonical `QSTASH_JOB_LABELS` labels at type and runtime, and add missing memory-sync dedup IDs
- make the trip collaborator webhook fail closed in production when QStash enqueue fails while preserving local/test-only fallback
- align Upstash emulator/smoke env names and update job, webhook, ADR, spec, and rate-limit docs

## Validation
- `pnpm biome:fix`
- `pnpm type-check`
- `pnpm exec vitest run src/lib/ratelimit/__tests__/upstash.test.ts src/lib/qstash/__tests__/client.test.ts src/lib/qstash/__tests__/receiver.test.ts src/lib/webhooks/__tests__/rate-limit.timeout.test.ts src/lib/webhooks/__tests__/rate-limit.test.ts src/app/api/hooks/trips/__tests__/route.test.ts src/app/api/hooks/files/__tests__/route.test.ts src/app/api/jobs/attachments-ingest/__tests__/route.test.ts src/lib/memory/__tests__/upstash-adapter.test.ts src/ai/lib/__tests__/tool-factory.test.ts src/ai/tools/server/__tests__/web-search-batch.test.ts`
- `pnpm test:upstash:unit`
- `pnpm test:upstash:int` (env-gated; skipped without emulator env)
- `pnpm test:upstash:smoke` (env-gated; skipped without live smoke env)
- `pnpm test:affected` (passed; emitted existing MSW handler lookup warning for OpenWeather test path)
- `pnpm check:zod-v4`
- `pnpm check:api-route-errors`
- `pnpm check:no-new-unknown-casts`
- `pnpm check:no-secrets:full`
- `pnpm build`

## Pre-PR review
- Security reviewer: no findings
- Runtime/correctness reviewer: no findings after focused checks
- Docs alignment reviewer: found stale webhook fallback docs and overstated label runtime validation; both fixed before PR

## Docs Impact
- Updated Upstash job/runbook docs, webhook route behavior, ADR-0041, ADR-0054, ADR-0067, rate-limit docs, testing docs, and SPEC-0107.

## Provider / Deploy Notes
- No new providers or packages.
- Upstash Redis/QStash/Ratelimit remain canonical for this release.
- Live smoke now uses runtime credential names plus `UPSTASH_QSTASH_SMOKE_TARGET_URL` as the disposable QStash publish destination.

## Screenshots
- Not applicable; backend/docs/test-only change.

## Residual Risks
- Live Upstash smoke and emulator integration tests are env-gated and skipped locally without credentials/emulator endpoints.