### PR TITLE
refactor(supabase): tighten typed helper contracts

### DIFF
--- a/src/app/api/chat/attachments/route.ts
+++ b/src/app/api/chat/attachments/route.ts
@@ -22,7 +22,7 @@ import {
 } from "@/lib/api/route-helpers";
 import { bumpTag } from "@/lib/cache/tags";
 import { secureUuid } from "@/lib/security/random";
-import { deleteSingle, insertSingle } from "@/lib/supabase/typed-helpers";
+import { deleteMany, insertSingle } from "@/lib/supabase/typed-helpers";
 import { createServerLogger } from "@/lib/telemetry/logger";
 import { ensureTripAccess } from "@/lib/trips/trip-access";
 
@@ -136,7 +136,7 @@ export const POST = withApiGuards({
   const cleanupInserted = async (): Promise<void> => {
     if (insertedIds.length === 0) return;
     try {
-      const { error: cleanupError } = await deleteSingle(
+      const { error: cleanupError } = await deleteMany(
         supabase,
         "file_attachments",
         (qb) => qb.in("id", insertedIds),

--- a/src/app/api/security/sessions/__tests__/routes.test.ts
+++ b/src/app/api/security/sessions/__tests__/routes.test.ts
@@ -146,20 +146,24 @@ describe("/api/security/sessions routes", () => {
       error: null,
     });
 
-    const deleteChain = {
-      eq: vi.fn(() => ({
-        eq: vi.fn(async () => ({ error: null })),
-      })),
-    };
+    const deleteChain = Object.assign(Promise.resolve({ count: 1, error: null }), {
+      eq: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+    });
+    const query = Object.assign(
+      Promise.resolve({ count: 1, data: [{ id: "sess-1" }], error: null }),
+      {
+        delete: vi.fn(() => deleteChain),
+        eq: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn(async () => ({ data: mockSessionRow, error: null })),
+        select: vi.fn().mockReturnThis(),
+      }
+    );
 
     adminInstance = unsafeCast<ReturnType<typeof adminMock>>({
       schema: vi.fn(() => ({
-        from: vi.fn(() => ({
-          delete: vi.fn(() => deleteChain),
-          eq: vi.fn().mockReturnThis(),
-          maybeSingle: vi.fn(async () => ({ data: mockSessionRow, error: null })),
-          select: vi.fn().mockReturnThis(),
-        })),
+        from: vi.fn(() => query),
       })),
     });
 

--- a/src/app/api/security/sessions/_handlers.ts
+++ b/src/app/api/security/sessions/_handlers.ts
@@ -69,7 +69,7 @@ export async function terminateSessionHandler(params: {
         adminSupabase,
         "sessions",
         (qb) => qb.eq("id", sessionId).eq("user_id", userId),
-        { count: null, schema: "auth" }
+        { schema: "auth" }
       );
 
       if (deleteResult.error) {

--- a/src/lib/supabase/__tests__/typed-helpers.test.ts
+++ b/src/lib/supabase/__tests__/typed-helpers.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { Tables, TablesInsert, TablesUpdate } from "@/lib/supabase/database.types";
 import type { TypedClient } from "@/lib/supabase/typed-helpers";
 import {
+  deleteMany,
   deleteSingle,
   getMany,
   getMaybeSingle,
@@ -24,22 +25,26 @@ import { unsafeCast } from "@/test/helpers/unsafe-cast";
  */
 type MockChain = {
   delete: ReturnType<typeof vi.fn>;
-  eq: (column: string, value: unknown) => MockChain;
-  insert: (values: unknown) => MockChain;
+  eq: ReturnType<typeof vi.fn>;
+  in: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
   maybeSingle: ReturnType<typeof vi.fn>;
   order: ReturnType<typeof vi.fn>;
   range: ReturnType<typeof vi.fn>;
   select: ReturnType<typeof vi.fn>;
   single: ReturnType<typeof vi.fn>;
-  update: (values: unknown) => MockChain;
-  upsert: (values: unknown, options: unknown) => MockChain;
+  update: ReturnType<typeof vi.fn>;
+  upsert: ReturnType<typeof vi.fn>;
 };
 
 function makeMockFrom(): MockChain {
   const chain: MockChain = {
     delete: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
     insert: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
     maybeSingle: vi.fn(),
     order: vi.fn().mockReturnThis(),
     range: vi.fn().mockReturnThis(),
@@ -64,6 +69,17 @@ function makeClientWithChain(): { client: TypedClient; chain: MockChain } {
     },
   });
   return { chain, client };
+}
+
+function mockQueryResult<Result extends object>(
+  chain: MockChain,
+  method: "delete" | "select" | "update",
+  result: Result
+): MockChain {
+  const queryPromise = Promise.resolve(result);
+  const queryChain = Object.assign(queryPromise, chain) as MockChain;
+  chain[method].mockReturnValue(queryChain);
+  return queryChain;
 }
 
 const userId = "123e4567-e89b-12d3-a456-426614174000";
@@ -182,6 +198,60 @@ describe("typed-helpers", () => {
       expect(data).toBeNull();
       expect(error).toBeTruthy();
     });
+
+    it("rejects validation for tables without registered Zod schemas", async () => {
+      const { client, chain } = makeClientWithChain();
+      const unsupportedTable = unsafeCast<"trips">("unsupported_table");
+      const payload: TablesInsert<"trips"> = {
+        budget: 100,
+        destination: "LAX",
+        end_date: "2025-02-01",
+        name: "Unsupported Trip",
+        start_date: "2025-01-01",
+        travelers: 1,
+        user_id: userId,
+      };
+
+      const { data, error } = await insertSingle(client, unsupportedTable, payload);
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe(
+        "unsupported_table_for_validation:public.unsupported_table"
+      );
+      expect(chain.insert).not.toHaveBeenCalled();
+    });
+
+    it("allows generated tables without Zod schemas when validation is disabled", async () => {
+      const { client, chain } = makeClientWithChain();
+      const payload: TablesInsert<"bookings"> = {
+        checkin: "2025-01-01",
+        checkout: "2025-01-02",
+        guest_email: "guest@example.com",
+        guest_name: "Guest User",
+        guests: 1,
+        id: "booking-1",
+        property_id: "hotel-1",
+        provider_booking_id: "provider-booking-1",
+        status: "pending",
+        trip_id: 1,
+        user_id: userId,
+      };
+
+      chain.single.mockResolvedValue({
+        data: unsafeCast<Tables<"bookings">>({ id: "booking-1" }),
+        error: null,
+      });
+
+      const { data, error } = await insertSingle(client, "bookings", payload, {
+        select: "id",
+        validate: false,
+      });
+
+      expect(error).toBeNull();
+      expect(data?.id).toBe("booking-1");
+      expect(chain.insert).toHaveBeenCalledWith(payload);
+    });
   });
 
   describe("updateSingle", () => {
@@ -228,6 +298,29 @@ describe("typed-helpers", () => {
       expect(result.error).toBeTruthy();
       expect(chain.update).not.toHaveBeenCalled();
     });
+
+    it("supports partial selects when validation is disabled", async () => {
+      const { client, chain } = makeClientWithChain();
+      chain.single.mockResolvedValue({
+        data: unsafeCast<Tables<"trips">>({ id: 7 }),
+        error: null,
+      });
+
+      const result = await updateSingle(
+        client,
+        "trips",
+        { name: "Updated" },
+        (qb) => qb.eq("id", 7),
+        {
+          select: "id",
+          validate: false,
+        }
+      );
+
+      expect(result.error).toBeNull();
+      expect(chain.select).toHaveBeenCalledWith("id");
+      expect(result.data?.id).toBe(7);
+    });
   });
 
   describe("updateMany", () => {
@@ -235,10 +328,7 @@ describe("typed-helpers", () => {
       const { client, chain } = makeClientWithChain();
       const updates: Partial<TablesUpdate<"trips">> = { status: "completed" };
 
-      const updatePromise = Promise.resolve({ count: 2, error: null });
-      (chain.update as ReturnType<typeof vi.fn>).mockReturnValue(
-        Object.assign(updatePromise, chain) as MockChain
-      );
+      mockQueryResult(chain, "update", { count: 2, error: null });
 
       const { count, error } = await updateMany(client, "trips", updates, (qb) =>
         qb.eq("status", "planning")
@@ -251,10 +341,7 @@ describe("typed-helpers", () => {
       const { client, chain } = makeClientWithChain();
       const updates: Partial<TablesUpdate<"trips">> = { status: "completed" };
 
-      const updatePromise = Promise.resolve({ count: 0, error: null });
-      (chain.update as ReturnType<typeof vi.fn>).mockReturnValue(
-        Object.assign(updatePromise, chain) as MockChain
-      );
+      mockQueryResult(chain, "update", { count: 0, error: null });
 
       const { count, error } = await updateMany(client, "trips", updates, (qb) => qb, {
         count: null,
@@ -268,13 +355,10 @@ describe("typed-helpers", () => {
       const { client, chain } = makeClientWithChain();
       const updates: Partial<TablesUpdate<"trips">> = { status: "cancelled" };
 
-      const updatePromise = Promise.resolve({
+      mockQueryResult(chain, "update", {
         count: 0,
         error: { message: "Update failed" },
       });
-      (chain.update as ReturnType<typeof vi.fn>).mockReturnValue(
-        Object.assign(updatePromise, chain) as MockChain
-      );
 
       const { count, error } = await updateMany(client, "trips", updates, (qb) => qb);
       expect(count).toBe(0);
@@ -311,26 +395,113 @@ describe("typed-helpers", () => {
   describe("deleteSingle", () => {
     it("deletes successfully", async () => {
       const { client, chain } = makeClientWithChain();
-      // Mock delete to return a thenable that resolves
-      const deleteResult = Promise.resolve({ count: 1, error: null });
-      (chain.delete as ReturnType<typeof vi.fn>).mockReturnValue(deleteResult);
-
-      const { count, error } = await deleteSingle(client, "trips", () => {
-        return unsafeCast(deleteResult);
+      mockQueryResult(chain, "select", {
+        count: 1,
+        data: [{ id: 1 }],
+        error: null,
       });
+      mockQueryResult(chain, "delete", { count: 1, error: null });
+
+      const { count, error } = await deleteSingle(client, "trips", (qb) =>
+        qb.eq("id", 1)
+      );
       expect(count).toBe(1);
       expect(error).toBeNull();
+      expect(chain.delete).toHaveBeenCalledWith({ count: "exact" });
+      expect(chain.limit).toHaveBeenCalledWith(1);
     });
 
+    it("allows zero-row deletes so callers can return not found", async () => {
+      const { client, chain } = makeClientWithChain();
+      mockQueryResult(chain, "select", {
+        count: 0,
+        data: [],
+        error: null,
+      });
+
+      const { count, error } = await deleteSingle(client, "trips", (qb) =>
+        qb.eq("id", 404)
+      );
+      expect(count).toBe(0);
+      expect(error).toBeNull();
+      expect(chain.delete).not.toHaveBeenCalled();
+    });
+
+    it("rejects no-count deletes", async () => {
+      const { client, chain } = makeClientWithChain();
+
+      const { count, error } = await deleteSingle(client, "trips", (qb) => qb, {
+        count: null,
+      });
+
+      expect(count).toBe(0);
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("delete_single_requires_count");
+      expect(chain.delete).not.toHaveBeenCalled();
+    });
+
+    it("returns an error when more than one row matches", async () => {
+      const { client, chain } = makeClientWithChain();
+      mockQueryResult(chain, "select", {
+        count: 2,
+        data: [{ id: 1 }, { id: 2 }],
+        error: null,
+      });
+
+      const { count, error } = await deleteSingle(client, "trips", (qb) =>
+        qb.in("id", [1, 2])
+      );
+
+      expect(count).toBe(2);
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("delete_single_matched_multiple_rows");
+      expect(chain.delete).not.toHaveBeenCalled();
+    });
+
+    it("returns an error if the delete result reports multiple rows after preflight", async () => {
+      const { client, chain } = makeClientWithChain();
+      mockQueryResult(chain, "select", {
+        count: 1,
+        data: [{ id: 1 }],
+        error: null,
+      });
+      mockQueryResult(chain, "delete", { count: 2, error: null });
+
+      const { count, error } = await deleteSingle(client, "trips", (qb) =>
+        qb.eq("status", "planning")
+      );
+
+      expect(count).toBe(2);
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("delete_single_matched_multiple_rows");
+      expect(chain.limit).toHaveBeenCalledWith(1);
+    });
+
+    it("returns error when delete fails", async () => {
+      const { client, chain } = makeClientWithChain();
+      const deleteError = { message: "Delete failed" };
+      mockQueryResult(chain, "select", {
+        count: 1,
+        data: [{ id: 1 }],
+        error: null,
+      });
+      mockQueryResult(chain, "delete", { count: 0, error: deleteError });
+
+      const { count, error } = await deleteSingle(client, "trips", (qb) => qb);
+      expect(count).toBe(0);
+      expect(error).toBeTruthy();
+    });
+  });
+
+  describe("deleteMany", () => {
     it("omits count preference when count is null", async () => {
       const { client, chain } = makeClientWithChain();
-      const deleteResult = Promise.resolve({ count: 0, error: null });
-      (chain.delete as ReturnType<typeof vi.fn>).mockReturnValue(deleteResult);
+      mockQueryResult(chain, "delete", { count: 0, error: null });
 
-      const { count, error } = await deleteSingle(
+      const { count, error } = await deleteMany(
         client,
         "trips",
-        () => unsafeCast(deleteResult),
+        (qb) => qb.in("id", [1, 2]),
         { count: null }
       );
       expect(count).toBe(0);
@@ -338,17 +509,16 @@ describe("typed-helpers", () => {
       expect(chain.delete).toHaveBeenCalledWith();
     });
 
-    it("returns error when delete fails", async () => {
+    it("allows multi-row deletes", async () => {
       const { client, chain } = makeClientWithChain();
-      const deleteError = { message: "Delete failed" };
-      const deleteResult = Promise.resolve({ count: 0, error: deleteError });
-      (chain.delete as ReturnType<typeof vi.fn>).mockReturnValue(deleteResult);
+      mockQueryResult(chain, "delete", { count: 3, error: null });
 
-      const { count, error } = await deleteSingle(client, "trips", () => {
-        return unsafeCast(deleteResult);
-      });
-      expect(count).toBe(0);
-      expect(error).toBeTruthy();
+      const { count, error } = await deleteMany(client, "trips", (qb) =>
+        qb.eq("status", "cancelled")
+      );
+
+      expect(count).toBe(3);
+      expect(error).toBeNull();
     });
   });
 
@@ -466,10 +636,7 @@ describe("typed-helpers", () => {
         mockTripsRow({ ...payloads[1], id: 11 }),
       ];
 
-      const selectPromise = Promise.resolve({ data: rows, error: null });
-      (chain.select as ReturnType<typeof vi.fn>).mockReturnValue(
-        Object.assign(selectPromise, chain) as MockChain
-      );
+      mockQueryResult(chain, "select", { data: rows, error: null });
 
       const { data, error } = await upsertMany(client, "trips", payloads, "user_id");
       expect(error).toBeNull();
@@ -492,13 +659,10 @@ describe("typed-helpers", () => {
         },
       ];
 
-      const selectPromise = Promise.resolve({
+      mockQueryResult(chain, "select", {
         data: null,
         error: { message: "Upsert failed" },
       });
-      (chain.select as ReturnType<typeof vi.fn>).mockReturnValue(
-        Object.assign(selectPromise, chain) as MockChain
-      );
 
       const { data, error } = await upsertMany(client, "trips", payloads, "user_id");
       expect(data).toHaveLength(0);
@@ -515,11 +679,7 @@ describe("typed-helpers", () => {
         mockTripsRow({ id: 3, name: "Trip 3" }),
       ];
 
-      // Mock the select chain to return rows when awaited
-      const selectPromise = Promise.resolve({ count: null, data: rows, error: null });
-      (chain.select as ReturnType<typeof vi.fn>).mockReturnValue(
-        Object.assign(selectPromise, chain) as MockChain
-      );
+      mockQueryResult(chain, "select", { count: null, data: rows, error: null });
 
       const { data, count, error } = await getMany(client, "trips", (qb) => qb);
       expect(error).toBeNull();
@@ -532,10 +692,7 @@ describe("typed-helpers", () => {
       const { client, chain } = makeClientWithChain();
       const rows = [mockTripsRow({ id: 2 }), mockTripsRow({ id: 3 })];
 
-      const selectPromise = Promise.resolve({ count: null, data: rows, error: null });
-      (chain.select as ReturnType<typeof vi.fn>).mockReturnValue(
-        Object.assign(selectPromise, chain) as MockChain
-      );
+      mockQueryResult(chain, "select", { count: null, data: rows, error: null });
 
       const { data, error } = await getMany(client, "trips", (qb) => qb, {
         limit: 2,
@@ -554,10 +711,7 @@ describe("typed-helpers", () => {
         mockTripsRow({ id: 1 }),
       ];
 
-      const selectPromise = Promise.resolve({ count: null, data: rows, error: null });
-      (chain.select as ReturnType<typeof vi.fn>).mockReturnValue(
-        Object.assign(selectPromise, chain) as MockChain
-      );
+      mockQueryResult(chain, "select", { count: null, data: rows, error: null });
 
       const { data, error } = await getMany(client, "trips", (qb) => qb, {
         ascending: false,
@@ -572,10 +726,7 @@ describe("typed-helpers", () => {
       const { client, chain } = makeClientWithChain();
       const rows = [mockTripsRow({ id: 1 })];
 
-      const selectPromise = Promise.resolve({ count: 10, data: rows, error: null });
-      (chain.select as ReturnType<typeof vi.fn>).mockReturnValue(
-        Object.assign(selectPromise, chain) as MockChain
-      );
+      mockQueryResult(chain, "select", { count: 10, data: rows, error: null });
 
       const { count, data, error } = await getMany(client, "trips", (qb) => qb, {
         count: "exact",
@@ -589,14 +740,11 @@ describe("typed-helpers", () => {
     it("returns error when query fails", async () => {
       const { client, chain } = makeClientWithChain();
 
-      const selectPromise = Promise.resolve({
+      mockQueryResult(chain, "select", {
         count: null,
         data: null,
         error: { message: "Query failed" },
       });
-      (chain.select as ReturnType<typeof vi.fn>).mockReturnValue(
-        Object.assign(selectPromise, chain) as MockChain
-      );
 
       const { data, error } = await getMany(client, "trips", (qb) => qb);
       expect(data).toHaveLength(0);
@@ -633,11 +781,7 @@ describe("typed-helpers", () => {
         mockTripsRow({ ...second, id: 2 }),
       ];
 
-      // Mock the insert chain to return rows when select is called
-      const selectPromise = Promise.resolve({ data: rows, error: null });
-      (chain.select as ReturnType<typeof vi.fn>).mockReturnValue(
-        Object.assign(selectPromise, chain) as MockChain
-      );
+      mockQueryResult(chain, "select", { data: rows, error: null });
 
       const { data, error } = await insertMany(client, "trips", payloads);
       expect(error).toBeNull();
@@ -668,13 +812,10 @@ describe("typed-helpers", () => {
         },
       ];
 
-      const selectPromise = Promise.resolve({
+      mockQueryResult(chain, "select", {
         data: null,
         error: { message: "Insert failed" },
       });
-      (chain.select as ReturnType<typeof vi.fn>).mockReturnValue(
-        Object.assign(selectPromise, chain) as MockChain
-      );
 
       const { data, error } = await insertMany(client, "trips", payloads);
       expect(data).toHaveLength(0);

--- a/src/lib/supabase/typed-helpers.ts
+++ b/src/lib/supabase/typed-helpers.ts
@@ -23,20 +23,31 @@ type TableUpdate<S extends SchemaName, T extends TableName<S>> =
  * Keep this loose enough for test doubles while avoiding `any`.
  */
 export type TableFilterBuilder = {
-  eq: (...args: unknown[]) => TableFilterBuilder;
-  in: (...args: unknown[]) => TableFilterBuilder;
-  is: (...args: unknown[]) => TableFilterBuilder;
-  gt: (...args: unknown[]) => TableFilterBuilder;
-  gte: (...args: unknown[]) => TableFilterBuilder;
-  lt: (...args: unknown[]) => TableFilterBuilder;
-  lte: (...args: unknown[]) => TableFilterBuilder;
-  neq: (...args: unknown[]) => TableFilterBuilder;
-  like: (...args: unknown[]) => TableFilterBuilder;
-  ilike: (...args: unknown[]) => TableFilterBuilder;
-  contains: (...args: unknown[]) => TableFilterBuilder;
-  overlaps: (...args: unknown[]) => TableFilterBuilder;
-  order: (...args: unknown[]) => TableFilterBuilder;
-  select: (...args: unknown[]) => TableFilterBuilder;
+  eq: (column: string, value: unknown) => TableFilterBuilder;
+  in: (column: string, values: readonly unknown[]) => TableFilterBuilder;
+  is: (column: string, value: boolean | null) => TableFilterBuilder;
+  gt: (column: string, value: unknown) => TableFilterBuilder;
+  gte: (column: string, value: unknown) => TableFilterBuilder;
+  lt: (column: string, value: unknown) => TableFilterBuilder;
+  lte: (column: string, value: unknown) => TableFilterBuilder;
+  neq: (column: string, value: unknown) => TableFilterBuilder;
+  like: (column: string, pattern: string) => TableFilterBuilder;
+  ilike: (column: string, pattern: string) => TableFilterBuilder;
+  contains: (column: string, value: unknown) => TableFilterBuilder;
+  overlaps: (column: string, value: readonly unknown[]) => TableFilterBuilder;
+  order: (
+    column: string,
+    options?: {
+      ascending?: boolean;
+      foreignTable?: string;
+      nullsFirst?: boolean;
+      referencedTable?: string;
+    }
+  ) => TableFilterBuilder;
+  select: (
+    columns?: string,
+    options?: { count?: CountPreference }
+  ) => TableFilterBuilder;
   limit: (count: number) => TableFilterBuilder;
   offset?: (count: number) => TableFilterBuilder;
   range?: (from: number, to: number) => TableFilterBuilder;
@@ -49,12 +60,17 @@ export type TableFilterBuilder = {
 };
 
 type TableQueryBuilder = {
-  select: (...args: unknown[]) => TableFilterBuilder;
+  select: (
+    columns?: string,
+    options?: { count?: CountPreference }
+  ) => TableFilterBuilder;
   insert: (values: unknown) => TableFilterBuilder;
   update: (values: unknown, options?: unknown) => TableFilterBuilder;
   upsert: (values: unknown, options?: unknown) => TableFilterBuilder;
-  delete: (options?: unknown) => TableFilterBuilder;
+  delete: (options?: { count?: CountPreference }) => TableFilterBuilder;
 };
+
+type TableOperation = keyof TableQueryBuilder;
 
 type SupabaseTableSchema = {
   insert?: z.ZodTypeAny;
@@ -63,45 +79,6 @@ type SupabaseTableSchema = {
 };
 
 type CountPreference = "exact" | "planned" | "estimated";
-
-/**
- * Registry of tables supported by runtime Zod validation.
- * authoritative source: src/domain/schemas/supabase.ts
- * To add a new table:
- * 1. Ensure schema exists in src/domain/schemas/supabase.ts
- * 2. Add table name to the appropriate schema array below
- */
-const SUPPORTED_TABLES = {
-  auth: ["sessions"],
-  memories: ["sessions", "turns"],
-  public: [
-    "accommodations",
-    "agent_config",
-    "agent_config_versions",
-    "api_metrics",
-    "auth_backup_codes",
-    "chat_messages",
-    "chat_sessions",
-    "chat_tool_calls",
-    "file_attachments",
-    "flights",
-    "itinerary_items",
-    "mfa_backup_code_audit",
-    "mfa_enrollments",
-    "rag_documents",
-    "saved_places",
-    "trip_collaborators",
-    "trips",
-    "user_settings",
-  ],
-} as const;
-
-type SupportedSchema = keyof typeof SUPPORTED_TABLES;
-
-const isSupportedTable = (schema: SchemaName, table: string): boolean => {
-  const tables = SUPPORTED_TABLES[schema as SupportedSchema];
-  return Array.isArray(tables) && tables.includes(table as never);
-};
 
 const resolveSchema = (schema?: SchemaName): SchemaName => schema ?? "public";
 
@@ -122,14 +99,47 @@ const getFromClient = (
   };
 };
 
-const getValidationSchema = (
+const getTableBuilder = (
+  client: TypedClient,
   schema: SchemaName,
-  table: string
-): SupabaseTableSchema | undefined => {
-  if (!isSupportedTable(schema, table)) return undefined;
-  return getSupabaseSchema(table as never, { schema }) as
+  table: string,
+  operation: TableOperation
+): TableQueryBuilder | Error => {
+  const schemaClient = getFromClient(client, schema);
+  if (!schemaClient) {
+    return new Error("from_unavailable");
+  }
+
+  const base = schemaClient.from(table);
+  if (typeof base[operation] !== "function") {
+    return new Error(`${operation}_unavailable`);
+  }
+  return base;
+};
+
+const resolveValidationSchema = (
+  schema: SchemaName,
+  table: string,
+  shouldValidate: boolean
+): SupabaseTableSchema | Error | undefined => {
+  const tableSchema = getSupabaseSchema(table as never, { schema }) as
     | SupabaseTableSchema
     | undefined;
+  if (shouldValidate && !tableSchema) {
+    return new Error(`unsupported_table_for_validation:${schema}.${table}`);
+  }
+  return tableSchema;
+};
+
+const failWithError = <T extends object>(
+  span: Parameters<typeof recordErrorOnSpan>[0],
+  error: unknown,
+  fallback: T
+): T & { error: unknown } => {
+  if (error instanceof Error) {
+    recordErrorOnSpan(span, error);
+  }
+  return { ...fallback, error };
 };
 
 const resolveMaybeSingle = async (
@@ -163,9 +173,9 @@ const resolveMaybeSingle = async (
  * Use `options.select` to limit returned columns; validation defaults to
  * `false` when selecting partial columns.
  * Explicit validation with partial selects returns an error.
- * When `options.select` is provided, the returned data only contains those
- * columns and may not satisfy the full `TableRow<S, T>` shape at runtime.
- * TODO: Add a type-narrowing overload or dedicated helper for partial selects.
+ * When `options.select` is provided, callers must set `validate: false`; the
+ * returned data only contains the requested columns and is intentionally not
+ * validated against the full row schema.
  *
  * Note: This function accepts only single objects, not arrays.
  * For batch inserts, use `insertMany` instead.
@@ -206,8 +216,15 @@ export function insertSingle<
         return { data: null, error };
       }
       const shouldValidate = options?.validate ?? selectColumns === "*";
+      const schema = resolveValidationSchema(
+        schemaName,
+        table as string,
+        shouldValidate
+      );
+      if (schema instanceof Error) {
+        return failWithError(span, schema, { data: null });
+      }
       // Validate input if schema exists
-      const schema = getValidationSchema(schemaName, table as string);
       if (Array.isArray(values)) {
         const error = new Error("insert_single_requires_object");
         recordErrorOnSpan(span, error);
@@ -224,14 +241,8 @@ export function insertSingle<
         }
       }
 
-      const schemaClient = getFromClient(client, schemaName);
-      if (!schemaClient) {
-        return { data: null, error: new Error("from_unavailable") };
-      }
-      const base = schemaClient.from(table as string);
-      if (typeof base.insert !== "function") {
-        return { data: null, error: new Error("insert_unavailable") };
-      }
+      const base = getTableBuilder(client, schemaName, table, "insert");
+      if (base instanceof Error) return { data: null, error: base };
       const insertQb = base.insert(values as unknown);
       // Some tests stub a very lightweight query builder without select/single methods.
       // Gracefully handle those by treating the insert as fire-and-forget.
@@ -315,8 +326,15 @@ export function updateSingle<
         return { data: null, error };
       }
       const shouldValidate = options?.validate ?? selectColumns === "*";
+      const schema = resolveValidationSchema(
+        schemaName,
+        table as string,
+        shouldValidate
+      );
+      if (schema instanceof Error) {
+        return failWithError(span, schema, { data: null });
+      }
       // Validate input if schema exists
-      const schema = getValidationSchema(schemaName, table as string);
       if (schema?.update && shouldValidate) {
         try {
           schema.update.parse(updates);
@@ -328,14 +346,8 @@ export function updateSingle<
         }
       }
 
-      const schemaClient = getFromClient(client, schemaName);
-      if (!schemaClient) {
-        return { data: null, error: new Error("from_unavailable") };
-      }
-      const base = schemaClient.from(table as string);
-      if (typeof base.update !== "function") {
-        return { data: null, error: new Error("update_unavailable") };
-      }
+      const base = getTableBuilder(client, schemaName, table, "update");
+      if (base instanceof Error) return { data: null, error: base };
       const filtered = where(base.update(updates as unknown));
       if (filtered && typeof filtered.select === "function") {
         const { data, error } = await filtered.select(selectColumns).single();
@@ -408,7 +420,14 @@ export function updateMany<
     async (span) => {
       const schemaName = resolveSchema(options?.schema);
       const shouldValidate = options?.validate ?? true;
-      const schema = getValidationSchema(schemaName, table as string);
+      const schema = resolveValidationSchema(
+        schemaName,
+        table as string,
+        shouldValidate
+      );
+      if (schema instanceof Error) {
+        return failWithError(span, schema, { count: 0 });
+      }
       if (schema?.update && shouldValidate) {
         try {
           schema.update.parse(updates);
@@ -420,14 +439,8 @@ export function updateMany<
         }
       }
 
-      const schemaClient = getFromClient(client, schemaName);
-      if (!schemaClient) {
-        return { count: 0, error: new Error("from_unavailable") };
-      }
-      const base = schemaClient.from(table as string);
-      if (typeof base.update !== "function") {
-        return { count: 0, error: new Error("update_unavailable") };
-      }
+      const base = getTableBuilder(client, schemaName, table, "update");
+      if (base instanceof Error) return { count: 0, error: base };
       const countPreference = options?.count;
       const updateBuilder =
         countPreference === null
@@ -478,18 +491,19 @@ export function getSingle<
     },
     async (span) => {
       const schemaName = resolveSchema(options?.schema);
-      const schema = getValidationSchema(schemaName, table as string);
       const selectColumns = options?.select ?? "*";
       const shouldValidate = options?.validate ?? selectColumns === "*";
+      const schema = resolveValidationSchema(
+        schemaName,
+        table as string,
+        shouldValidate
+      );
+      if (schema instanceof Error) {
+        return failWithError(span, schema, { data: null });
+      }
 
-      const schemaClient = getFromClient(client, schemaName);
-      if (!schemaClient) {
-        return { data: null, error: new Error("from_unavailable") };
-      }
-      const base = schemaClient.from(table as string);
-      if (typeof base.select !== "function") {
-        return { data: null, error: new Error("select_unavailable") };
-      }
+      const base = getTableBuilder(client, schemaName, table, "select");
+      if (base instanceof Error) return { data: null, error: base };
       const qb = where(base.select(selectColumns));
       if (qb && typeof qb === "object" && "error" in qb) {
         return { data: null, error: (qb as { error?: unknown }).error ?? null };
@@ -522,41 +536,27 @@ export function getSingle<
   );
 }
 
-/**
- * Deletes rows from the specified table matching the given criteria.
- * A `where` closure receives the fluent query builder to apply filters
- * (`eq`, `in`, etc.) prior to deletion. Naming follows getSingle/updateSingle;
- * callers must provide filters that target the intended row(s). This helper
- * does not enforce single-row deletion and will delete all rows matching the
- * supplied filter.
- * Use `options.count` to request a PostgREST count preference; set to `null`
- * to skip counting entirely.
- * Use `options.returning: "representation"` (with `options.select`) to request
- * deleted rows when the caller needs return data or reliable count headers.
- *
- * @typeParam S - Supabase schema name for the target table.
- * @typeParam T - Table name within the selected schema.
- * @param client - Typed Supabase client.
- * @param table - Target table name.
- * @param where - Closure to apply filters to the builder.
- * @param options - Optional schema, count preference, returning mode, and select columns.
- * @returns Count of deleted rows and error (if any).
- */
-export function deleteSingle<
+type DeleteOptions<S extends SchemaName> = {
+  schema?: S;
+  count?: CountPreference | null;
+  limit?: number;
+  returning?: "representation";
+  select?: string;
+};
+
+const multiRowDeleteError = (count: number): Error | null =>
+  count > 1 ? new Error("delete_single_matched_multiple_rows") : null;
+
+const deleteRows = async <
   S extends SchemaName = "public",
   T extends TableName<S> = TableName<S>,
 >(
   client: TypedClient,
   table: T,
   where: (qb: TableFilterBuilder) => TableFilterBuilder,
-  options?: {
-    schema?: S;
-    count?: CountPreference | null;
-    returning?: "representation";
-    select?: string;
-  }
-): Promise<{ count: number; error: unknown | null }> {
-  return withTelemetrySpan(
+  options?: DeleteOptions<S>
+): Promise<{ count: number; error: unknown | null }> =>
+  withTelemetrySpan(
     "supabase.delete",
     {
       attributes: {
@@ -568,15 +568,8 @@ export function deleteSingle<
     },
     async (span) => {
       const schemaName = resolveSchema(options?.schema);
-      const schemaClient = getFromClient(client, schemaName);
-      if (!schemaClient) {
-        return { count: 0, error: new Error("from_unavailable") };
-      }
-      const base = schemaClient.from(table as string);
-
-      if (typeof base.delete !== "function") {
-        return { count: 0, error: new Error("delete_unavailable") };
-      }
+      const base = getTableBuilder(client, schemaName, table, "delete");
+      if (base instanceof Error) return { count: 0, error: base };
 
       const countPreference = options?.count;
       const deleteBuilder =
@@ -592,21 +585,111 @@ export function deleteSingle<
           ? deleteBuilder.select(selectColumns)
           : deleteBuilder;
 
-      const qb = where(returningBuilder);
+      const filtered = where(returningBuilder);
+      const qb =
+        options?.limit === undefined ? filtered : filtered.limit(options.limit);
       const { count, error } = await qb;
       span.setAttribute("db.supabase.row_count", count ?? 0);
       return { count: count ?? 0, error: error ?? null };
     }
   );
+
+const countDeleteCandidates = async <
+  S extends SchemaName = "public",
+  T extends TableName<S> = TableName<S>,
+>(
+  client: TypedClient,
+  table: T,
+  where: (qb: TableFilterBuilder) => TableFilterBuilder,
+  options?: DeleteOptions<S>
+): Promise<{ count: number; error: unknown | null }> =>
+  withTelemetrySpan(
+    "supabase.delete.preflight",
+    {
+      attributes: {
+        "db.name": "tripsage",
+        "db.supabase.operation": "select",
+        "db.supabase.table": table,
+        "db.system": "postgres",
+      },
+    },
+    async (span) => {
+      const schemaName = resolveSchema(options?.schema);
+      const base = getTableBuilder(client, schemaName, table, "select");
+      if (base instanceof Error) return { count: 0, error: base };
+
+      const selectColumns = options?.select ?? "id";
+      const qb = where(base.select(selectColumns, { count: "exact" }).limit(2));
+      const { count, data, error } = await qb;
+      if (error) return { count: 0, error };
+
+      const rowCount =
+        count ??
+        (Array.isArray(data)
+          ? data.length
+          : data === null || data === undefined
+            ? 0
+            : 1);
+      span.setAttribute("db.supabase.row_count", rowCount);
+      return { count: rowCount, error: null };
+    }
+  );
+
+/**
+ * Deletes at most one row from the specified table matching the given criteria.
+ * A `where` closure receives the fluent query builder to apply filters
+ * (`eq`, etc.) prior to deletion. This helper requests a count and returns an
+ * error if the filter matches more than one row. Use `deleteMany` for bulk
+ * deletes or no-count cleanup operations.
+ *
+ * @typeParam S - Supabase schema name for the target table.
+ * @typeParam T - Table name within the selected schema.
+ * @param client - Typed Supabase client.
+ * @param table - Target table name.
+ * @param where - Closure to apply filters to the builder.
+ * @param options - Optional schema, count preference, returning mode, and select columns.
+ * @returns Count of deleted rows and error (if any).
+ */
+export async function deleteSingle<
+  S extends SchemaName = "public",
+  T extends TableName<S> = TableName<S>,
+>(
+  client: TypedClient,
+  table: T,
+  where: (qb: TableFilterBuilder) => TableFilterBuilder,
+  options?: DeleteOptions<S>
+): Promise<{ count: number; error: unknown | null }> {
+  if (options?.count === null) {
+    return { count: 0, error: new Error("delete_single_requires_count") };
+  }
+
+  const candidateResult = await countDeleteCandidates(client, table, where, options);
+  if (candidateResult.error) return candidateResult;
+  if (candidateResult.count === 0) return candidateResult;
+  const preflightError = multiRowDeleteError(candidateResult.count);
+  if (preflightError) {
+    return {
+      count: candidateResult.count,
+      error: preflightError,
+    };
+  }
+
+  const deleteResult = await deleteRows(client, table, where, {
+    ...options,
+    count: options?.count ?? "exact",
+    limit: 1,
+  });
+  if (deleteResult.error) return deleteResult;
+
+  const deleteCountError = multiRowDeleteError(deleteResult.count);
+  return deleteCountError ? { ...deleteResult, error: deleteCountError } : deleteResult;
 }
 
 /**
  * Deletes rows from the specified table matching the given criteria.
- * Naming aligns with bulk operations (e.g., updateMany) and does not enforce
- * single-row deletes.
- * NOTE: deleteMany is an intentional alias for deleteSingle, and deleteSingle
- * deletes all matching rows. This keeps naming consistent with updateMany and
- * insertMany while sharing the same implementation.
+ * Naming aligns with bulk operations (e.g., updateMany). This helper does not
+ * enforce single-row effects and is the only supported path for no-count
+ * cleanup deletes.
  *
  * @typeParam S - Supabase schema name for the target table.
  * @typeParam T - Table name within the selected schema.
@@ -623,9 +706,9 @@ export function deleteMany<
   client: TypedClient,
   table: T,
   where: (qb: TableFilterBuilder) => TableFilterBuilder,
-  options?: { schema?: S; count?: CountPreference | null }
+  options?: DeleteOptions<S>
 ): Promise<{ count: number; error: unknown | null }> {
-  return deleteSingle(client, table, where, options);
+  return deleteRows(client, table, where, options);
 }
 
 /**
@@ -664,18 +747,19 @@ export function getMaybeSingle<
     },
     async (span) => {
       const schemaName = resolveSchema(options?.schema);
-      const schema = getValidationSchema(schemaName, table as string);
       const selectColumns = options?.select ?? "*";
       const shouldValidate = options?.validate ?? selectColumns === "*";
+      const schema = resolveValidationSchema(
+        schemaName,
+        table as string,
+        shouldValidate
+      );
+      if (schema instanceof Error) {
+        return failWithError(span, schema, { data: null });
+      }
 
-      const schemaClient = getFromClient(client, schemaName);
-      if (!schemaClient) {
-        return { data: null, error: new Error("from_unavailable") };
-      }
-      const base = schemaClient.from(table as string);
-      if (typeof base.select !== "function") {
-        return { data: null, error: new Error("select_unavailable") };
-      }
+      const base = getTableBuilder(client, schemaName, table, "select");
+      if (base instanceof Error) return { data: null, error: base };
       const qb = where(base.select(selectColumns));
       if (qb && typeof qb === "object" && "error" in qb) {
         return { data: null, error: (qb as { error?: unknown }).error ?? null };
@@ -739,7 +823,14 @@ export function upsertSingle<
     async (span) => {
       const schemaName = resolveSchema(options?.schema);
       const shouldValidate = options?.validate ?? true;
-      const schema = getValidationSchema(schemaName, table as string);
+      const schema = resolveValidationSchema(
+        schemaName,
+        table as string,
+        shouldValidate
+      );
+      if (schema instanceof Error) {
+        return failWithError(span, schema, { data: null });
+      }
       if (schema?.insert && shouldValidate) {
         try {
           schema.insert.parse(values);
@@ -751,14 +842,8 @@ export function upsertSingle<
         }
       }
 
-      const schemaClient = getFromClient(client, schemaName);
-      if (!schemaClient) {
-        return { data: null, error: new Error("from_unavailable") };
-      }
-      const base = schemaClient.from(table as string);
-      if (typeof base.upsert !== "function") {
-        return { data: null, error: new Error("upsert_unavailable") };
-      }
+      const base = getTableBuilder(client, schemaName, table, "upsert");
+      if (base instanceof Error) return { data: null, error: base };
       const upsertQb = base.upsert(values as unknown, {
         ignoreDuplicates: false,
         onConflict,
@@ -830,7 +915,14 @@ export function upsertMany<
         return { data: [], error: null };
       }
 
-      const schema = getValidationSchema(schemaName, table as string);
+      const schema = resolveValidationSchema(
+        schemaName,
+        table as string,
+        shouldValidate
+      );
+      if (schema instanceof Error) {
+        return failWithError(span, schema, { data: [] });
+      }
       if (schema?.insert && shouldValidate) {
         try {
           z.array(schema.insert).parse(values);
@@ -842,14 +934,8 @@ export function upsertMany<
         }
       }
 
-      const schemaClient = getFromClient(client, schemaName);
-      if (!schemaClient) {
-        return { data: [], error: new Error("from_unavailable") };
-      }
-      const base = schemaClient.from(table as string);
-      if (typeof base.upsert !== "function") {
-        return { data: [], error: new Error("upsert_unavailable") };
-      }
+      const base = getTableBuilder(client, schemaName, table, "upsert");
+      if (base instanceof Error) return { data: [], error: base };
       const upsertQb = base.upsert(values as unknown, {
         ignoreDuplicates: false,
         onConflict,
@@ -941,21 +1027,21 @@ export function getMany<
     },
     async (span) => {
       const schemaName = resolveSchema(options?.schema);
-      const schema = getValidationSchema(schemaName, table as string);
       const selectColumns = options?.select ?? "*";
       const shouldValidate = options?.validate ?? selectColumns === "*";
-
-      const schemaClient = getFromClient(client, schemaName);
-      if (!schemaClient) {
-        return { count: null, data: [], error: new Error("from_unavailable") };
+      const schema = resolveValidationSchema(
+        schemaName,
+        table as string,
+        shouldValidate
+      );
+      if (schema instanceof Error) {
+        return failWithError(span, schema, { count: null, data: [] });
       }
 
       // Build the initial query with optional count
       const selectOptions = options?.count ? { count: options.count } : undefined;
-      const base = schemaClient.from(table as string);
-      if (typeof base.select !== "function") {
-        return { count: null, data: [], error: new Error("select_unavailable") };
-      }
+      const base = getTableBuilder(client, schemaName, table, "select");
+      if (base instanceof Error) return { count: null, data: [], error: base };
       let qb = base.select(selectColumns, selectOptions);
 
       // Apply where clause
@@ -1054,8 +1140,15 @@ export function insertMany<
         return { data: [], error: null };
       }
 
+      const schema = resolveValidationSchema(
+        schemaName,
+        table as string,
+        shouldValidate
+      );
+      if (schema instanceof Error) {
+        return failWithError(span, schema, { data: [] });
+      }
       // Validate input if schema exists
-      const schema = getValidationSchema(schemaName, table as string);
       if (schema?.insert && shouldValidate) {
         try {
           for (const value of values) {
@@ -1069,14 +1162,8 @@ export function insertMany<
         }
       }
 
-      const schemaClient = getFromClient(client, schemaName);
-      if (!schemaClient) {
-        return { data: [], error: new Error("from_unavailable") };
-      }
-      const base = schemaClient.from(table as string);
-      if (typeof base.insert !== "function") {
-        return { data: [], error: new Error("insert_unavailable") };
-      }
+      const base = getTableBuilder(client, schemaName, table, "insert");
+      if (base instanceof Error) return { data: [], error: base };
       const insertQb = base.insert(values as unknown);
 
       // Chain select to return the inserted rows

--- a/src/lib/supabase/typed-helpers.ts
+++ b/src/lib/supabase/typed-helpers.ts
@@ -539,10 +539,10 @@ export function getSingle<
 type DeleteOptions<S extends SchemaName> = {
   schema?: S;
   count?: CountPreference | null;
-  limit?: number;
   returning?: "representation";
   select?: string;
 };
+type DeleteRowsOptions<S extends SchemaName> = DeleteOptions<S> & { limit?: number };
 
 const multiRowDeleteError = (count: number): Error | null =>
   count > 1 ? new Error("delete_single_matched_multiple_rows") : null;
@@ -554,7 +554,7 @@ const deleteRows = async <
   client: TypedClient,
   table: T,
   where: (qb: TableFilterBuilder) => TableFilterBuilder,
-  options?: DeleteOptions<S>
+  options?: DeleteRowsOptions<S>
 ): Promise<{ count: number; error: unknown | null }> =>
   withTelemetrySpan(
     "supabase.delete",
@@ -601,7 +601,7 @@ const countDeleteCandidates = async <
   client: TypedClient,
   table: T,
   where: (qb: TableFilterBuilder) => TableFilterBuilder,
-  options?: DeleteOptions<S>
+  options?: Pick<DeleteOptions<S>, "schema">
 ): Promise<{ count: number; error: unknown | null }> =>
   withTelemetrySpan(
     "supabase.delete.preflight",
@@ -618,8 +618,7 @@ const countDeleteCandidates = async <
       const base = getTableBuilder(client, schemaName, table, "select");
       if (base instanceof Error) return { count: 0, error: base };
 
-      const selectColumns = options?.select ?? "id";
-      const qb = where(base.select(selectColumns, { count: "exact" }).limit(2));
+      const qb = where(base.select("id", { count: "exact" }).limit(2));
       const { count, data, error } = await qb;
       if (error) return { count: 0, error };
 


### PR DESCRIPTION
Closes #741
Parent release ledger: #731

## Summary
- Removes the manual `SUPPORTED_TABLES` registry and treats generated Supabase types plus registered Zod schemas as the validation source of truth.
- Tightens the Supabase helper builder surface, centralizes table-builder availability checks, and keeps partial selects validation-disabled by contract.
- Splits `deleteSingle` and `deleteMany` semantics: single deletes reject no-count mode, preflight candidate count, cap the mutation with `limit(1)`, and surface multi-row delete results as errors; bulk/no-count cleanup now uses `deleteMany`.
- Updates attachment rollback and auth-session termination call sites, plus focused tests for unsupported validation, partial selects, and delete safety.

## Validation
- `pnpm exec vitest run src/lib/supabase/__tests__/typed-helpers.test.ts src/app/api/chat/attachments/__tests__/route.test.ts src/app/api/security/sessions/__tests__/routes.test.ts`
- `pnpm biome:fix`
- `pnpm type-check`
- `pnpm test:affected`
- `pnpm check:zod-v4`
- `pnpm check:api-route-errors`
- `pnpm check:api-route-errors:full`
- `pnpm check:no-new-unknown-casts`
- `pnpm check:no-secrets:full`
- `git diff --check`
- `pnpm build`

## Pre-PR Review Evidence
- Runtime reviewer found the initial post-delete multi-row edge; fixed with mutation `limit(1)` and regression coverage, then follow-up runtime review confirmed resolved with no new findings.
- Security reviewer found no exploitable authz bypass, accidental bulk-delete path, or data exposure in the changed flow.
- Bun/TypeScript reviewer found no blocking findings; noted the repo is pnpm-managed despite Bun audit warnings.

## Docs Impact
- No standalone docs changed. Helper JSDoc now reflects the narrowed delete and partial-select contracts.

## Provider / Deploy Notes
- No provider configuration or database migrations.
- Supabase behavior relies on `@supabase/postgrest-js` supporting `.limit()` on DELETE builders; verified against installed source.

## Screenshots
- Not applicable; backend/helper-only change.

## Residual Risks
- `deleteSingle` uses a select preflight plus a capped DELETE request, not a transactional database RPC. Concurrent matching-row changes can still race between requests, but the delete mutation is limited to one row and any reported multi-row delete result is returned as an error.
