### PR TITLE
perf(jobs): instrument and bound attachment and RAG jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 * BYOK readiness now has an operator-only `/api/health/byok` probe backed by a service-role Vault health RPC that creates/decrypts/deletes a non-user probe secret, redacted `supabase.rpc.*` and provider-validation spans, and deployment smoke documentation for the planned `VAULT_UNAVAILABLE`, `INVALID_KEY`, `NETWORK_ERROR`, and `REQUEST_TIMEOUT` error-code contract.
 * BYOK metadata writes are now restricted to service-role RPC/API paths, password changes run through shared auth and rate-limit guards, public CSP has a stricter report-only staging policy, and secret scanning covers the expanded provider/env secret surface.
 
+### Performance
+
+* Attachment ingest and RAG indexing jobs now emit redacted duration/cost counters, enforce QStash payload and RAG chunk budgets, and map RAG budget failures to non-retryable DLQ responses.
+
 ## [1.32.5](https://github.com/BjornMelin/tripsage-ai/compare/v1.32.4...v1.32.5) (2026-05-11)
 
 ### Bug Fixes

--- a/docs/api/internal/jobs.md
+++ b/docs/api/internal/jobs.md
@@ -33,6 +33,7 @@ workflow-orchestration rewrite:
 | --- | ---: | --- |
 | Vercel function max duration | 60s | `vercel.json` |
 | QStash RAG delivery timeout | 55s | `RAG_INDEX_QSTASH_TIMEOUT_SECONDS` |
+| Embedding abort timeout | 50s | `RAG_INDEX_EMBED_TIMEOUT_BUDGET_MS` |
 | QStash RAG request body cap | 512 KiB | `MAX_RAG_INDEX_JOB_BODY_BYTES` |
 | QStash documented message-size ceiling | 1 MiB | Upstash QStash docs |
 | Attachment download cap | 10 MiB | `ATTACHMENT_MAX_FILE_SIZE` |
@@ -53,6 +54,13 @@ and durations only:
   upserted, indexed count, failed count, and namespace.
 - `rag.indexer.embedding_failed`: chunk count, document count, namespace, and
   provider error class name; never raw document content or provider payloads.
+
+The attachment-to-RAG QStash message body is a raw user-content processor
+boundary: it carries extracted document content and attachment metadata so the
+worker can index asynchronously, and retryable failures can leave that body in
+QStash retry/DLQ storage. Treat QStash credentials, DLQ access, and payload
+inspection as sensitive production data access. Telemetry must only record
+redacted aggregate counters and hashes, never the payload content or metadata.
 
 Open a separate Upstash Workflow pilot issue only if production telemetry shows
 one of these conditions for the attachment/RAG path:

--- a/docs/api/internal/jobs.md
+++ b/docs/api/internal/jobs.md
@@ -35,7 +35,7 @@ workflow-orchestration rewrite:
 | QStash RAG delivery timeout | 55s | `RAG_INDEX_QSTASH_TIMEOUT_SECONDS` |
 | Embedding abort timeout | 50s | `RAG_INDEX_EMBED_TIMEOUT_BUDGET_MS` |
 | QStash RAG request body cap | 512 KiB | `MAX_RAG_INDEX_JOB_BODY_BYTES` |
-| QStash documented message-size ceiling | 1 MiB | Upstash QStash docs |
+| QStash documented default message-size limit | 1 MiB | Upstash QStash docs |
 | Attachment download cap | 10 MiB | `ATTACHMENT_MAX_FILE_SIZE` |
 | Extracted text cap | 250,000 chars | `MAX_RAG_INDEX_TOTAL_CONTENT_CHARS` |
 | Documents per RAG job | 100 | `MAX_RAG_INDEX_DOCUMENTS` |
@@ -59,8 +59,10 @@ The attachment-to-RAG QStash message body is a raw user-content processor
 boundary: it carries extracted document content and attachment metadata so the
 worker can index asynchronously, and retryable failures can leave that body in
 QStash retry/DLQ storage. Treat QStash credentials, DLQ access, and payload
-inspection as sensitive production data access. Telemetry must only record
-redacted aggregate counters and hashes, never the payload content or metadata.
+inspection as sensitive production data access. The publisher must request
+provider-side request-body log redaction for this message. Telemetry must only
+record redacted aggregate counters and hashes, never the payload content or
+sensitive metadata such as filenames and storage paths.
 
 Open a separate Upstash Workflow pilot issue only if production telemetry shows
 one of these conditions for the attachment/RAG path:

--- a/docs/api/internal/jobs.md
+++ b/docs/api/internal/jobs.md
@@ -44,9 +44,14 @@ workflow-orchestration rewrite:
 Telemetry must stay redacted and low-cardinality. The job path records counts
 and durations only:
 
-- `jobs.attachments_ingest.completed|skipped|failed`: duration, file size,
-  MIME type, extracted char counts, estimated chunk count, serialized RAG
-  payload bytes, truncation, retry outcome, and skip/error code.
+- `jobs.attachments_ingest.completed`: duration, file size, MIME type,
+  extracted char counts, estimated chunk count, serialized RAG payload bytes,
+  truncation, retry outcome, and QStash deduplication result.
+- `jobs.attachments_ingest.skipped`: duration, file size, MIME type, skip
+  reason, and retry outcome.
+- `jobs.attachments_ingest.failed`: duration, file size, MIME type, extracted
+  char counts, estimated chunk count, serialized RAG payload bytes, error code,
+  and retry outcome.
 - `jobs.rag_index.completed|failed`: document count, chunk count, indexed and
   failed counts, namespace, and retry outcome.
 - `rag.indexer.index_complete`: duration, document/chunk counts, embedding

--- a/docs/api/internal/jobs.md
+++ b/docs/api/internal/jobs.md
@@ -24,6 +24,47 @@ Background job endpoints delivered by Upstash QStash.
 - **Production degradation**: job enqueue failures on production webhook paths
   must fail closed. Local/test-only in-process fallbacks must be explicitly gated.
 
+## Attachment and RAG budgets
+
+The attachment ingest to RAG index path is intentionally bounded before any
+workflow-orchestration rewrite:
+
+| Budget | Value | Owner |
+| --- | ---: | --- |
+| Vercel function max duration | 60s | `vercel.json` |
+| QStash RAG delivery timeout | 55s | `RAG_INDEX_QSTASH_TIMEOUT_SECONDS` |
+| QStash RAG request body cap | 512 KiB | `MAX_RAG_INDEX_JOB_BODY_BYTES` |
+| QStash documented message-size ceiling | 1 MiB | Upstash QStash docs |
+| Attachment download cap | 10 MiB | `ATTACHMENT_MAX_FILE_SIZE` |
+| Extracted text cap | 250,000 chars | `MAX_RAG_INDEX_TOTAL_CONTENT_CHARS` |
+| Documents per RAG job | 100 | `MAX_RAG_INDEX_DOCUMENTS` |
+| Chunks per embedding batch | 1,200 | `MAX_RAG_EMBED_CHUNKS_PER_BATCH` |
+
+Telemetry must stay redacted and low-cardinality. The job path records counts
+and durations only:
+
+- `jobs.attachments_ingest.completed|skipped|failed`: duration, file size,
+  MIME type, extracted char counts, estimated chunk count, serialized RAG
+  payload bytes, truncation, retry outcome, and skip/error code.
+- `jobs.rag_index.completed|failed`: document count, chunk count, indexed and
+  failed counts, namespace, and retry outcome.
+- `rag.indexer.index_complete`: duration, document/chunk counts, embedding
+  calls, embedding token usage, embedding warnings, DB upsert count, DB rows
+  upserted, indexed count, failed count, and namespace.
+- `rag.indexer.embedding_failed`: chunk count, document count, namespace, and
+  provider error class name; never raw document content or provider payloads.
+
+Open a separate Upstash Workflow pilot issue only if production telemetry shows
+one of these conditions for the attachment/RAG path:
+
+- sustained P95 job duration above 45s or recurring 60s function timeouts;
+- repeated QStash delivery timeout or retry/DLQ events for the same budget
+  class after input caps are enforced;
+- embedding calls or DB upserts require multi-step checkpointing that would
+  delete more custom state code than the workflow SDK adds;
+- operator cost traces show runaway embedding volume that cannot be solved with
+  tighter payload/chunk/batch limits.
+
 ## Job ownership and publish labels
 
 | Job | Owner | Worker | Publish label | Dedup key shape |
@@ -116,6 +157,10 @@ Persist conversation turns and update memory sync markers for a chat session.
 
 Ingest a single uploaded attachment: download from Supabase Storage, extract text, then enqueue a RAG indexing job.
 
