### PR TITLE
test(tokens): remove stale model fixture names

### DIFF
--- a/src/lib/tokens/__tests__/budget.test.ts
+++ b/src/lib/tokens/__tests__/budget.test.ts
@@ -116,34 +116,22 @@ describe("clampMaxTokens", () => {
     expect(getModelContextLimit("grok-4.3")).toBe(1_000_000);
   });
 
-  it("does not retain stale GPT-5 or Claude 4 model aliases", () => {
-    const oldGptBase = ["gpt", "5"].join("-");
-    const oldClaudeSonnetBase = ["claude", "sonnet", "4"].join("-");
-    const oldClaudeOpusBase = ["claude", "opus", "4"].join("-");
-    const staleModels = [
-      oldGptBase,
-      [oldGptBase, "mini"].join("-"),
-      oldClaudeSonnetBase,
-      oldClaudeOpusBase,
-      `anthropic/${oldClaudeSonnetBase}-20250514`,
-    ];
-
-    for (const model of staleModels) {
-      expect(getModelContextLimit(model)).toBe(DEFAULT_CONTEXT_LIMIT);
-    }
-    const stalePrefixes = [
-      oldGptBase,
-      [oldGptBase, "mini"].join("-"),
-      oldClaudeSonnetBase,
-      oldClaudeOpusBase,
-    ];
-    const hasStaleAliasKey = Object.keys(MODEL_LIMITS).some((key) =>
-      stalePrefixes.some(
-        (prefix) =>
-          key === prefix || key.startsWith(`${prefix}-`) || key.includes(`/${prefix}`)
-      )
+  it("keeps model limits restricted to the current canonical model set", () => {
+    expect(Object.keys(MODEL_LIMITS).sort()).toEqual(
+      [
+        "deepseek-v4-flash",
+        "deepseek-v4-pro",
+        "gemini-3.1-flash-lite",
+        "glm-5.1",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano",
+        "gpt-5.5",
+        "grok-4.3",
+        "kimi-k2.6",
+        "mimo-v2.5",
+        "mimo-v2.5-pro",
+      ].sort()
     );
-    expect(hasStaleAliasKey).toBe(false);
   });
 
   it("coerces invalid desiredMax to 1 with reason", () => {


### PR DESCRIPTION
## Summary
- Replace the token-limit stale-model regression test with an exact canonical `MODEL_LIMITS` key-set assertion.
- Removes obsolete model identifiers from active source/tests while preserving coverage that old aliases cannot be reintroduced.

## Validation
- `rg --pcre2 -n "gpt-5-mini|gpt-5-nano|(?<![\w.-])gpt-5(?![\w.-])|claude-sonnet-4|claude-opus-4|claude-4|sonnet-4|opus-4|20250514|20250522|20240229|20241022|20240620|20250301" src docs scripts e2e .github package.json pnpm-lock.yaml --glob "!node_modules" --glob "!opensrc"` -> no matches
- `pnpm exec vitest run src/lib/tokens/__tests__/budget.test.ts`
- `rtk err pnpm biome:fix`
- `rtk err pnpm type-check`
- `rtk test pnpm test:affected`
- `git diff --check`
- Pre-PR shallow bug reviewer: no findings

## Docs Impact
No docs changes.

## Provider/Deploy Notes
No runtime model defaults changed. This only removes stale literal fixture names from tests.

## Screenshots
Not applicable; test-only change.

## Residual Risks
Low. The assertion is intentionally stricter: adding any model limit now requires updating the canonical expected key set.

Direct follow-up to the user-requested stale model hard cut before returning to #741.