+The worker caps extracted text at 250,000 characters, validates the serialized
+RAG job payload against the 512 KiB QStash body budget, estimates chunk fan-out
+before enqueueing, and sets a 55s QStash delivery timeout for `/api/jobs/rag-index`.
+
 ### Request body
 
 ```json
@@ -138,6 +183,10 @@ Ingest a single uploaded attachment: download from Supabase Storage, extract tex
 ## `POST /api/jobs/rag-index`
 
 Index documents into the RAG store (chunking + embeddings + storage).
+
+The worker rejects request bodies over 512 KiB before JSON parsing, validates
+chunk overlap is smaller than chunk size, maps RAG budget-limit failures to
+HTTP `489`, and records embedding/DB cost counters without content.
 
 ### Request body
 

--- a/docs/architecture/decisions/adr-0048-qstash-retries-and-idempotency.md
+++ b/docs/architecture/decisions/adr-0048-qstash-retries-and-idempotency.md
@@ -19,7 +19,7 @@
 - Handlers must be idempotent: wrap side-effecting operations in a per-business-key Upstash Redis reservation (default TTL 300s) before executing.  
 - Retry policy: max 6 attempts (1 initial + 5 retries), with an explicit retry delay expression via `Upstash-Retry-Delay` (configured by `src/lib/qstash/client.ts`).  
 - Dead Letter Queue (DLQ): Use QStash's native DLQ support. For non-retryable errors, return HTTP `489` and set `Upstash-NonRetryable-Error: true` so QStash forwards the message to the configured DLQ.  
-- Observability: emit OTEL span attributes `qstash.attempt`, `qstash.dedup_id_present`, optional `qstash.dedup_id_hash`, `qstash.dlq`, and structured log on final failure. Never export the raw deduplication id because job keys can include tenant, attachment, or event identifiers.
+- Observability: emit OTEL span attributes `qstash.attempt`, `qstash.dedup_id_present`, optional `qstash.dedup_id_hash`, and structured log on final failure. Never export the raw deduplication id because job keys can include tenant, attachment, or event identifiers.
 - Security:
   - Validate QStash signature on the raw request body; reject unverified requests before any side effects.
   - Enforce a hard request body size limit before verification/parsing (reject before JSON parsing). For QStash-delivered jobs, treat oversized payloads as non-retryable (`489` + header) to avoid retry loops.

--- a/docs/architecture/decisions/adr-0048-qstash-retries-and-idempotency.md
+++ b/docs/architecture/decisions/adr-0048-qstash-retries-and-idempotency.md
@@ -19,7 +19,7 @@
 - Handlers must be idempotent: wrap side-effecting operations in a per-business-key Upstash Redis reservation (default TTL 300s) before executing.  
 - Retry policy: max 6 attempts (1 initial + 5 retries), with an explicit retry delay expression via `Upstash-Retry-Delay` (configured by `src/lib/qstash/client.ts`).  
 - Dead Letter Queue (DLQ): Use QStash's native DLQ support. For non-retryable errors, return HTTP `489` and set `Upstash-NonRetryable-Error: true` so QStash forwards the message to the configured DLQ.  
-- Observability: emit OTEL span attributes `qstash.attempt`, `qstash.dedup_id`, `qstash.dlq` and structured log on final failure.  
+- Observability: emit OTEL span attributes `qstash.attempt`, `qstash.dedup_id_present`, optional `qstash.dedup_id_hash`, `qstash.dlq`, and structured log on final failure. Never export the raw deduplication id because job keys can include tenant, attachment, or event identifiers.
 - Security:
   - Validate QStash signature on the raw request body; reject unverified requests before any side effects.
   - Enforce a hard request body size limit before verification/parsing (reject before JSON parsing). For QStash-delivered jobs, treat oversized payloads as non-retryable (`489` + header) to avoid retry loops.

--- a/docs/architecture/decisions/adr-0067-upstash-redis-qstash-rate-limit-and-jobs.md
+++ b/docs/architecture/decisions/adr-0067-upstash-redis-qstash-rate-limit-and-jobs.md
@@ -1,6 +1,6 @@
 # ADR-0067: Upstash Redis + QStash for caching, rate limits, and background jobs
 
-**Version**: 1.1.0
+**Version**: 1.2.0
 **Status**: Accepted  
 **Date**: 2026-01-05  
 **Category**: backend + ops  
@@ -40,6 +40,21 @@ TripSage needs:
   - canonical `label` from `QSTASH_JOB_LABELS`
   - explicit retry count and retry delay expression
   - optional flow control and failure callback where the job owner needs them
+- Keep the expensive attachment ingest and RAG index path bounded before any
+  workflow SDK rewrite:
+  - `vercel.json` caps API route execution at 60 seconds.
+  - RAG QStash delivery timeout is 55 seconds.
+  - RAG QStash request bodies are capped at 512 KiB, below the documented 1 MiB
+    QStash message-size ceiling.
+  - Attachment downloads are capped at 10 MiB.
+  - Extracted text/RAG content is capped at 250,000 characters.
+  - RAG jobs accept at most 100 documents and 1,200 embedding chunks per batch.
+  - RAG chunk overlap must be smaller than chunk size.
+- Record redacted job telemetry for duration, estimated chunk count, document
+  count, embedding calls/tokens/warnings, DB upsert count/rows, provider failure
+  class, retry outcome, and QStash payload bytes. Never record raw attachment
+  filenames, storage paths, extracted text, document content, embedding values,
+  provider payloads, or user/trip/chat identifiers.
 
 ## Decision Matrix
 
@@ -54,6 +69,21 @@ The hardened-current-stack option wins because it preserves the serverless
 provider fit while deleting duplicate rate-limit construction and tightening
 publish contracts. Workflow products stay viable future options, but they are
 not a net simplification for the current job graph.
+
+## Workflow pilot thresholds
+
+Do not add `@upstash/workflow`, Vercel Workflow, or Vercel Queues for the
+attachment/RAG path until telemetry from the bounded QStash implementation shows
+one or more of:
+
+- sustained P95 job duration above 45 seconds or recurring 60-second Vercel
+  function timeouts;
+- repeated QStash delivery timeouts, retries, or DLQ entries after the payload
+  and chunk budgets are enforced;
+- multi-step checkpoint/state code that a workflow SDK would delete more than it
+  adds;
+- embedding or retry volume that remains cost-excessive after tightening
+  content, chunk, and batch limits.
 
 ## Consequences
 
@@ -72,6 +102,9 @@ Upstash QStash local development: https://upstash.com/docs/qstash/howto/local-de
 QStash retry behavior: https://upstash.com/docs/qstash/features/retry
 QStash deduplication: https://upstash.com/docs/qstash/features/deduplication
 QStash flow control: https://upstash.com/docs/qstash/features/flowcontrol
+QStash message size and timeout: https://upstash.com/docs/qstash
+Vercel Functions duration: https://vercel.com/docs/functions/configuring-functions/duration
+Vercel AI SDK embedMany: https://ai-sdk.dev/docs/reference/ai-sdk-core/embed-many
 QStash DLQ operations: https://upstash.com/docs/qstash/api-reference/dlq/bulk-retry-dlq-messages
 NPM @upstash/ratelimit: https://www.npmjs.com/package/@upstash/ratelimit
 NPM @upstash/redis: https://www.npmjs.com/package/@upstash/redis

--- a/docs/architecture/decisions/adr-0067-upstash-redis-qstash-rate-limit-and-jobs.md
+++ b/docs/architecture/decisions/adr-0067-upstash-redis-qstash-rate-limit-and-jobs.md
@@ -44,6 +44,8 @@ TripSage needs:
   workflow SDK rewrite:
   - `vercel.json` caps API route execution at 60 seconds.
   - RAG QStash delivery timeout is 55 seconds.
+  - RAG embedding abort timeout is 50 seconds so workers can finish cleanup
+    before QStash gives up on delivery.
   - RAG QStash request bodies are capped at 512 KiB, below the documented 1 MiB
     QStash message-size ceiling.
   - Attachment downloads are capped at 10 MiB.
@@ -55,6 +57,11 @@ TripSage needs:
   class, retry outcome, and QStash payload bytes. Never record raw attachment
   filenames, storage paths, extracted text, document content, embedding values,
   provider payloads, or user/trip/chat identifiers.
+- Treat attachment-to-RAG QStash message bodies as a raw user-content processor
+  boundary. They carry extracted document content and attachment metadata for
+  asynchronous indexing, and retryable failures can leave those bodies in
+  QStash retry/DLQ storage. Operator access to QStash payloads/DLQs is sensitive
+  production data access; telemetry must remain aggregate and redacted.
 
 ## Decision Matrix
 

--- a/docs/architecture/decisions/adr-0067-upstash-redis-qstash-rate-limit-and-jobs.md
+++ b/docs/architecture/decisions/adr-0067-upstash-redis-qstash-rate-limit-and-jobs.md
@@ -47,7 +47,7 @@ TripSage needs:
   - RAG embedding abort timeout is 50 seconds so workers can finish cleanup
     before QStash gives up on delivery.
   - RAG QStash request bodies are capped at 512 KiB, below the documented 1 MiB
-    QStash message-size ceiling.
+    default QStash message-size limit.
   - Attachment downloads are capped at 10 MiB.
   - Extracted text/RAG content is capped at 250,000 characters.
   - RAG jobs accept at most 100 documents and 1,200 embedding chunks per batch.
@@ -60,8 +60,9 @@ TripSage needs:
 - Treat attachment-to-RAG QStash message bodies as a raw user-content processor
   boundary. They carry extracted document content and attachment metadata for
   asynchronous indexing, and retryable failures can leave those bodies in
-  QStash retry/DLQ storage. Operator access to QStash payloads/DLQs is sensitive
-  production data access; telemetry must remain aggregate and redacted.
+  QStash retry/DLQ storage. The publisher requests provider-side request-body
+  log redaction for this path. Operator access to QStash payloads/DLQs is
+  sensitive production data access; telemetry must remain aggregate and redacted.
 
 ## Decision Matrix
 

--- a/docs/development/backend/observability.md
+++ b/docs/development/backend/observability.md
@@ -161,6 +161,23 @@ QStash helpers emit spans for enqueue operations:
 Job routes (e.g. `jobs.*` spans) should record `qstash.message_id` and `qstash.attempt`
 (derived from `Upstash-Retried`) for correlation with the Upstash Console.
 
+Attachment/RAG jobs add cost and duration signals without content:
+
+| Event | Purpose |
+| :--- | :--- |
+| `jobs.attachments_ingest.completed` | Attachment extraction duration, truncation, estimated chunk count, RAG payload bytes, and QStash dedupe status |
+| `jobs.attachments_ingest.skipped` | Unsupported/empty attachment outcomes that should not retry |
+| `jobs.attachments_ingest.failed` | Retryable vs non-retryable attachment ingest failures with safe error codes |
+| `jobs.rag_index.completed` | RAG job document/chunk/index counts and retry outcome |
+| `jobs.rag_index.failed` | Retryable vs non-retryable RAG job failure counts |
+| `rag.indexer.index_complete` | Embedding calls, embedding token usage, embedding warnings, DB upserts, DB rows, and duration |
+| `rag.indexer.embedding_failed` | Provider failure class name plus document/chunk counts |
+
+Do not record raw attachment filenames, storage paths, extracted text, document
+content, embedding values, provider payloads, or user/trip/chat identifiers in
+these job telemetry events. Use counts, booleans, namespaces, MIME types, and
+low-cardinality error codes.
+
 #### DLQ visibility (Upstash native)
 
 When a job is non-retryable and should be forwarded to the DLQ, return HTTP `489`

--- a/docs/development/backend/observability.md
+++ b/docs/development/backend/observability.md
@@ -160,6 +160,10 @@ QStash helpers emit spans for enqueue operations:
 
 Job routes (e.g. `jobs.*` spans) should record `qstash.message_id` and `qstash.attempt`
 (derived from `Upstash-Retried`) for correlation with the Upstash Console.
+Publish spans record whether a deduplication id was present and, when
+`TELEMETRY_HASH_SECRET` is configured, `qstash.dedup_id_hash`; they must not
+export the raw deduplication id because job dedup keys can include tenant,
+attachment, or event identifiers.
 
 Attachment/RAG jobs add cost and duration signals without content:
 

--- a/docs/specs/active/0104-spec-memory-and-rag.md
+++ b/docs/specs/active/0104-spec-memory-and-rag.md
@@ -50,6 +50,10 @@ Requests and responses:
 - `/api/rag/index`
   - Body: `ragIndexRequestSchema`
     - `maxParallelCalls` (optional, default `2`): bounds `embedMany()` concurrency during indexing.
+    - `chunkOverlap` must be smaller than `chunkSize`; this invariant applies to
+      the public API and the QStash RAG job schema.
+    - Request size is bounded by the shared RAG limits: at most 100 documents
+      and 250,000 total content characters per request.
   - Response: `ragIndexResponseSchema` (HTTP 200; partial success via `success: false` and per-item failures)
 - `/api/rag/search`
   - Body: `ragSearchRequestSchema`

--- a/docs/specs/active/0107-spec-jobs-and-webhooks.md
+++ b/docs/specs/active/0107-spec-jobs-and-webhooks.md
@@ -48,6 +48,34 @@ Jobs (QStash workers):
   - `event.key` (dedup key), `table`, `op`
   - `qstash.message_id`, `qstash.attempt` (derived from `Upstash-Retried`)
 - Prefer server log events with consistent keys (e.g., `job_type`, `event_key`) rather than free-form strings.
+- High-cost jobs must also record redacted cost counters and duration signals:
+  - attachment ingest: duration, file size, MIME type, extracted char counts,
+    estimated RAG chunks, serialized RAG payload bytes, skip/error code, and
+    retry outcome;
+  - RAG index: duration, document count, chunk count, embedding call count,
+    embedding token usage, DB upsert count, DB rows upserted, provider failure
+    class, failed count, and retry outcome.
+- Never record raw attachment filenames, storage paths, document content,
+  extracted text, embedding values, or provider payloads in job telemetry.
+
+## Attachment and RAG budget contract
+
+- Vercel function cap: `vercel.json` sets `src/app/api/**/route.*` to 60s.
+- QStash RAG delivery timeout: 55s.
+- QStash RAG request body cap: 512 KiB, below the documented 1 MiB QStash
+  message-size ceiling.
+- Attachment download cap: 10 MiB.
+- Extracted text and RAG total content cap: 250,000 chars.
+- Documents per RAG job: 100.
+- Chunks per embedding batch: 1,200.
+- `chunkOverlap` must be smaller than `chunkSize`.
+- RAG budget violations are non-retryable and must return HTTP `489` with
+  `Upstash-NonRetryable-Error: true`.
+
+Open a follow-up Upstash Workflow pilot only after production telemetry shows
+sustained P95 duration above 45s, repeated QStash delivery timeouts/DLQ events,
+or enough custom checkpoint/state code that a workflow SDK would delete more
+code than it adds.
 
 ## Error handling and retries
 

--- a/docs/specs/active/0107-spec-jobs-and-webhooks.md
+++ b/docs/specs/active/0107-spec-jobs-and-webhooks.md
@@ -76,8 +76,9 @@ Jobs (QStash workers):
   `Upstash-NonRetryable-Error: true`.
 - Attachment-to-RAG QStash message bodies currently carry extracted document
   content and attachment metadata; treat QStash retry/DLQ access as sensitive
-  production data access and keep telemetry redacted to counts, booleans,
-  namespaces, low-cardinality codes, and hashes.
+  production data access, request provider-side body log redaction on publish,
+  and keep telemetry redacted to counts, booleans, namespaces, low-cardinality
+  codes, and hashes.
 
 Open a follow-up Upstash Workflow pilot only after production telemetry shows
 sustained P95 duration above 45s, repeated QStash delivery timeouts/DLQ events,

--- a/docs/specs/active/0107-spec-jobs-and-webhooks.md
+++ b/docs/specs/active/0107-spec-jobs-and-webhooks.md
@@ -52,9 +52,11 @@ Jobs (QStash workers):
   - attachment ingest: duration, file size, MIME type, extracted char counts,
     estimated RAG chunks, serialized RAG payload bytes, skip/error code, and
     retry outcome;
-  - RAG index: duration, document count, chunk count, embedding call count,
-    embedding token usage, DB upsert count, DB rows upserted, provider failure
-    class, failed count, and retry outcome.
+  - RAG job route: document count, chunk count, indexed/failed counts,
+    namespace, and retry outcome;
+  - RAG indexer: duration, document/chunk counts, embedding call count,
+    embedding token usage, embedding warnings, DB upsert count, DB rows
+    upserted, provider failure class, failed count, and namespace.
 - Never record raw attachment filenames, storage paths, document content,
   extracted text, embedding values, or provider payloads in job telemetry.
 
@@ -62,6 +64,7 @@ Jobs (QStash workers):
 
 - Vercel function cap: `vercel.json` sets `src/app/api/**/route.*` to 60s.
 - QStash RAG delivery timeout: 55s.
+- Embedding abort timeout: 50s, capped below QStash delivery timeout.
 - QStash RAG request body cap: 512 KiB, below the documented 1 MiB QStash
   message-size ceiling.
 - Attachment download cap: 10 MiB.
@@ -71,6 +74,10 @@ Jobs (QStash workers):
 - `chunkOverlap` must be smaller than `chunkSize`.
 - RAG budget violations are non-retryable and must return HTTP `489` with
   `Upstash-NonRetryable-Error: true`.
+- Attachment-to-RAG QStash message bodies currently carry extracted document
+  content and attachment metadata; treat QStash retry/DLQ access as sensitive
+  production data access and keep telemetry redacted to counts, booleans,
+  namespaces, low-cardinality codes, and hashes.
 
 Open a follow-up Upstash Workflow pilot only after production telemetry shows
 sustained P95 duration above 45s, repeated QStash delivery timeouts/DLQ events,

--- a/src/app/api/jobs/attachments-ingest/__tests__/route.test.ts
+++ b/src/app/api/jobs/attachments-ingest/__tests__/route.test.ts
@@ -1,6 +1,7 @@
 /** @vitest-environment node */
 
 import { ATTACHMENT_MAX_FILE_SIZE } from "@schemas/attachments";
+import { RAG_INDEX_QSTASH_TIMEOUT_SECONDS } from "@schemas/rag";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { QSTASH_JOB_LABELS } from "@/lib/qstash/config";
 import { setupUpstashTestEnvironment } from "@/test/upstash/setup";
@@ -15,7 +16,7 @@ type TryEnqueueJob = (
   jobType: string,
   payload: unknown,
   path: string,
-  options?: { deduplicationId?: string; label?: string }
+  options?: { deduplicationId?: string; label?: string; timeout?: number }
 ) => Promise<
   { success: true; messageId: string } | { success: false; error: Error | null }
 >;
@@ -46,7 +47,7 @@ vi.mock("@/lib/qstash/client", () => ({
     jobType: string,
     payload: unknown,
     path: string,
-    options?: { deduplicationId?: string; label?: string }
+    options?: { deduplicationId?: string; label?: string; timeout?: number }
   ) => tryEnqueueJobMock(jobType, payload, path, options),
 }));
 
@@ -157,6 +158,7 @@ describe("POST /api/jobs/attachments-ingest", () => {
       {
         deduplicationId: "rag-index:attachment:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
         label: QSTASH_JOB_LABELS.RAG_INDEX,
+        timeout: RAG_INDEX_QSTASH_TIMEOUT_SECONDS,
       }
     );
   });
@@ -342,8 +344,42 @@ describe("POST /api/jobs/attachments-ingest", () => {
       {
         deduplicationId: "rag-index:attachment:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
         label: QSTASH_JOB_LABELS.RAG_INDEX,
+        timeout: RAG_INDEX_QSTASH_TIMEOUT_SECONDS,
       }
     );
+  });
+
+  it("returns 489 when the generated RAG job payload exceeds the QStash budget", async () => {
+    createAdminSupabaseMock.mockReturnValue(
+      createSupabaseStub({
+        attachment: {
+          bucket_name: "attachments",
+          chat_id: "123e4567-e89b-12d3-a456-426614174000",
+          file_path: "u/c/a/file.txt",
+          file_size: 1024,
+          id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          mime_type: "text/plain",
+          original_filename: `${"x".repeat(400_000)}.txt`,
+          trip_id: null,
+          upload_status: "completed",
+          user_id: "11111111-1111-4111-8111-111111111111",
+          virus_scan_status: "clean",
+        },
+        downloadBlob: new Blob(["x".repeat(300_000)]),
+      })
+    );
+
+    const { POST } = await loadRoute();
+
+    const res = await POST(
+      makeRequest({ attachmentId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(489);
+    expect(res.headers.get("Upstash-NonRetryable-Error")).toBe("true");
+    expect(json.error).toBe("rag_payload_too_large");
+    expect(tryEnqueueJobMock).not.toHaveBeenCalled();
   });
 
   afterAll(() => {

--- a/src/app/api/jobs/attachments-ingest/__tests__/route.test.ts
+++ b/src/app/api/jobs/attachments-ingest/__tests__/route.test.ts
@@ -16,7 +16,12 @@ type TryEnqueueJob = (
   jobType: string,
   payload: unknown,
   path: string,
-  options?: { deduplicationId?: string; label?: string; timeout?: number }
+  options?: {
+    deduplicationId?: string;
+    label?: string;
+    redact?: { body?: true };
+    timeout?: number;
+  }
 ) => Promise<
   { success: true; messageId: string } | { success: false; error: Error | null }
 >;
@@ -48,7 +53,12 @@ vi.mock("@/lib/qstash/client", () => ({
     jobType: string,
     payload: unknown,
     path: string,
-    options?: { deduplicationId?: string; label?: string; timeout?: number }
+    options?: {
+      deduplicationId?: string;
+      label?: string;
+      redact?: { body?: true };
+      timeout?: number;
+    }
   ) => tryEnqueueJobMock(jobType, payload, path, options),
 }));
 
@@ -160,6 +170,7 @@ describe("POST /api/jobs/attachments-ingest", () => {
       {
         deduplicationId: "rag-index:attachment:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
         label: QSTASH_JOB_LABELS.RAG_INDEX,
+        redact: { body: true },
         timeout: RAG_INDEX_QSTASH_TIMEOUT_SECONDS,
       }
     );
@@ -358,6 +369,7 @@ describe("POST /api/jobs/attachments-ingest", () => {
       {
         deduplicationId: "rag-index:attachment:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
         label: QSTASH_JOB_LABELS.RAG_INDEX,
+        redact: { body: true },
         timeout: RAG_INDEX_QSTASH_TIMEOUT_SECONDS,
       }
     );

--- a/src/app/api/jobs/attachments-ingest/__tests__/route.test.ts
+++ b/src/app/api/jobs/attachments-ingest/__tests__/route.test.ts
@@ -30,6 +30,7 @@ const envStore = vi.hoisted<Record<string, string | undefined>>(() => ({
 
 const tryEnqueueJobMock = vi.hoisted(() => vi.fn<TryEnqueueJob>());
 const createAdminSupabaseMock = vi.hoisted(() => vi.fn());
+const recordTelemetryEventMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/env/server", () => ({
   getServerEnvVar: (key: string) => {
@@ -56,7 +57,7 @@ vi.mock("@/lib/supabase/admin", () => ({
 }));
 
 vi.mock("@/lib/telemetry/span", () => ({
-  recordTelemetryEvent: vi.fn(),
+  recordTelemetryEvent: (...args: unknown[]) => recordTelemetryEventMock(...args),
   sanitizeAttributes: vi.fn((attrs) => attrs),
   withTelemetrySpan: vi.fn(
     (_name: string, _opts: unknown, fn: (span: unknown) => unknown) =>
@@ -106,6 +107,7 @@ describe("POST /api/jobs/attachments-ingest", () => {
     tryEnqueueJobMock.mockReset();
     tryEnqueueJobMock.mockResolvedValue({ messageId: "rag-1", success: true });
     createAdminSupabaseMock.mockReset();
+    recordTelemetryEventMock.mockReset();
     upstashMocks.qstash.__forceVerify(true);
 
     createAdminSupabaseMock.mockReturnValue(
@@ -160,6 +162,18 @@ describe("POST /api/jobs/attachments-ingest", () => {
         label: QSTASH_JOB_LABELS.RAG_INDEX,
         timeout: RAG_INDEX_QSTASH_TIMEOUT_SECONDS,
       }
+    );
+    expect(recordTelemetryEventMock).toHaveBeenCalledWith(
+      "jobs.attachments_ingest.completed",
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          estimatedChunks: expect.any(Number),
+          fileSizeBytes: 1024,
+          mimeType: "text/plain",
+          ragPayloadBytes: expect.any(Number),
+          retryOutcome: "not_applicable",
+        }),
+      })
     );
   });
 
@@ -380,6 +394,16 @@ describe("POST /api/jobs/attachments-ingest", () => {
     expect(res.headers.get("Upstash-NonRetryable-Error")).toBe("true");
     expect(json.error).toBe("rag_payload_too_large");
     expect(tryEnqueueJobMock).not.toHaveBeenCalled();
+    expect(recordTelemetryEventMock).toHaveBeenCalledWith(
+      "jobs.attachments_ingest.failed",
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          errorCode: "rag_payload_too_large",
+          retryOutcome: "non_retryable",
+        }),
+        level: "error",
+      })
+    );
   });
 
   afterAll(() => {

--- a/src/app/api/jobs/attachments-ingest/_handler.ts
+++ b/src/app/api/jobs/attachments-ingest/_handler.ts
@@ -5,18 +5,26 @@
 import "server-only";
 
 import { ATTACHMENT_MAX_FILE_SIZE } from "@schemas/attachments";
+import {
+  MAX_RAG_EMBED_CHUNKS_PER_BATCH,
+  MAX_RAG_INDEX_JOB_BODY_BYTES,
+  MAX_RAG_INDEX_TOTAL_CONTENT_CHARS,
+  RAG_CHARS_PER_TOKEN,
+  RAG_INDEX_QSTASH_TIMEOUT_SECONDS,
+} from "@schemas/rag";
 import type { AttachmentsIngestJob, RagIndexJob } from "@schemas/webhooks";
 import type { EnqueueJobOptions } from "@/lib/qstash/client";
 import { QSTASH_JOB_LABELS } from "@/lib/qstash/config";
 import type { TypedAdminSupabase } from "@/lib/supabase/admin";
 import { getMaybeSingle } from "@/lib/supabase/typed-helpers";
 import { createServerLogger } from "@/lib/telemetry/logger";
+import { recordTelemetryEvent } from "@/lib/telemetry/span";
 
 const logger = createServerLogger("jobs.attachments-ingest");
 const STORAGE_BUCKET = "attachments";
 
 // Keep job payloads bounded and avoid runaway embedding costs.
-const MAX_EXTRACTED_TEXT_CHARS = 250_000;
+const MAX_EXTRACTED_TEXT_CHARS = MAX_RAG_INDEX_TOTAL_CONTENT_CHARS;
 const MAX_PDF_PAGES = 50;
 
 export interface AttachmentsIngestDeps {
@@ -40,6 +48,40 @@ export class NonRetryableJobError extends Error {
     this.errorCode = errorCode;
     this.name = "NonRetryableJobError";
   }
+}
+
+function roundDurationMs(durationMs: number): number {
+  return Math.round(durationMs * 100) / 100;
+}
+
+function estimateRagChunkCount(params: {
+  chunkOverlap: number;
+  chunkSize: number;
+  contentChars: number;
+}): number {
+  const estimatedChunkChars = Math.max(
+    1,
+    (params.chunkSize - params.chunkOverlap) * RAG_CHARS_PER_TOKEN
+  );
+  return Math.ceil(params.contentChars / estimatedChunkChars);
+}
+
+function getJsonByteLength(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), "utf8");
+}
+
+function recordAttachmentIngestEvent(
+  eventName: string,
+  startedAt: number,
+  attributes: Record<string, boolean | number | string>
+): void {
+  recordTelemetryEvent(eventName, {
+    attributes: {
+      ...attributes,
+      durationMs: roundDurationMs(performance.now() - startedAt),
+    },
+    level: eventName.endsWith(".failed") ? "error" : "info",
+  });
 }
 
 function normalizeExtractedText(text: string): string {
@@ -116,12 +158,17 @@ async function extractTextFromBuffer(params: {
     }
 
     case "application/msword": {
-      logger.info("unsupported_doc_format", { originalFilename });
+      logger.info("unsupported_doc_format", {
+        hasOriginalFilename: Boolean(originalFilename),
+      });
       return { ok: false, reason: "unsupported_mime" };
     }
 
     default: {
-      logger.info("unsupported_mime_type", { mimeType, originalFilename });
+      logger.info("unsupported_mime_type", {
+        hasOriginalFilename: Boolean(originalFilename),
+        mimeType,
+      });
       return { ok: false, reason: "unsupported_mime" };
     }
   }
@@ -148,142 +195,220 @@ export async function handleAttachmentsIngest(
     }
 > {
   const { supabase } = deps;
+  const startedAt = performance.now();
+  let fileSizeBytes = 0;
+  let mimeType = "unknown";
+  let extractedCharsOriginal = 0;
+  let extractedCharsUsed = 0;
+  let estimatedChunks = 0;
+  let ragPayloadBytes = 0;
 
-  const { data: attachment, error } = await getMaybeSingle(
-    supabase,
-    "file_attachments",
-    (qb) => qb.eq("id", job.attachmentId),
-    {
-      select:
-        "id,bucket_name,file_path,file_size,mime_type,original_filename,upload_status,virus_scan_status,user_id,trip_id,chat_id",
-      validate: false,
-    }
-  );
-
-  if (error) {
-    const message =
-      error instanceof Error
-        ? error.message
-        : error && typeof error === "object" && "message" in error
-          ? String((error as { message?: unknown }).message ?? error)
-          : String(error);
-    throw new Error(`db_error:${message}`);
-  }
-
-  if (!attachment) {
-    throw new NonRetryableJobError("not_found", "Attachment does not exist");
-  }
-
-  if (attachment.upload_status !== "completed") {
-    throw new Error("upload_not_completed");
-  }
-
-  if (attachment.virus_scan_status === "infected") {
-    throw new NonRetryableJobError(
-      "virus_infected",
-      "Attachment is flagged as infected"
-    );
-  }
-
-  if (attachment.bucket_name !== STORAGE_BUCKET) {
-    throw new NonRetryableJobError(
-      "invalid_bucket",
-      `Unexpected attachment bucket: ${attachment.bucket_name}`
-    );
-  }
-
-  if (attachment.file_size > ATTACHMENT_MAX_FILE_SIZE) {
-    throw new NonRetryableJobError(
-      "file_too_large",
-      "Attachment exceeds supported size"
-    );
-  }
-
-  const buffer = await downloadStorageObjectToBuffer({
-    bucket: attachment.bucket_name,
-    maxBytes: ATTACHMENT_MAX_FILE_SIZE,
-    path: attachment.file_path,
-    supabase,
-  });
-
-  const extracted = await extractTextFromBuffer({
-    buffer,
-    mimeType: attachment.mime_type,
-    originalFilename: attachment.original_filename,
-  });
-
-  if (!extracted.ok) {
-    return {
-      ok: true,
-      queued: false,
-      skipped: true,
-      skipReason: extracted.reason,
-    };
-  }
-
-  const normalized = normalizeExtractedText(extracted.text);
-  if (normalized.length === 0) {
-    return {
-      ok: true,
-      queued: false,
-      skipped: true,
-      skipReason: "empty_text",
-    };
-  }
-
-  const extractedCharsOriginal = normalized.length;
-  let text = normalized;
-  let truncated = false;
-  if (text.length > MAX_EXTRACTED_TEXT_CHARS) {
-    truncated = true;
-    text = text.slice(0, MAX_EXTRACTED_TEXT_CHARS);
-    logger.warn("extracted_text_truncated", {
-      attachmentId: job.attachmentId,
-      extractedCharsOriginal,
-      extractedCharsUsed: text.length,
-    });
-  }
-
-  const ragJob: RagIndexJob = {
-    chatId: attachment.chat_id ?? null,
-    chunkOverlap: 100,
-    chunkSize: 512,
-    documents: [
+  try {
+    const { data: attachment, error } = await getMaybeSingle(
+      supabase,
+      "file_attachments",
+      (qb) => qb.eq("id", job.attachmentId),
       {
-        content: text,
-        id: job.attachmentId,
-        metadata: {
-          attachmentId: job.attachmentId,
-          extractedCharsOriginal,
-          extractedCharsUsed: text.length,
-          filePath: attachment.file_path,
-          mimeType: attachment.mime_type,
-          originalFilename: attachment.original_filename,
-          truncated,
+        select:
+          "id,bucket_name,file_path,file_size,mime_type,original_filename,upload_status,virus_scan_status,user_id,trip_id,chat_id",
+        validate: false,
+      }
+    );
+
+    if (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : error && typeof error === "object" && "message" in error
+            ? String((error as { message?: unknown }).message ?? error)
+            : String(error);
+      throw new Error(`db_error:${message}`);
+    }
+
+    if (!attachment) {
+      throw new NonRetryableJobError("not_found", "Attachment does not exist");
+    }
+
+    fileSizeBytes = attachment.file_size;
+    mimeType = attachment.mime_type;
+
+    if (attachment.upload_status !== "completed") {
+      throw new Error("upload_not_completed");
+    }
+
+    if (attachment.virus_scan_status === "infected") {
+      throw new NonRetryableJobError(
+        "virus_infected",
+        "Attachment is flagged as infected"
+      );
+    }
+
+    if (attachment.bucket_name !== STORAGE_BUCKET) {
+      throw new NonRetryableJobError(
+        "invalid_bucket",
+        `Unexpected attachment bucket: ${attachment.bucket_name}`
+      );
+    }
+
+    if (attachment.file_size > ATTACHMENT_MAX_FILE_SIZE) {
+      throw new NonRetryableJobError(
+        "file_too_large",
+        "Attachment exceeds supported size"
+      );
+    }
+
+    const buffer = await downloadStorageObjectToBuffer({
+      bucket: attachment.bucket_name,
+      maxBytes: ATTACHMENT_MAX_FILE_SIZE,
+      path: attachment.file_path,
+      supabase,
+    });
+
+    const extracted = await extractTextFromBuffer({
+      buffer,
+      mimeType: attachment.mime_type,
+      originalFilename: attachment.original_filename,
+    });
+
+    if (!extracted.ok) {
+      recordAttachmentIngestEvent("jobs.attachments_ingest.skipped", startedAt, {
+        fileSizeBytes,
+        mimeType,
+        retryOutcome: "not_applicable",
+        skipReason: extracted.reason,
+      });
+      return {
+        ok: true,
+        queued: false,
+        skipped: true,
+        skipReason: extracted.reason,
+      };
+    }
+
+    const normalized = normalizeExtractedText(extracted.text);
+    if (normalized.length === 0) {
+      recordAttachmentIngestEvent("jobs.attachments_ingest.skipped", startedAt, {
+        fileSizeBytes,
+        mimeType,
+        retryOutcome: "not_applicable",
+        skipReason: "empty_text",
+      });
+      return {
+        ok: true,
+        queued: false,
+        skipped: true,
+        skipReason: "empty_text",
+      };
+    }
+
+    extractedCharsOriginal = normalized.length;
+    let text = normalized;
+    let truncated = false;
+    if (text.length > MAX_EXTRACTED_TEXT_CHARS) {
+      truncated = true;
+      text = text.slice(0, MAX_EXTRACTED_TEXT_CHARS);
+      logger.warn("extracted_text_truncated", {
+        extractedCharsOriginal,
+        extractedCharsUsed: text.length,
+        hasAttachmentId: true,
+      });
+    }
+    extractedCharsUsed = text.length;
+
+    const chunkSize = 512;
+    const chunkOverlap = 100;
+    estimatedChunks = estimateRagChunkCount({
+      chunkOverlap,
+      chunkSize,
+      contentChars: text.length,
+    });
+    if (estimatedChunks > MAX_RAG_EMBED_CHUNKS_PER_BATCH) {
+      throw new NonRetryableJobError(
+        "rag_chunk_budget_exceeded",
+        "Attachment text would exceed the RAG chunk budget"
+      );
+    }
+
+    const ragJob: RagIndexJob = {
+      chatId: attachment.chat_id ?? null,
+      chunkOverlap,
+      chunkSize,
+      documents: [
+        {
+          content: text,
+          id: job.attachmentId,
+          metadata: {
+            attachmentId: job.attachmentId,
+            extractedCharsOriginal,
+            extractedCharsUsed: text.length,
+            filePath: attachment.file_path,
+            mimeType: attachment.mime_type,
+            originalFilename: attachment.original_filename,
+            truncated,
+          },
+          sourceId: job.attachmentId,
         },
-        sourceId: job.attachmentId,
-      },
-    ],
-    namespace: "user_content",
-    tripId: attachment.trip_id ?? null,
-    userId: attachment.user_id,
-  };
+      ],
+      namespace: "user_content",
+      tripId: attachment.trip_id ?? null,
+      userId: attachment.user_id,
+    };
 
-  const enqueue = await deps.tryEnqueueJob("rag-index", ragJob, "/api/jobs/rag-index", {
-    deduplicationId: `rag-index:attachment:${job.attachmentId}`,
-    label: QSTASH_JOB_LABELS.RAG_INDEX,
-  });
+    ragPayloadBytes = getJsonByteLength(ragJob);
+    if (ragPayloadBytes > MAX_RAG_INDEX_JOB_BODY_BYTES) {
+      throw new NonRetryableJobError(
+        "rag_payload_too_large",
+        "RAG index job payload exceeds the QStash budget"
+      );
+    }
 
-  if (!enqueue.success) {
-    throw enqueue.error ?? new Error("qstash_unavailable");
+    const enqueue = await deps.tryEnqueueJob(
+      "rag-index",
+      ragJob,
+      "/api/jobs/rag-index",
+      {
+        deduplicationId: `rag-index:attachment:${job.attachmentId}`,
+        label: QSTASH_JOB_LABELS.RAG_INDEX,
+        timeout: RAG_INDEX_QSTASH_TIMEOUT_SECONDS,
+      }
+    );
+
+    if (!enqueue.success) {
+      throw enqueue.error ?? new Error("qstash_unavailable");
+    }
+
+    recordAttachmentIngestEvent("jobs.attachments_ingest.completed", startedAt, {
+      estimatedChunks,
+      extractedCharsOriginal,
+      extractedCharsUsed,
+      fileSizeBytes,
+      mimeType,
+      qstashDeduplicated: enqueue.deduplicated ?? false,
+      ragPayloadBytes,
+      retryOutcome: "not_applicable",
+      truncated,
+    });
+
+    return {
+      extractedChars: text.length,
+      extractedCharsOriginal: truncated ? extractedCharsOriginal : undefined,
+      ok: true,
+      queued: true,
+      ragMessageId: enqueue.messageId,
+      truncated: truncated ? true : undefined,
+    };
+  } catch (error) {
+    const nonRetryable = error instanceof NonRetryableJobError;
+    recordAttachmentIngestEvent("jobs.attachments_ingest.failed", startedAt, {
+      errorCode: nonRetryable ? error.errorCode : "retryable_error",
+      estimatedChunks,
+      extractedCharsOriginal,
+      extractedCharsUsed,
+      fileSizeBytes,
+      mimeType,
+      ragPayloadBytes,
+      retryOutcome: nonRetryable ? "non_retryable" : "retryable",
+    });
+    throw error;
   }
-
-  return {
-    extractedChars: text.length,
-    extractedCharsOriginal: truncated ? extractedCharsOriginal : undefined,
-    ok: true,
-    queued: true,
-    ragMessageId: enqueue.messageId,
-    truncated: truncated ? true : undefined,
-  };
 }

--- a/src/app/api/jobs/attachments-ingest/_handler.ts
+++ b/src/app/api/jobs/attachments-ingest/_handler.ts
@@ -369,6 +369,7 @@ export async function handleAttachmentsIngest(
       {
         deduplicationId: `rag-index:attachment:${job.attachmentId}`,
         label: QSTASH_JOB_LABELS.RAG_INDEX,
+        redact: { body: true },
         timeout: RAG_INDEX_QSTASH_TIMEOUT_SECONDS,
       }
     );

--- a/src/app/api/jobs/rag-index/__tests__/route.test.ts
+++ b/src/app/api/jobs/rag-index/__tests__/route.test.ts
@@ -140,6 +140,31 @@ describe("POST /api/jobs/rag-index", () => {
     expect(res.headers.get("Upstash-NonRetryable-Error")).toBeNull();
   });
 
+  it("returns 489 when all indexer failures are non-retryable RAG budget failures", async () => {
+    indexDocumentsMock.mockResolvedValue({
+      chunksCreated: 0,
+      failed: [{ error: "rag_limit:too_many_chunks", index: 0 }],
+      indexed: 0,
+      namespace: "user_content",
+      success: false,
+      total: 1,
+    });
+
+    const { POST } = await loadRoute();
+    const res = await POST(
+      makeRequest({
+        documents: [{ content: "Hello world" }],
+        userId: "11111111-1111-4111-8111-111111111111",
+      })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(489);
+    expect(res.headers.get("Upstash-NonRetryable-Error")).toBe("true");
+    expect(json.error).toBe("rag_index_limit");
+    expect(json.reason).toContain("rag_limit:too_many_chunks");
+  });
+
   it("returns 489 for invalid payload and marks as non-retryable", async () => {
     const { POST } = await loadRoute();
 

--- a/src/app/api/jobs/rag-index/__tests__/route.test.ts
+++ b/src/app/api/jobs/rag-index/__tests__/route.test.ts
@@ -167,10 +167,10 @@ describe("POST /api/jobs/rag-index", () => {
     indexDocumentsMock.mockResolvedValue({
       chunksCreated: 1,
       failed: [{ error: "boom", index: 0 }],
-      indexed: 0,
+      indexed: 1,
       namespace: "user_content",
       success: false,
-      total: 1,
+      total: 2,
     });
 
     const { POST } = await loadRoute();
@@ -186,6 +186,17 @@ describe("POST /api/jobs/rag-index", () => {
     expect(json.error).toBe("internal");
     expect(json.reason).toBe("RAG index job failed");
     expect(res.headers.get("Upstash-NonRetryable-Error")).toBeNull();
+    expect(recordTelemetryEventMock).toHaveBeenCalledWith(
+      "jobs.rag_index.failed",
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          failedCount: 1,
+          indexedCount: 1,
+          retryOutcome: "retryable",
+        }),
+        level: "error",
+      })
+    );
   });
 
   it("returns 489 when all indexer failures are non-retryable RAG budget failures", async () => {
@@ -218,6 +229,7 @@ describe("POST /api/jobs/rag-index", () => {
           chunksCreated: 0,
           documentCount: 1,
           failedCount: 1,
+          indexedCount: 0,
           namespace: "user_content",
           retryOutcome: "non_retryable",
         }),

--- a/src/app/api/jobs/rag-index/__tests__/route.test.ts
+++ b/src/app/api/jobs/rag-index/__tests__/route.test.ts
@@ -18,6 +18,7 @@ const envStore = vi.hoisted<Record<string, string | undefined>>(() => ({
 
 const createAdminSupabaseMock = vi.hoisted(() => vi.fn());
 const indexDocumentsMock = vi.hoisted(() => vi.fn());
+const recordTelemetryEventMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/env/server", () => ({
   getServerEnvVar: (key: string) => {
@@ -39,7 +40,7 @@ vi.mock("@/lib/rag/indexer", () => ({
 }));
 
 vi.mock("@/lib/telemetry/span", () => ({
-  recordTelemetryEvent: vi.fn(),
+  recordTelemetryEvent: (...args: unknown[]) => recordTelemetryEventMock(...args),
   sanitizeAttributes: vi.fn((attrs) => attrs),
   withTelemetrySpan: vi.fn(
     (_name: string, _opts: unknown, fn: (span: unknown) => unknown) =>
@@ -71,6 +72,7 @@ describe("POST /api/jobs/rag-index", () => {
     vi.clearAllMocks();
     upstashMocks.qstash.__forceVerify(true);
     createAdminSupabaseMock.mockReset();
+    recordTelemetryEventMock.mockReset();
     createAdminSupabaseMock.mockReturnValue({ from: vi.fn() });
     indexDocumentsMock.mockReset();
     indexDocumentsMock.mockResolvedValue({
@@ -111,6 +113,19 @@ describe("POST /api/jobs/rag-index", () => {
           expect.objectContaining({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }),
         ],
         userId: "11111111-1111-4111-8111-111111111111",
+      })
+    );
+    expect(recordTelemetryEventMock).toHaveBeenCalledWith(
+      "jobs.rag_index.completed",
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          chunksCreated: 1,
+          documentCount: 1,
+          failedCount: 0,
+          indexedCount: 1,
+          namespace: "user_content",
+          retryOutcome: "not_applicable",
+        }),
       })
     );
   });
@@ -163,6 +178,19 @@ describe("POST /api/jobs/rag-index", () => {
     expect(res.headers.get("Upstash-NonRetryable-Error")).toBe("true");
     expect(json.error).toBe("rag_index_limit");
     expect(json.reason).toContain("rag_limit:too_many_chunks");
+    expect(recordTelemetryEventMock).toHaveBeenCalledWith(
+      "jobs.rag_index.failed",
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          chunksCreated: 0,
+          documentCount: 1,
+          failedCount: 1,
+          namespace: "user_content",
+          retryOutcome: "non_retryable",
+        }),
+        level: "error",
+      })
+    );
   });
 
   it("returns 489 for invalid payload and marks as non-retryable", async () => {

--- a/src/app/api/jobs/rag-index/__tests__/route.test.ts
+++ b/src/app/api/jobs/rag-index/__tests__/route.test.ts
@@ -109,6 +109,10 @@ describe("POST /api/jobs/rag-index", () => {
     expect(json.success).toBe(true);
     expect(indexDocumentsMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        config: expect.objectContaining({
+          batchSize: 1,
+          namespace: "user_content",
+        }),
         documents: [
           expect.objectContaining({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }),
         ],
@@ -126,6 +130,35 @@ describe("POST /api/jobs/rag-index", () => {
           namespace: "user_content",
           retryOutcome: "not_applicable",
         }),
+      })
+    );
+  });
+
+  it("uses one indexer batch for the validated job payload", async () => {
+    const { POST } = await loadRoute();
+
+    const res = await POST(
+      makeRequest({
+        documents: [
+          {
+            content: "First document",
+            id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            sourceId: "src-1",
+          },
+          {
+            content: "Second document",
+            id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            sourceId: "src-2",
+          },
+        ],
+        userId: "11111111-1111-4111-8111-111111111111",
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(indexDocumentsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({ batchSize: 2 }),
       })
     );
   });

--- a/src/app/api/jobs/rag-index/_handler.ts
+++ b/src/app/api/jobs/rag-index/_handler.ts
@@ -20,6 +20,7 @@ export async function handleRagIndexJob(
   return await indexDocuments({
     chatId: job.chatId ?? undefined,
     config: {
+      batchSize: job.documents.length,
       chunkOverlap: job.chunkOverlap,
       chunkSize: job.chunkSize,
       namespace: job.namespace,

--- a/src/app/api/jobs/rag-index/route.ts
+++ b/src/app/api/jobs/rag-index/route.ts
@@ -50,6 +50,7 @@ export async function POST(req: Request): Promise<Response> {
                 chunksCreated: result.chunksCreated,
                 documentCount: payload.documents.length,
                 failedCount: result.failed.length,
+                indexedCount: result.indexed,
                 namespace: result.namespace,
                 retryOutcome,
               },

--- a/src/app/api/jobs/rag-index/route.ts
+++ b/src/app/api/jobs/rag-index/route.ts
@@ -4,13 +4,12 @@
 
 import "server-only";
 
+import { MAX_RAG_INDEX_JOB_BODY_BYTES } from "@schemas/rag";
 import { ragIndexJobSchema } from "@schemas/webhooks";
 import { runQstashJob } from "@/lib/qstash/job-route";
 import { createAdminSupabase } from "@/lib/supabase/admin";
-import { withTelemetrySpan } from "@/lib/telemetry/span";
+import { recordTelemetryEvent, withTelemetrySpan } from "@/lib/telemetry/span";
 import { handleRagIndexJob } from "./_handler";
-
-const MAX_RAG_JOB_BODY_BYTES = 512 * 1024;
 
 class NonRetryableRagIndexError extends Error {
   public readonly errorCode: string;
@@ -40,10 +39,23 @@ export async function POST(req: Request): Promise<Response> {
             const uniqueErrors = Array.from(
               new Set(result.failed.map((doc) => doc.error))
             );
-            if (
+            const hasOnlyNonRetryableFailures =
               uniqueErrors.length > 0 &&
-              uniqueErrors.every(isNonRetryableRagIndexFailure)
-            ) {
+              uniqueErrors.every(isNonRetryableRagIndexFailure);
+            const retryOutcome = hasOnlyNonRetryableFailures
+              ? "non_retryable"
+              : "retryable";
+            recordTelemetryEvent("jobs.rag_index.failed", {
+              attributes: {
+                chunksCreated: result.chunksCreated,
+                documentCount: payload.documents.length,
+                failedCount: result.failed.length,
+                namespace: result.namespace,
+                retryOutcome,
+              },
+              level: "error",
+            });
+            if (hasOnlyNonRetryableFailures) {
               throw new NonRetryableRagIndexError(
                 "rag_index_limit",
                 `Non-retryable RAG indexing failures: ${uniqueErrors
@@ -56,6 +68,17 @@ export async function POST(req: Request): Promise<Response> {
             // conservative to avoid silently dropping documents.
             throw new Error(`rag_index_failed:${result.failed.length}`);
           }
+
+          recordTelemetryEvent("jobs.rag_index.completed", {
+            attributes: {
+              chunksCreated: result.chunksCreated,
+              documentCount: payload.documents.length,
+              failedCount: 0,
+              indexedCount: result.indexed,
+              namespace: result.namespace,
+              retryOutcome: "not_applicable",
+            },
+          });
 
           return result;
         },
@@ -76,7 +99,7 @@ export async function POST(req: Request): Promise<Response> {
         req,
         schema: ragIndexJobSchema,
         span,
-        verifyMaxBytes: MAX_RAG_JOB_BODY_BYTES,
+        verifyMaxBytes: MAX_RAG_INDEX_JOB_BODY_BYTES,
       })
   );
 }

--- a/src/domain/schemas/rag.ts
+++ b/src/domain/schemas/rag.ts
@@ -93,7 +93,7 @@ export type RagSearchResult = z.infer<typeof ragSearchResultSchema>;
 export const MAX_RAG_INDEX_TOTAL_CONTENT_CHARS = 250_000;
 /** Maximum documents accepted in one RAG indexing request or job. */
 export const MAX_RAG_INDEX_DOCUMENTS = 100;
-/** Maximum serialized RAG QStash job body size, kept below the provider 1 MB limit. */
+/** Maximum serialized RAG QStash job body size for the app's operational budget. */
 export const MAX_RAG_INDEX_JOB_BODY_BYTES = 512 * 1024;
 /** Maximum chunks embedded in one provider call batch. */
 export const MAX_RAG_EMBED_CHUNKS_PER_BATCH = 1200;

--- a/src/domain/schemas/rag.ts
+++ b/src/domain/schemas/rag.ts
@@ -105,6 +105,12 @@ export const RAG_INDEX_QSTASH_TIMEOUT_SECONDS = 55;
 export const RAG_INDEX_EMBED_TIMEOUT_BUDGET_MS =
   (RAG_INDEX_QSTASH_TIMEOUT_SECONDS - 5) * 1000;
 
+/**
+ * Validates that a RAG chunk overlap is smaller than the chunk size.
+ *
+ * @param value - Chunk window settings containing `chunkOverlap` and `chunkSize`.
+ * @returns True when `chunkOverlap` is strictly smaller than `chunkSize`.
+ */
 export function isValidRagChunkWindow(value: {
   chunkOverlap: number;
   chunkSize: number;

--- a/src/domain/schemas/rag.ts
+++ b/src/domain/schemas/rag.ts
@@ -101,6 +101,9 @@ export const MAX_RAG_EMBED_CHUNKS_PER_BATCH = 1200;
 export const RAG_CHARS_PER_TOKEN = 4;
 /** QStash delivery timeout kept under the configured 60-second Vercel function cap. */
 export const RAG_INDEX_QSTASH_TIMEOUT_SECONDS = 55;
+/** Embedding abort timeout kept below QStash delivery timeout for handler cleanup. */
+export const RAG_INDEX_EMBED_TIMEOUT_BUDGET_MS =
+  (RAG_INDEX_QSTASH_TIMEOUT_SECONDS - 5) * 1000;
 
 export function isValidRagChunkWindow(value: {
   chunkOverlap: number;

--- a/src/domain/schemas/rag.ts
+++ b/src/domain/schemas/rag.ts
@@ -91,6 +91,23 @@ export type RagSearchResult = z.infer<typeof ragSearchResultSchema>;
 
 /** Maximum total content size for indexing requests (characters). */
 export const MAX_RAG_INDEX_TOTAL_CONTENT_CHARS = 250_000;
+/** Maximum documents accepted in one RAG indexing request or job. */
+export const MAX_RAG_INDEX_DOCUMENTS = 100;
+/** Maximum serialized RAG QStash job body size, kept below the provider 1 MB limit. */
+export const MAX_RAG_INDEX_JOB_BODY_BYTES = 512 * 1024;
+/** Maximum chunks embedded in one provider call batch. */
+export const MAX_RAG_EMBED_CHUNKS_PER_BATCH = 1200;
+/** Conservative token-to-character approximation used for chunk budgets. */
+export const RAG_CHARS_PER_TOKEN = 4;
+/** QStash delivery timeout kept under the configured 60-second Vercel function cap. */
+export const RAG_INDEX_QSTASH_TIMEOUT_SECONDS = 55;
+
+export function isValidRagChunkWindow(value: {
+  chunkOverlap: number;
+  chunkSize: number;
+}): boolean {
+  return value.chunkOverlap < value.chunkSize;
+}
 
 /**
  * Zod schema for POST /api/rag/index request body.
@@ -100,11 +117,18 @@ export const ragIndexRequestSchema = z
   .strictObject({
     chunkOverlap: z.number().int().min(0).max(500).default(100),
     chunkSize: z.number().int().min(100).max(2000).default(512),
-    documents: z.array(ragDocumentSchema).min(1).max(100, {
-      error: "Maximum 100 documents per batch",
-    }),
+    documents: z
+      .array(ragDocumentSchema)
+      .min(1)
+      .max(MAX_RAG_INDEX_DOCUMENTS, {
+        error: `Maximum ${MAX_RAG_INDEX_DOCUMENTS} documents per batch`,
+      }),
     maxParallelCalls: z.number().int().min(1).max(10).default(2),
     namespace: ragNamespaceSchema.default("default"),
+  })
+  .refine(isValidRagChunkWindow, {
+    error: "Chunk overlap must be smaller than chunk size",
+    path: ["chunkOverlap"],
   })
   .refine(
     (value) =>
@@ -281,13 +305,18 @@ export type RerankResult = z.infer<typeof rerankResultSchema>;
  * Zod schema for indexer configuration.
  * Used to configure document chunking and embedding.
  */
-export const indexerConfigSchema = z.strictObject({
-  batchSize: z.number().int().min(1).max(100).default(10),
-  chunkOverlap: z.number().int().min(0).max(500).default(100),
-  chunkSize: z.number().int().min(100).max(2000).default(512),
-  maxParallelCalls: z.number().int().min(1).max(10).default(2),
-  namespace: ragNamespaceSchema.default("default"),
-});
+export const indexerConfigSchema = z
+  .strictObject({
+    batchSize: z.number().int().min(1).max(100).default(10),
+    chunkOverlap: z.number().int().min(0).max(500).default(100),
+    chunkSize: z.number().int().min(100).max(2000).default(512),
+    maxParallelCalls: z.number().int().min(1).max(10).default(2),
+    namespace: ragNamespaceSchema.default("default"),
+  })
+  .refine(isValidRagChunkWindow, {
+    error: "Chunk overlap must be smaller than chunk size",
+    path: ["chunkOverlap"],
+  });
 
 /** TypeScript type for indexer configuration. */
 export type IndexerConfig = z.infer<typeof indexerConfigSchema>;

--- a/src/domain/schemas/webhooks.ts
+++ b/src/domain/schemas/webhooks.ts
@@ -4,6 +4,8 @@
 
 import { z } from "zod";
 import {
+  isValidRagChunkWindow,
+  MAX_RAG_INDEX_DOCUMENTS,
   MAX_RAG_INDEX_TOTAL_CONTENT_CHARS,
   ragDocumentSchema,
   ragNamespaceSchema,
@@ -89,12 +91,19 @@ export const ragIndexJobSchema = z
     chatId: primitiveSchemas.uuid.nullable().optional(),
     chunkOverlap: z.number().int().nonnegative().max(500).default(100),
     chunkSize: z.number().int().min(100).max(2000).default(512),
-    documents: z.array(ragDocumentSchema).min(1).max(100, {
-      error: "Maximum 100 documents per batch",
-    }),
+    documents: z
+      .array(ragDocumentSchema)
+      .min(1)
+      .max(MAX_RAG_INDEX_DOCUMENTS, {
+        error: `Maximum ${MAX_RAG_INDEX_DOCUMENTS} documents per batch`,
+      }),
     namespace: ragNamespaceSchema.default("user_content"),
     tripId: z.number().int().nonnegative().nullable().optional(),
     userId: primitiveSchemas.uuid,
+  })
+  .refine(isValidRagChunkWindow, {
+    error: "Chunk overlap must be smaller than chunk size",
+    path: ["chunkOverlap"],
   })
   .refine(
     (value) =>

--- a/src/lib/qstash/__tests__/client.test.ts
+++ b/src/lib/qstash/__tests__/client.test.ts
@@ -90,7 +90,12 @@ describe("enqueueJob", () => {
       label: QSTASH_JOB_LABELS.NOTIFY_COLLABORATORS,
     });
 
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("qstash.dedup_id_present", true);
     expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      "qstash.dedup_id_hash_available",
+      false
+    );
+    expect(mockSpan.setAttribute).not.toHaveBeenCalledWith(
       "qstash.dedup_id",
       "test-job:tenant-42"
     );
@@ -105,6 +110,30 @@ describe("enqueueJob", () => {
     expect(mockSpan.setAttribute).toHaveBeenCalledWith(
       "qstash.has_failure_callback",
       true
+    );
+  });
+
+  it("records a hashed deduplication id when telemetry hashing is configured", async () => {
+    GET_ENV_FALLBACK.mockImplementation((key: string, fallback?: string) =>
+      key === "TELEMETRY_HASH_SECRET" ? "test-telemetry-secret" : fallback
+    );
+    const { enqueueJob, setQStashClientFactoryForTests } = await import(
+      "@/lib/qstash/client"
+    );
+    setQStashClientFactoryForTests(() => new qstash.Client({ token: "test" }));
+
+    await enqueueJob("test-job", { ok: true }, "/api/jobs/test", {
+      deduplicationId: "test-job:tenant-42",
+      label: QSTASH_JOB_LABELS.NOTIFY_COLLABORATORS,
+    });
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      "qstash.dedup_id_hash",
+      expect.stringMatching(/^[a-f0-9]{64}$/)
+    );
+    expect(mockSpan.setAttribute).not.toHaveBeenCalledWith(
+      "qstash.dedup_id",
+      "test-job:tenant-42"
     );
   });
 

--- a/src/lib/qstash/__tests__/client.test.ts
+++ b/src/lib/qstash/__tests__/client.test.ts
@@ -61,6 +61,7 @@ describe("enqueueJob", () => {
       failureCallback: "https://example.com/failure",
       flowControl: { key: "tenant-1", parallelism: 2 },
       label: QSTASH_JOB_LABELS.NOTIFY_COLLABORATORS,
+      redact: { body: true },
       timeout: 30,
     });
 
@@ -73,6 +74,7 @@ describe("enqueueJob", () => {
     expect(messages[0]?.failureCallback).toBe("https://example.com/failure");
     expect(messages[0]?.retries).toBe(5);
     expect(messages[0]?.retryDelay).toBe("10000 * pow(2, retried)");
+    expect(messages[0]?.redact).toEqual({ body: true });
     expect(messages[0]?.timeout).toBe(30);
     expect(result?.messageId).toBe("qstash-mock-1");
   });

--- a/src/lib/qstash/client.ts
+++ b/src/lib/qstash/client.ts
@@ -6,6 +6,7 @@ import "server-only";
 
 import { Client } from "@upstash/qstash";
 import { getServerEnvVarWithFallback } from "@/lib/env/server";
+import { hashTelemetryIdentifier } from "@/lib/telemetry/identifiers";
 import { recordTelemetryEvent, withTelemetrySpan } from "@/lib/telemetry/span";
 import { getRequiredServerOrigin } from "@/lib/url/server-origin";
 import { QSTASH_JOB_LABELS, QSTASH_RETRY_CONFIG, type QStashJobLabel } from "./config";
@@ -271,7 +272,13 @@ export async function enqueueJob(
       span.setAttribute("qstash.url", url);
 
       const deduplicationId = options.deduplicationId;
-      span.setAttribute("qstash.dedup_id", deduplicationId);
+      span.setAttribute("qstash.dedup_id_present", true);
+      const deduplicationIdHash = hashTelemetryIdentifier(deduplicationId);
+      if (deduplicationIdHash) {
+        span.setAttribute("qstash.dedup_id_hash", deduplicationIdHash);
+      } else {
+        span.setAttribute("qstash.dedup_id_hash_available", false);
+      }
 
       if (options.contentBasedDeduplication) {
         span.setAttribute("qstash.content_based_dedup", true);

--- a/src/lib/qstash/client.ts
+++ b/src/lib/qstash/client.ts
@@ -162,6 +162,8 @@ export interface EnqueueJobOptions {
   failureCallback?: string;
   /** HTTP timeout in seconds */
   timeout?: number;
+  /** Provider-side log redaction for sensitive message fields */
+  redact?: QStashPublishJsonOptions["redact"];
   /** Delay before first delivery in seconds */
   delay?: number;
   /** Override default retry count */
@@ -312,6 +314,7 @@ export async function enqueueJob(
         flowControl: options.flowControl,
         headers,
         label: options.label,
+        redact: options.redact,
         retries: options.retries ?? QSTASH_RETRY_CONFIG.retries,
         retryDelay: options.retryDelay ?? QSTASH_RETRY_CONFIG.retryDelay,
         timeout: options.timeout,

--- a/src/lib/rag/__tests__/indexer.test.ts
+++ b/src/lib/rag/__tests__/indexer.test.ts
@@ -8,6 +8,9 @@ import { upsertMany } from "@/lib/supabase/typed-helpers";
 import { unsafeCast } from "@/test/helpers/unsafe-cast";
 import { chunkText, indexDocuments } from "../indexer";
 
+const recordTelemetryEventMock = vi.hoisted(() => vi.fn());
+const spanSetAttributeMock = vi.hoisted(() => vi.fn());
+
 // Mock server-only
 vi.mock("server-only", () => ({}));
 
@@ -31,8 +34,13 @@ vi.mock("@/lib/telemetry/logger", () => ({
 }));
 
 vi.mock("@/lib/telemetry/span", () => ({
+  recordTelemetryEvent: (...args: unknown[]) => recordTelemetryEventMock(...args),
   withTelemetrySpan: vi.fn(
-    async <T>(_name: string, _options: unknown, execute: () => Promise<T>) => execute()
+    async <T>(
+      _name: string,
+      _options: unknown,
+      execute: (span: { setAttribute: typeof spanSetAttributeMock }) => Promise<T>
+    ) => execute({ setAttribute: spanSetAttributeMock })
   ),
 }));
 
@@ -233,5 +241,75 @@ describe("indexDocuments", () => {
         expect(rows[i]?.chunk_index).toBe(i);
       }
     }
+  });
+
+  it("emits redacted embedding telemetry and aggregate cost counters", async () => {
+    const supabase = unsafeCast<SupabaseClient<Database>>({});
+    const upsertManyMock = vi.mocked(upsertMany);
+    upsertManyMock.mockResolvedValue({ data: [], error: null });
+
+    vi.mocked(embedMany).mockResolvedValueOnce({
+      embeddings: [Array(1536).fill(0)],
+      usage: { tokens: 42 },
+      values: ["Short document"],
+      warnings: [],
+    });
+
+    await indexDocuments({
+      config: { chunkOverlap: 20, chunkSize: 100, namespace: "default" },
+      documents: [{ content: "Short document" }],
+      supabase,
+      userId: "22222222-2222-2222-2222-222222222222",
+    });
+
+    expect(embedMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        experimental_telemetry: expect.objectContaining({
+          functionId: "rag.indexer.embed_many",
+          isEnabled: true,
+          recordInputs: false,
+          recordOutputs: false,
+        }),
+        maxParallelCalls: 2,
+      })
+    );
+    expect(spanSetAttributeMock).toHaveBeenCalledWith(
+      "rag.indexer.embedding_tokens",
+      42
+    );
+    expect(recordTelemetryEventMock).toHaveBeenCalledWith(
+      "rag.indexer.index_complete",
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          chunksCreated: 1,
+          dbRowsUpserted: 1,
+          dbUpserts: 1,
+          documentCount: 1,
+          embeddingCalls: 1,
+          embeddingTokens: 42,
+          failedCount: 0,
+        }),
+      })
+    );
+  });
+
+  it("marks chunk budget failures with the non-retryable RAG limit code", async () => {
+    const supabase = unsafeCast<SupabaseClient<Database>>({});
+    const result = await indexDocuments({
+      config: {
+        batchSize: 1,
+        chunkOverlap: 99,
+        chunkSize: 100,
+        namespace: "default",
+      },
+      documents: [{ content: "A".repeat(5000) }],
+      supabase,
+      userId: "22222222-2222-2222-2222-222222222222",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.failed).toEqual([{ error: "rag_limit:too_many_chunks", index: 0 }]);
+    expect(embedMany).not.toHaveBeenCalled();
+    expect(upsertMany).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/rag/__tests__/indexer.test.ts
+++ b/src/lib/rag/__tests__/indexer.test.ts
@@ -1,5 +1,6 @@
 /** @vitest-environment node */
 
+import { RAG_INDEX_EMBED_TIMEOUT_BUDGET_MS } from "@schemas/rag";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { embedMany } from "ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -291,6 +292,33 @@ describe("indexDocuments", () => {
         }),
       })
     );
+  });
+
+  it("caps embedding abort timeout under the QStash delivery budget", async () => {
+    const supabase = unsafeCast<SupabaseClient<Database>>({});
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockImplementation(() => new AbortController().signal);
+    vi.mocked(embedMany).mockRejectedValueOnce(new Error("provider_down"));
+
+    try {
+      await indexDocuments({
+        config: {
+          batchSize: 1,
+          chunkOverlap: 99,
+          chunkSize: 100,
+          namespace: "default",
+        },
+        documents: [{ content: "A".repeat(4800) }],
+        supabase,
+        userId: "22222222-2222-2222-2222-222222222222",
+      });
+      expect(timeoutSpy).toHaveBeenCalledWith(RAG_INDEX_EMBED_TIMEOUT_BUDGET_MS);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+
+    expect(upsertMany).not.toHaveBeenCalled();
   });
 
   it("marks chunk budget failures with the non-retryable RAG limit code", async () => {

--- a/src/lib/rag/indexer.ts
+++ b/src/lib/rag/indexer.ts
@@ -15,6 +15,7 @@ import {
   indexerConfigSchema,
   MAX_RAG_EMBED_CHUNKS_PER_BATCH,
   RAG_CHARS_PER_TOKEN,
+  RAG_INDEX_EMBED_TIMEOUT_BUDGET_MS,
 } from "@schemas/rag";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { embedMany } from "ai";
@@ -44,7 +45,11 @@ const EMBED_TIMEOUT_PER_CHUNK_MS = 100;
 function getEmbedTimeoutMs(chunkCount: number, maxParallelCalls: number): number {
   const parallelCalls = Math.max(1, maxParallelCalls);
   const rounds = Math.ceil(chunkCount / parallelCalls);
-  return Math.max(EMBED_TIMEOUT_BASE_MS, rounds * EMBED_TIMEOUT_PER_CHUNK_MS);
+  const dynamicTimeoutMs = Math.max(
+    EMBED_TIMEOUT_BASE_MS,
+    rounds * EMBED_TIMEOUT_PER_CHUNK_MS
+  );
+  return Math.min(dynamicTimeoutMs, RAG_INDEX_EMBED_TIMEOUT_BUDGET_MS);
 }
 
 function roundDurationMs(durationMs: number): number {

--- a/src/lib/rag/indexer.ts
+++ b/src/lib/rag/indexer.ts
@@ -11,7 +11,11 @@ import type {
   RagIndexResponse,
   RagNamespace,
 } from "@schemas/rag";
-import { indexerConfigSchema } from "@schemas/rag";
+import {
+  indexerConfigSchema,
+  MAX_RAG_EMBED_CHUNKS_PER_BATCH,
+  RAG_CHARS_PER_TOKEN,
+} from "@schemas/rag";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { embedMany } from "ai";
 import {
@@ -22,18 +26,13 @@ import { secureUuid } from "@/lib/security/random";
 import type { Database } from "@/lib/supabase/database.types";
 import { deleteMany, upsertMany } from "@/lib/supabase/typed-helpers";
 import { createServerLogger } from "@/lib/telemetry/logger";
-import { withTelemetrySpan } from "@/lib/telemetry/span";
+import { recordTelemetryEvent, withTelemetrySpan } from "@/lib/telemetry/span";
 import { RagLimitError } from "./errors";
 import { toPgvector } from "./pgvector";
 
 const logger = createServerLogger("rag.indexer");
 const EMBED_TIMEOUT_BASE_MS = 30_000;
 const EMBED_TIMEOUT_PER_CHUNK_MS = 100;
-
-/** Token to character ratio approximation (conservative). */
-const CHARS_PER_TOKEN = 4;
-/** Max chunks per embedding batch to prevent runaway costs and respect API limits. */
-const MAX_CHUNKS_PER_EMBED_BATCH = 1200;
 
 /**
  * Computes a dynamic timeout for embedding requests based on chunk count and parallelism.
@@ -46,6 +45,16 @@ function getEmbedTimeoutMs(chunkCount: number, maxParallelCalls: number): number
   const parallelCalls = Math.max(1, maxParallelCalls);
   const rounds = Math.ceil(chunkCount / parallelCalls);
   return Math.max(EMBED_TIMEOUT_BASE_MS, rounds * EMBED_TIMEOUT_PER_CHUNK_MS);
+}
+
+function roundDurationMs(durationMs: number): number {
+  return Math.round(durationMs * 100) / 100;
+}
+
+function getFailureCode(error: unknown): string {
+  if (error instanceof RagLimitError) return error.code;
+  if (error instanceof Error) return error.message;
+  return "batch_failed";
 }
 
 /**
@@ -63,19 +72,19 @@ interface ChunkLimitContext {
  *
  * @param count - Actual number of chunks to be processed.
  * @param context - Metadata for logging and error reporting.
- * @throws {RagLimitError} If the chunk count exceeds MAX_CHUNKS_PER_EMBED_BATCH.
+ * @throws {RagLimitError} If the chunk count exceeds MAX_RAG_EMBED_CHUNKS_PER_BATCH.
  */
 function enforceChunkLimit(count: number, context: ChunkLimitContext): void {
-  if (count <= MAX_CHUNKS_PER_EMBED_BATCH) return;
+  if (count <= MAX_RAG_EMBED_CHUNKS_PER_BATCH) return;
   logger.warn("chunk_limit_exceeded", {
     ...context,
     chunkCount: count,
-    limit: MAX_CHUNKS_PER_EMBED_BATCH,
+    limit: MAX_RAG_EMBED_CHUNKS_PER_BATCH,
   });
   // Hard limit to avoid runaway embedding costs; callers should split batches.
   throw new RagLimitError("too_many_chunks", {
     chunkCount: count,
-    limit: MAX_CHUNKS_PER_EMBED_BATCH,
+    limit: MAX_RAG_EMBED_CHUNKS_PER_BATCH,
   });
 }
 
@@ -119,8 +128,8 @@ export function chunkText(
   chunkSize: number = 512,
   chunkOverlap: number = 100
 ): string[] {
-  const chunkChars = chunkSize * CHARS_PER_TOKEN;
-  const overlapChars = chunkOverlap * CHARS_PER_TOKEN;
+  const chunkChars = chunkSize * RAG_CHARS_PER_TOKEN;
+  const overlapChars = chunkOverlap * RAG_CHARS_PER_TOKEN;
 
   if (text.length <= chunkChars) {
     return [text.trim()].filter((t) => t.length > 0);
@@ -224,6 +233,7 @@ export async function indexDocuments(
 ): Promise<RagIndexResponse> {
   const { chatId, documents, supabase, tripId, userId } = params;
   const config = indexerConfigSchema.parse(params.config ?? {});
+  const startedAt = performance.now();
 
   return withTelemetrySpan(
     "rag.indexer.index_documents",
@@ -239,10 +249,15 @@ export async function indexDocuments(
         "rag.indexer.trip_id_present": Boolean(tripId),
       },
     },
-    async () => {
+    async (span) => {
       const failed: RagIndexFailedDoc[] = [];
       let indexedCount = 0;
       let chunksCreated = 0;
+      let dbRowsUpserted = 0;
+      let dbUpserts = 0;
+      let embeddingCalls = 0;
+      let embeddingTokens = 0;
+      let embeddingWarnings = 0;
 
       // Process documents in batches to control memory
       for (let i = 0; i < documents.length; i += config.batchSize) {
@@ -261,17 +276,23 @@ export async function indexDocuments(
 
           indexedCount += batchResult.indexed;
           chunksCreated += batchResult.chunksCreated;
+          dbRowsUpserted += batchResult.dbRowsUpserted;
+          dbUpserts += batchResult.dbUpserts;
+          embeddingCalls += batchResult.embeddingCalls;
+          embeddingTokens += batchResult.embeddingTokens;
+          embeddingWarnings += batchResult.embeddingWarnings;
           failed.push(...batchResult.failed);
         } catch (error) {
+          const failureCode = getFailureCode(error);
           // If entire batch fails, mark all documents in batch as failed
           logger.error("batch_failed", {
             batchStart: i,
-            error: error instanceof Error ? error.message : "unknown_error",
+            error: failureCode,
           });
 
           for (let j = 0; j < batch.length; j++) {
             failed.push({
-              error: error instanceof Error ? error.message : "batch_failed",
+              error: failureCode,
               index: i + j,
             });
           }
@@ -289,10 +310,43 @@ export async function indexDocuments(
 
       logger.info("index_complete", {
         chunksCreated,
+        dbRowsUpserted,
+        dbUpserts,
+        durationMs: roundDurationMs(performance.now() - startedAt),
+        embeddingCalls,
+        embeddingTokens,
+        embeddingWarnings,
         failedCount: failed.length,
         indexedCount,
         namespace: config.namespace,
         total: documents.length,
+      });
+
+      const durationMs = roundDurationMs(performance.now() - startedAt);
+      span.setAttribute("rag.indexer.chunks_created", chunksCreated);
+      span.setAttribute("rag.indexer.db_rows_upserted", dbRowsUpserted);
+      span.setAttribute("rag.indexer.db_upserts", dbUpserts);
+      span.setAttribute("rag.indexer.duration_ms", durationMs);
+      span.setAttribute("rag.indexer.embedding_calls", embeddingCalls);
+      span.setAttribute("rag.indexer.embedding_tokens", embeddingTokens);
+      span.setAttribute("rag.indexer.embedding_warnings", embeddingWarnings);
+      span.setAttribute("rag.indexer.failed_count", failed.length);
+      span.setAttribute("rag.indexer.indexed_count", indexedCount);
+
+      recordTelemetryEvent("rag.indexer.index_complete", {
+        attributes: {
+          chunksCreated,
+          dbRowsUpserted,
+          dbUpserts,
+          documentCount: documents.length,
+          durationMs,
+          embeddingCalls,
+          embeddingTokens,
+          embeddingWarnings,
+          failedCount: failed.length,
+          indexedCount,
+          namespace: config.namespace,
+        },
       });
 
       return result;
@@ -318,6 +372,11 @@ interface IndexBatchParams {
  */
 interface IndexBatchResult {
   chunksCreated: number;
+  dbRowsUpserted: number;
+  dbUpserts: number;
+  embeddingCalls: number;
+  embeddingTokens: number;
+  embeddingWarnings: number;
   failed: RagIndexFailedDoc[];
   indexed: number;
 }
@@ -335,7 +394,7 @@ async function indexBatch(params: IndexBatchParams): Promise<IndexBatchResult> {
   let chunksCreated = 0;
   const estimatedChunkChars = Math.max(
     1,
-    (config.chunkSize - config.chunkOverlap) * CHARS_PER_TOKEN
+    (config.chunkSize - config.chunkOverlap) * RAG_CHARS_PER_TOKEN
   );
   let estimatedChunkCount = 0;
 
@@ -381,7 +440,16 @@ async function indexBatch(params: IndexBatchParams): Promise<IndexBatchResult> {
   }
 
   if (allChunks.length === 0) {
-    return { chunksCreated: 0, failed, indexed: 0 };
+    return {
+      chunksCreated: 0,
+      dbRowsUpserted: 0,
+      dbUpserts: 0,
+      embeddingCalls: 0,
+      embeddingTokens: 0,
+      embeddingWarnings: 0,
+      failed,
+      indexed: 0,
+    };
   }
 
   enforceChunkLimit(allChunks.length, {
@@ -391,15 +459,44 @@ async function indexBatch(params: IndexBatchParams): Promise<IndexBatchResult> {
     documentCount: batch.length,
   });
 
-  // Generate embeddings for all chunks in batch
-  const { embeddings } = await embedMany({
-    abortSignal: AbortSignal.timeout(
-      getEmbedTimeoutMs(allChunks.length, config.maxParallelCalls)
-    ),
-    maxParallelCalls: config.maxParallelCalls,
-    model: getTextEmbeddingModel(),
-    values: allChunks.map((c) => c.chunk),
-  });
+  // Generate embeddings for all chunks in batch without recording raw input/output.
+  let embedResult: Awaited<ReturnType<typeof embedMany>>;
+  try {
+    embedResult = await embedMany({
+      abortSignal: AbortSignal.timeout(
+        getEmbedTimeoutMs(allChunks.length, config.maxParallelCalls)
+      ),
+      // biome-ignore lint/style/useNamingConvention: AI SDK option name.
+      experimental_telemetry: {
+        functionId: "rag.indexer.embed_many",
+        isEnabled: true,
+        metadata: {
+          batchStartIndex,
+          chunkCount: allChunks.length,
+          namespace: config.namespace,
+        },
+        recordInputs: false,
+        recordOutputs: false,
+      },
+      maxParallelCalls: config.maxParallelCalls,
+      model: getTextEmbeddingModel(),
+      values: allChunks.map((c) => c.chunk),
+    });
+  } catch (error) {
+    recordTelemetryEvent("rag.indexer.embedding_failed", {
+      attributes: {
+        batchStartIndex,
+        chunkCount: allChunks.length,
+        documentCount: batch.length,
+        errorName: error instanceof Error ? error.name : "unknown_error",
+        namespace: config.namespace,
+      },
+      level: "error",
+    });
+    throw error;
+  }
+
+  const { embeddings, usage, warnings } = embedResult;
 
   if (embeddings.length !== allChunks.length) {
     throw new Error(
@@ -448,7 +545,16 @@ async function indexBatch(params: IndexBatchParams): Promise<IndexBatchResult> {
   indexed = successfulDocIndices.size;
   chunksCreated = rows.length;
 
-  return { chunksCreated, failed, indexed };
+  return {
+    chunksCreated,
+    dbRowsUpserted: rows.length,
+    dbUpserts: 1,
+    embeddingCalls: 1,
+    embeddingTokens: usage.tokens,
+    embeddingWarnings: warnings.length,
+    failed,
+    indexed,
+  };
 }
 
 /**


### PR DESCRIPTION
Closes #738

## Summary
- Adds shared RAG/attachment job budgets for document count, serialized QStash body size, chunk fan-out, QStash delivery timeout, and embedding abort timeout.
- Instruments attachment ingest, RAG job route, and RAG indexer with redacted duration/cost counters for chunks, documents, embedding calls/tokens/warnings, DB upserts, retry outcome, and payload bytes.
- Maps RAG budget-limit failures to non-retryable QStash/DLQ responses, hashes QStash dedup ids in telemetry, requests provider-side QStash body log redaction for raw attachment-to-RAG payloads, and caps RAG jobs to one indexer batch per validated payload.
- Documents the attachment/RAG budget contract, telemetry event split, public `/api/rag/index` chunk-window invariant, QStash raw-payload processor boundary, and workflow-pilot thresholds.

## Validation
- `pnpm biome:fix`
- `pnpm exec vitest run src/app/api/jobs/attachments-ingest/__tests__/route.test.ts src/app/api/jobs/rag-index/__tests__/route.test.ts src/lib/rag/__tests__/indexer.test.ts src/lib/qstash/__tests__/client.test.ts`
- `pnpm type-check`
- `pnpm check:zod-v4`
- `pnpm check:api-route-errors`
- `pnpm check:no-new-unknown-casts`
- `pnpm check:no-secrets:full`
- `pnpm test:affected`
- `pnpm build`
- `git diff --check`

## Docs impact
- Updated `docs/api/internal/jobs.md`, `docs/development/backend/observability.md`, `docs/specs/active/0104-spec-memory-and-rag.md`, `docs/specs/active/0107-spec-jobs-and-webhooks.md`, ADR-0048, ADR-0067, and `CHANGELOG.md`.

## Provider / deploy notes
- Uses existing Upstash QStash publish support for `timeout` and `redact: { body: true }`; no new provider dependency or migration.
- Keeps the current `vercel.json` 60s API route cap and sets RAG QStash delivery to 55s with embedding abort capped to 50s.
- No workflow SDK is introduced; docs define telemetry thresholds for a future workflow pilot if production evidence warrants it.

## Pre-PR review
- Runtime subagent review: fixed timeout budget drift and multi-batch RAG job runtime risk; final pass clean.
- Security subagent review: fixed raw QStash dedup telemetry and provider body redaction gap; final pass clean.
- Docs subagent review: fixed public RAG invariant, event split, QStash processor boundary, and wording drift.

## Residual risks
- Attachment-to-RAG QStash messages intentionally carry extracted content for asynchronous indexing. The path now requests provider-side body log redaction and documents QStash retry/DLQ access as sensitive production data access; a reference-only payload design remains a future architecture change if product/security requirements tighten.
