### PR TITLE
refactor(search): consolidate client state lifecycles

### DIFF
--- a/src/app/(app)/dashboard/search/activities/activities-search-client.tsx
+++ b/src/app/(app)/dashboard/search/activities/activities-search-client.tsx
@@ -32,6 +32,10 @@ import { ActivityCard } from "@/features/search/components/cards/activity-card";
 import { ActivitySearchForm } from "@/features/search/components/forms/activity-search-form";
 import { ActivityComparisonModal } from "@/features/search/components/modals/activity-comparison-modal";
 import { TripSelectionModal } from "@/features/search/components/modals/trip-selection-modal";
+import {
+  isAbortError,
+  useAbortableSearchTask,
+} from "@/features/search/hooks/search/use-search-client-state";
 import { useSearchOrchestration } from "@/features/search/hooks/search/use-search-orchestration";
 import { useComparisonStore } from "@/features/search/store/comparison-store";
 import { useSearchResultsStore } from "@/features/search/store/search-results-store";
@@ -85,6 +89,7 @@ export default function ActivitiesSearchClient({
   const searchMetadata = useSearchResultsStore((state) => state.metrics);
   const primaryActionRef = useRef<HTMLButtonElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const { clearSearchController, startSearchController } = useAbortableSearchTask();
   const [pendingAddFromComparison, setPendingAddFromComparison] = useState(false);
   const [hasSearched, setHasSearched] = useState(false);
   const didInitFromUrlParams = useRef(false);
@@ -112,14 +117,6 @@ export default function ActivitiesSearchClient({
     initializeSearch("activity");
   }, [initializeSearch]);
 
-  const manualSearchController = useRef<AbortController | null>(null);
-  useEffect(() => {
-    return () => {
-      manualSearchController.current?.abort();
-      manualSearchController.current = null;
-    };
-  }, []);
-
   // Initialize search with URL parameters
   useEffect(() => {
     if (didInitFromUrlParams.current) return;
@@ -137,6 +134,7 @@ export default function ActivitiesSearchClient({
       (async () => {
         try {
           const normalizedParams = await onSubmitServer(initialParams);
+          if (controller.signal.aborted) return;
           if (!normalizedParams.ok) {
             toast({
               description: normalizedParams.error.reason,
@@ -150,10 +148,7 @@ export default function ActivitiesSearchClient({
           if (controller.signal.aborted) return;
           setHasSearched(true);
         } catch (error) {
-          if (
-            controller.signal.aborted ||
-            (error instanceof Error && error.name === "AbortError")
-          ) {
+          if (controller.signal.aborted || isAbortError(error)) {
             return;
           }
           const message = getErrorMessage(error);
@@ -171,11 +166,10 @@ export default function ActivitiesSearchClient({
   const handleSearch = useCallback(
     async (params: ActivitySearchParams) => {
       if (params.destination) {
-        manualSearchController.current?.abort();
-        const controller = new AbortController();
-        manualSearchController.current = controller;
+        const controller = startSearchController();
         try {
           const normalizedParams = await onSubmitServer(params); // server-side telemetry and validation
+          if (controller.signal.aborted) return;
           if (!normalizedParams.ok) {
             toast({
               description: normalizedParams.error.reason,
@@ -189,10 +183,7 @@ export default function ActivitiesSearchClient({
           if (controller.signal.aborted) return;
           setHasSearched(true);
         } catch (error) {
-          if (
-            controller.signal.aborted ||
-            (error instanceof Error && error.name === "AbortError")
-          ) {
+          if (controller.signal.aborted || isAbortError(error)) {
             return;
           }
           const message = getErrorMessage(error);
@@ -202,13 +193,11 @@ export default function ActivitiesSearchClient({
             variant: "destructive",
           });
         } finally {
-          if (manualSearchController.current === controller) {
-            manualSearchController.current = null;
-          }
+          clearSearchController(controller);
         }
       }
     },
-    [executeSearch, onSubmitServer, toast]
+    [clearSearchController, executeSearch, onSubmitServer, startSearchController, toast]
   );
 
   const handleAddToTripClick = useCallback(async () => {
@@ -431,7 +420,6 @@ export default function ActivitiesSearchClient({
     <SearchLayout>
       <TooltipProvider>
         <div className="space-y-6">
-          {/* Search Form Section */}
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             <div className="lg:col-span-1">
               <Card>
@@ -448,7 +436,6 @@ export default function ActivitiesSearchClient({
             </div>
 
             <div className="lg:col-span-2 space-y-4">
-              {/* Comparison Bar */}
               {comparisonList.size > 0 && (
                 <Card className="border-primary/50 bg-primary/5">
                   <CardContent className="py-4">
@@ -498,7 +485,6 @@ export default function ActivitiesSearchClient({
                 </Card>
               )}
 
-              {/* Loading State */}
               {isSearching && (
                 <Card>
                   <CardHeader>
@@ -516,7 +502,6 @@ export default function ActivitiesSearchClient({
                 </Card>
               )}
 
-              {/* Error State */}
               {searchError && (
                 <Alert variant="destructive">
                   <AlertCircleIcon aria-hidden="true" className="h-4 w-4" />
@@ -527,7 +512,6 @@ export default function ActivitiesSearchClient({
                 </Alert>
               )}
 
-              {/* Results */}
               {!isSearching && hasActiveResults && (
                 <div className="space-y-4">
                   <div className="flex items-center justify-between">
@@ -545,7 +529,6 @@ export default function ActivitiesSearchClient({
                     )}
                   </div>
 
-                  {/* Mixed Results (Verified + AI) */}
                   {verifiedActivities.length > 0 && (
                     <div className="space-y-6">
                       <div>
@@ -606,7 +589,6 @@ export default function ActivitiesSearchClient({
                     </div>
                   )}
 
-                  {/* Standard Results */}
                   {verifiedActivities.length === 0 && (
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                       {allAi && (
@@ -631,7 +613,6 @@ export default function ActivitiesSearchClient({
                 </div>
               )}
 
-              {/* Empty State */}
               {!isSearching && !hasActiveResults && !searchError && hasSearched && (
                 <Card>
                   <CardContent className="text-center py-12">
@@ -654,7 +635,6 @@ export default function ActivitiesSearchClient({
                 </Card>
               )}
 
-              {/* Initial State */}
               {!isSearching && !hasSearched && !searchError && (
                 <Card className="bg-muted/50">
                   <CardContent className="text-center py-12">
@@ -681,7 +661,6 @@ export default function ActivitiesSearchClient({
             </div>
           </div>
 
-          {/* Floating Compare Button */}
           {comparisonList.size > 0 && (
             <div className="fixed bottom-6 right-6 z-40">
               <Tooltip>
@@ -705,7 +684,6 @@ export default function ActivitiesSearchClient({
             </div>
           )}
 
-          {/* Comparison Modal */}
           <ActivityComparisonModal
             isOpen={showComparisonModal}
             onClose={() => setShowComparisonModal(false)}
@@ -725,7 +703,6 @@ export default function ActivitiesSearchClient({
             closeButtonRef={closeButtonRef}
           />
 
-          {/* Trip Selection Modal */}
           {selectedActivity && isTripModalOpen && (
             <TripSelectionModal
               isOpen={isTripModalOpen}

--- a/src/app/(app)/dashboard/search/destinations/destinations-search-client.tsx
+++ b/src/app/(app)/dashboard/search/destinations/destinations-search-client.tsx
@@ -13,7 +13,7 @@ import {
   XIcon,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import { SearchLayout } from "@/components/layouts/search-layout";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -31,6 +31,10 @@ import { DestinationCard } from "@/features/search/components/cards/destination-
 import { DestinationSearchForm } from "@/features/search/components/forms/destination-search-form";
 import type { DestinationResult } from "@/features/search/hooks/search/use-destination-search";
 import { useDestinationSearch } from "@/features/search/hooks/search/use-destination-search";
+import {
+  isAbortError,
+  useAbortableSearchTask,
+} from "@/features/search/hooks/search/use-search-client-state";
 import { useSearchOrchestration } from "@/features/search/hooks/search/use-search-orchestration";
 import { getErrorMessage } from "@/lib/api/error-types";
 import type { Result, ResultError } from "@/lib/result";
@@ -56,14 +60,7 @@ export default function DestinationsSearchClient({
   const { searchDestinations, isSearching, searchError, resetSearch, results } =
     useDestinationSearch();
   const { toast } = useToast();
-  const currentSearchController = useRef<AbortController | null>(null);
-
-  useEffect(() => {
-    return () => {
-      currentSearchController.current?.abort();
-      currentSearchController.current = null;
-    };
-  }, []);
+  const { clearSearchController, startSearchController } = useAbortableSearchTask();
 
   const [selectedDestinations, setSelectedDestinations] = useState<Destination[]>([]);
   const [showComparisonModal, setShowComparisonModal] = useState(false);
@@ -75,11 +72,10 @@ export default function DestinationsSearchClient({
   /** Handles the search for destinations. */
   const handleSearch = useCallback(
     async (params: DestinationSearchParams) => {
-      currentSearchController.current?.abort();
-      const controller = new AbortController();
-      currentSearchController.current = controller;
+      const controller = startSearchController();
       try {
         const normalized = await onSubmitServer(params); // server-side telemetry and validation
+        if (controller.signal.aborted) return;
         if (!normalized.ok) {
           toast({
             description:
@@ -95,10 +91,7 @@ export default function DestinationsSearchClient({
         await searchDestinations(normalized.data, controller.signal); // client fetch/store update
         if (controller.signal.aborted) return;
       } catch (error) {
-        if (
-          controller.signal.aborted ||
-          (error instanceof Error && error.name === "AbortError")
-        ) {
+        if (controller.signal.aborted || isAbortError(error)) {
           return;
         }
         const normalizedError =
@@ -115,15 +108,19 @@ export default function DestinationsSearchClient({
           variant: "destructive",
         });
       } finally {
-        if (currentSearchController.current === controller) {
-          currentSearchController.current = null;
-        }
+        clearSearchController(controller);
         if (!controller.signal.aborted) {
           setHasSearched(true);
         }
       }
     },
-    [onSubmitServer, searchDestinations, toast]
+    [
+      clearSearchController,
+      onSubmitServer,
+      searchDestinations,
+      startSearchController,
+      toast,
+    ]
   );
 
   /** Handles the selection of a destination. */
@@ -240,7 +237,6 @@ export default function DestinationsSearchClient({
     <SearchLayout>
       <TooltipProvider>
         <div className="space-y-6">
-          {/* Search Form Card */}
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
@@ -253,7 +249,6 @@ export default function DestinationsSearchClient({
             </CardContent>
           </Card>
 
-          {/* Comparison Bar */}
           {selectedDestinations.length > 0 && (
             <Card className="border-primary/50 bg-primary/5">
               <CardHeader className="pb-3">
@@ -305,7 +300,6 @@ export default function DestinationsSearchClient({
             </Card>
           )}
 
-          {/* Loading State */}
           {isLoading && (
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
               {["sk-1", "sk-2", "sk-3", "sk-4", "sk-5", "sk-6"].map((id) => (
@@ -316,7 +310,6 @@ export default function DestinationsSearchClient({
             </div>
           )}
 
-          {/* Error State */}
           {searchError && (
             <Alert variant="destructive">
               <AlertCircleIcon aria-hidden="true" className="h-4 w-4" />
@@ -330,7 +323,6 @@ export default function DestinationsSearchClient({
             </Alert>
           )}
 
-          {/* Empty State */}
           {!isLoading && hasSearched && !hasActiveResults && !searchError && (
             <Card>
               <CardContent className="text-center py-12">
@@ -356,7 +348,6 @@ export default function DestinationsSearchClient({
             </Card>
           )}
 
-          {/* Results Grid */}
           {!isLoading && !searchError && hasActiveResults && (
             <div className="space-y-4">
               <div className="flex items-center justify-between">
@@ -385,7 +376,6 @@ export default function DestinationsSearchClient({
             </div>
           )}
 
-          {/* Initial State */}
           {!isLoading && !hasSearched && !searchError && (
             <Card className="bg-muted/50">
               <CardContent className="text-center py-12">
@@ -407,7 +397,6 @@ export default function DestinationsSearchClient({
             </Card>
           )}
 
-          {/* Floating Compare Button */}
           {selectedDestinations.length > 0 && (
             <div className="fixed bottom-6 right-6 z-40">
               <Tooltip>
@@ -431,7 +420,6 @@ export default function DestinationsSearchClient({
             </div>
           )}
 
-          {/* Comparison Modal */}
           <DestinationComparisonModal
             isOpen={showComparisonModal}
             onClose={handleCloseComparisonModal}

--- a/src/app/(app)/dashboard/search/flights/flights-search-client.tsx
+++ b/src/app/(app)/dashboard/search/flights/flights-search-client.tsx
@@ -38,6 +38,10 @@ import { buildFlightApiPayload } from "@/features/search/components/filters/api-
 import { FilterPanel } from "@/features/search/components/filters/filter-panel";
 import { FilterPresets } from "@/features/search/components/filters/filter-presets";
 import { FlightSearchForm } from "@/features/search/components/forms/flight-search-form";
+import {
+  isAbortError,
+  useAbortableSearchTask,
+} from "@/features/search/hooks/search/use-search-client-state";
 import { useSearchOrchestration } from "@/features/search/hooks/search/use-search-orchestration";
 import { useSearchFiltersStore } from "@/features/search/store/search-filters-store";
 import { getErrorMessage } from "@/lib/api/error-types";
@@ -117,7 +121,7 @@ export default function FlightsSearchClient({
   const router = useRouter();
   const { toast } = useToast();
   const activeFilters = useSearchFiltersStore((s) => s.activeFilters);
-  const currentSearchController = React.useRef<AbortController | null>(null);
+  const { clearSearchController, startSearchController } = useAbortableSearchTask();
   const didInitFromUrlParams = React.useRef(false);
   const {
     data: popularRoutes = [],
@@ -135,13 +139,6 @@ export default function FlightsSearchClient({
     queryKey: keys.flights.popularRoutes(),
     staleTime: 60 * 60 * 1000, // 1 hour
   });
-
-  React.useEffect(() => {
-    return () => {
-      currentSearchController.current?.abort();
-      currentSearchController.current = null;
-    };
-  }, []);
 
   React.useEffect(() => {
     initializeSearch("flight");
@@ -191,7 +188,7 @@ export default function FlightsSearchClient({
         })
         .catch((error) => {
           if (controller.signal.aborted) return;
-          if (error instanceof Error && error.name === "AbortError") return;
+          if (isAbortError(error)) return;
           toast({
             description: getErrorMessage(error),
             title: "Search Failed",
@@ -204,9 +201,7 @@ export default function FlightsSearchClient({
   }, [executeSearch, initialUrlParams, onSubmitServer, toast]);
 
   const handleSearch = async (params: FlightSearchParams) => {
-    currentSearchController.current?.abort();
-    const controller = new AbortController();
-    currentSearchController.current = controller;
+    const controller = startSearchController();
     try {
       // Merge form params with active filter payload
       const filterPayload = buildFlightApiPayload(activeFilters);
@@ -236,16 +231,14 @@ export default function FlightsSearchClient({
       }
     } catch (error) {
       if (controller.signal.aborted) return;
-      if (error instanceof Error && error.name === "AbortError") return;
+      if (isAbortError(error)) return;
       toast({
         description: getErrorMessage(error),
         title: "Search Failed",
         variant: "destructive",
       });
     } finally {
-      if (currentSearchController.current === controller) {
-        currentSearchController.current = null;
-      }
+      clearSearchController(controller);
     }
   };
 
@@ -253,9 +246,7 @@ export default function FlightsSearchClient({
     <SearchLayout>
       <TooltipProvider>
         <div className="grid gap-6 lg:grid-cols-4">
-          {/* Main content - 3 columns */}
           <div className="lg:col-span-3 space-y-6">
-            {/* Search Form */}
             <Card>
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
@@ -271,7 +262,6 @@ export default function FlightsSearchClient({
               </CardContent>
             </Card>
 
-            {/* Popular Routes */}
             <Card>
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
@@ -310,7 +300,6 @@ export default function FlightsSearchClient({
               </CardContent>
             </Card>
 
-            {/* Travel Tips */}
             <Card>
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
@@ -347,7 +336,6 @@ export default function FlightsSearchClient({
             </Card>
           </div>
 
-          {/* Sidebar - 1 column */}
           <div className="space-y-6">
             <FilterPanel />
             <FilterPresets />

--- a/src/app/(app)/dashboard/search/hotels/hotels-search-client.tsx
+++ b/src/app/(app)/dashboard/search/hotels/hotels-search-client.tsx
@@ -43,6 +43,7 @@ import { FilterPanel } from "@/features/search/components/filters/filter-panel";
 import { HotelSearchForm } from "@/features/search/components/forms/hotel-search-form";
 import { HotelResults } from "@/features/search/components/results/hotel-results";
 import {
+  HOTEL_WISHLIST_STORAGE_KEY,
   isAbortError,
   toggleStringSetValue,
   useAbortableSearchTask,
@@ -86,7 +87,7 @@ export default function HotelsSearchClient({
   const filterPanelRef = useRef<HTMLDivElement | null>(null);
   const [selectedHotel, setSelectedHotel] = useState<HotelResult | null>(null);
   const [wishlistHotelIds, setWishlistHotelIds] = usePersistentStringSet(
-    "hotelsSearch:wishlistHotels"
+    HOTEL_WISHLIST_STORAGE_KEY
   );
   const [isWishlistUpdating, setIsWishlistUpdating] = useState(false);
   const [popularDestinations, setPopularDestinations] = useState<

--- a/src/app/(app)/dashboard/search/hotels/hotels-search-client.tsx
+++ b/src/app/(app)/dashboard/search/hotels/hotels-search-client.tsx
@@ -42,6 +42,12 @@ import { buildHotelApiPayload } from "@/features/search/components/filters/api-p
 import { FilterPanel } from "@/features/search/components/filters/filter-panel";
 import { HotelSearchForm } from "@/features/search/components/forms/hotel-search-form";
 import { HotelResults } from "@/features/search/components/results/hotel-results";
+import {
+  isAbortError,
+  toggleStringSetValue,
+  useAbortableSearchTask,
+  usePersistentStringSet,
+} from "@/features/search/hooks/search/use-search-client-state";
 import { useSearchOrchestration } from "@/features/search/hooks/search/use-search-orchestration";
 import { useSearchFiltersStore } from "@/features/search/store/search-filters-store";
 import { useSearchResultsStore } from "@/features/search/store/search-results-store";
@@ -76,10 +82,12 @@ export default function HotelsSearchClient({
   const { toast } = useToast();
   const [hasSearched, setHasSearched] = useState(false);
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
-  const currentSearchController = useRef<AbortController | null>(null);
+  const { clearSearchController, startSearchController } = useAbortableSearchTask();
   const filterPanelRef = useRef<HTMLDivElement | null>(null);
   const [selectedHotel, setSelectedHotel] = useState<HotelResult | null>(null);
-  const [wishlistHotelIds, setWishlistHotelIds] = useState<Set<string>>(new Set());
+  const [wishlistHotelIds, setWishlistHotelIds] = usePersistentStringSet(
+    "hotelsSearch:wishlistHotels"
+  );
   const [isWishlistUpdating, setIsWishlistUpdating] = useState(false);
   const [popularDestinations, setPopularDestinations] = useState<
     PopularDestinationProps[]
@@ -94,26 +102,6 @@ export default function HotelsSearchClient({
   useEffect(() => {
     initializeSearch("accommodation");
   }, [initializeSearch]);
-
-  useEffect(() => {
-    return () => {
-      currentSearchController.current?.abort();
-      currentSearchController.current = null;
-    };
-  }, []);
-
-  useEffect(() => {
-    try {
-      const stored = window.localStorage.getItem("hotelsSearch:wishlistHotels");
-      if (!stored) return;
-      const parsed: unknown = JSON.parse(stored);
-      if (Array.isArray(parsed) && parsed.every((value) => typeof value === "string")) {
-        setWishlistHotelIds(new Set(parsed));
-      }
-    } catch {
-      // ignore
-    }
-  }, []);
 
   useEffect(() => {
     const cached = readCachedPopularDestinations(window.sessionStorage, Date.now());
@@ -133,19 +121,18 @@ export default function HotelsSearchClient({
         const body: unknown = await res.json();
         const mapped = mapPopularDestinationsFromApiResponse(body);
 
-        if (mapped.length > 0) {
+        if (!controller.signal.aborted && mapped.length > 0) {
           setPopularDestinations(mapped);
           writeCachedPopularDestinations(window.sessionStorage, Date.now(), mapped);
         }
       } catch (error) {
-        if (
-          controller.signal.aborted ||
-          (error instanceof Error && error.name === "AbortError")
-        ) {
+        if (controller.signal.aborted || isAbortError(error)) {
           return;
         }
       } finally {
-        setIsPopularDestinationsLoading(false);
+        if (!controller.signal.aborted) {
+          setIsPopularDestinationsLoading(false);
+        }
       }
     })();
 
@@ -186,26 +173,15 @@ export default function HotelsSearchClient({
     if (isWishlistUpdating) return;
     setIsWishlistUpdating(true);
     try {
-      const next = new Set(wishlistHotelIds);
-      const wasSaved = next.has(hotelId);
-      if (wasSaved) {
-        next.delete(hotelId);
-      } else {
-        next.add(hotelId);
-      }
-
-      setWishlistHotelIds(next);
-      try {
-        window.localStorage.setItem(
-          "hotelsSearch:wishlistHotels",
-          JSON.stringify([...next])
-        );
-      } catch {
-        // ignore
-      }
+      let wasPresent = false;
+      setWishlistHotelIds((currentValues) => {
+        const toggled = toggleStringSetValue(currentValues, hotelId);
+        wasPresent = toggled.wasPresent;
+        return toggled.nextValues;
+      });
 
       toast({
-        description: wasSaved ? `Removed hotel ${hotelId}` : `Saved hotel ${hotelId}`,
+        description: wasPresent ? `Removed hotel ${hotelId}` : `Saved hotel ${hotelId}`,
         title: "Wishlist updated",
       });
     } catch (error) {
@@ -233,9 +209,7 @@ export default function HotelsSearchClient({
   };
 
   const handleSearch = async (params: SearchAccommodationParams) => {
-    currentSearchController.current?.abort();
-    const controller = new AbortController();
-    currentSearchController.current = controller;
+    const controller = startSearchController();
     try {
       // Merge form params with active filter payload
       const filterPayload = buildHotelApiPayload(activeFilters);
@@ -258,7 +232,7 @@ export default function HotelsSearchClient({
       if (controller.signal.aborted) return;
       setHasSearched(true);
     } catch (error) {
-      if (error instanceof Error && error.name === "AbortError") {
+      if (controller.signal.aborted || isAbortError(error)) {
         return;
       }
       toast({
@@ -267,9 +241,7 @@ export default function HotelsSearchClient({
         variant: "destructive",
       });
     } finally {
-      if (currentSearchController.current === controller) {
-        currentSearchController.current = null;
-      }
+      clearSearchController(controller);
     }
   };
 
@@ -313,9 +285,7 @@ export default function HotelsSearchClient({
         </Dialog>
 
         <div className="grid gap-6 lg:grid-cols-4">
-          {/* Main content - 3 columns */}
           <div className="lg:col-span-3 space-y-6">
-            {/* Search Form */}
             <Card>
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
@@ -331,7 +301,6 @@ export default function HotelsSearchClient({
               </CardContent>
             </Card>
 
-            {/* Error State */}
             {searchError && (
               <Alert variant="destructive">
                 <AlertCircleIcon aria-hidden="true" className="h-4 w-4" />
@@ -342,7 +311,6 @@ export default function HotelsSearchClient({
               </Alert>
             )}
 
-            {/* Loading State */}
             {isSearching && (
               <Card>
                 <CardHeader>
@@ -366,7 +334,6 @@ export default function HotelsSearchClient({
               </Card>
             )}
 
-            {/* Results State */}
             {hasSearched && !isSearching && hasAccommodationResults && (
               <div className="space-y-6">
                 <div className="flex justify-between items-center flex-wrap gap-4">
@@ -408,7 +375,6 @@ export default function HotelsSearchClient({
               </div>
             )}
 
-            {/* Initial State - Popular Destinations & Tips */}
             {!hasSearched && !isSearching && (
               <HotelsEmptyState
                 baseCurrency={baseCurrency}
@@ -417,7 +383,6 @@ export default function HotelsSearchClient({
               />
             )}
 
-            {/* Empty State */}
             {hasSearched &&
               !isSearching &&
               !hasAccommodationResults &&
@@ -448,7 +413,6 @@ export default function HotelsSearchClient({
               )}
           </div>
 
-          {/* Sidebar - 1 column */}
           <div className="space-y-6" data-testid="filter-panel" ref={filterPanelRef}>
             <FilterPanel />
           </div>

--- a/src/app/(app)/dashboard/search/unified/__tests__/unified-search-client.test.tsx
+++ b/src/app/(app)/dashboard/search/unified/__tests__/unified-search-client.test.tsx
@@ -1,0 +1,217 @@
+/** @vitest-environment jsdom */
+
+import type {
+  FlightResult,
+  FlightSearchFormData,
+  HotelResult,
+  HotelSearchFormData,
+} from "@schemas/search";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Result, ResultError } from "@/lib/result";
+import { MOCK_HOTEL_RESULTS } from "@/mocks/unified-search-mocks";
+import UnifiedSearchClient from "../unified-search-client";
+
+const mockToast = vi.hoisted(() => vi.fn());
+
+vi.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock("@/components/layouts/search-layout", () => ({
+  SearchLayout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="search-layout">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/ui/tabs", async () => {
+  const ReactModule = await import("react");
+  type TabsContextValue = {
+    onValueChange: (value: string) => void;
+    value: string;
+  };
+  const TabsContext = ReactModule.createContext<TabsContextValue>({
+    onValueChange: () => undefined,
+    value: "",
+  });
+
+  return {
+    Tabs: ({
+      children,
+      onValueChange,
+      value,
+    }: {
+      children: React.ReactNode;
+      onValueChange: (value: string) => void;
+      value: string;
+    }) => (
+      <TabsContext.Provider value={{ onValueChange, value }}>
+        <div>{children}</div>
+      </TabsContext.Provider>
+    ),
+    TabsContent: ({
+      children,
+      value,
+    }: {
+      children: React.ReactNode;
+      value: string;
+    }) => {
+      const context = ReactModule.useContext(TabsContext);
+      return context.value === value ? <div role="tabpanel">{children}</div> : null;
+    },
+    TabsList: ({ children }: { children: React.ReactNode }) => (
+      <div role="tablist">{children}</div>
+    ),
+    TabsTrigger: ({
+      children,
+      value,
+    }: {
+      children: React.ReactNode;
+      value: string;
+    }) => {
+      const context = ReactModule.useContext(TabsContext);
+      return (
+        <button
+          aria-selected={context.value === value}
+          onClick={() => context.onValueChange(value)}
+          role="tab"
+          type="button"
+        >
+          {children}
+        </button>
+      );
+    },
+  };
+});
+
+vi.mock("@/features/search/components/forms/flight-search-form", () => ({
+  FlightSearchForm: ({
+    onSearch,
+  }: {
+    onSearch: (params: FlightSearchFormData) => Promise<void> | void;
+  }) => (
+    <button
+      type="button"
+      onClick={() => {
+        onSearch({
+          cabinClass: "economy",
+          departureDate: "2026-06-01",
+          destination: "LAX",
+          directOnly: false,
+          origin: "JFK",
+          passengers: { adults: 1, children: 0, infants: 0 },
+          returnDate: "2026-06-05",
+          tripType: "round-trip",
+        });
+      }}
+    >
+      Run Flight Search
+    </button>
+  ),
+}));
+
+vi.mock("@/features/search/components/forms/hotel-search-form", () => ({
+  HotelSearchForm: ({
+    onSearch,
+  }: {
+    onSearch: (params: HotelSearchFormData) => Promise<void> | void;
+  }) => (
+    <button
+      type="button"
+      onClick={() => {
+        onSearch({
+          adults: 2,
+          amenities: [],
+          checkIn: "2026-06-01",
+          checkOut: "2026-06-05",
+          children: 0,
+          location: "Paris",
+          priceRange: { max: 1000, min: 0 },
+          rating: 0,
+          rooms: 1,
+        });
+      }}
+    >
+      Run Hotel Search
+    </button>
+  ),
+}));
+
+vi.mock("@/features/search/components/results/flight-results", () => ({
+  FlightResults: ({ results }: { results: FlightResult[] }) => (
+    <div data-testid="flight-results">
+      {results.map((flight) => (
+        <span key={flight.id}>{flight.airline}</span>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("@/features/search/components/results/hotel-results", () => ({
+  HotelResults: ({ results }: { results: HotelResult[] }) => (
+    <div data-testid="hotel-results">
+      {results.map((hotel) => (
+        <span key={hotel.id}>{hotel.name}</span>
+      ))}
+    </div>
+  ),
+}));
+
+type HotelSearchResult = Result<HotelResult[], ResultError>;
+
+function createDeferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((resolver) => {
+    resolve = resolver;
+  });
+  return { promise, resolve };
+}
+
+describe("UnifiedSearchClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("ignores stale hotel results after a newer search starts", async () => {
+    const staleSearch = createDeferred<HotelSearchResult>();
+    const latestSearch = createDeferred<HotelSearchResult>();
+    const onSearchHotels = vi
+      .fn<
+        (
+          params: HotelSearchFormData,
+          signal?: AbortSignal
+        ) => Promise<HotelSearchResult>
+      >()
+      .mockReturnValueOnce(staleSearch.promise)
+      .mockReturnValueOnce(latestSearch.promise);
+
+    render(<UnifiedSearchClient onSearchHotels={onSearchHotels} />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Hotels" }));
+    const searchButton = screen.getByRole("button", { name: "Run Hotel Search" });
+    fireEvent.click(searchButton);
+    fireEvent.click(searchButton);
+
+    await act(async () => {
+      latestSearch.resolve({
+        data: [{ ...MOCK_HOTEL_RESULTS[1], name: "Latest Hotel" }],
+        ok: true,
+      });
+      await latestSearch.promise;
+    });
+
+    await waitFor(() => expect(screen.getByText("Latest Hotel")).toBeInTheDocument());
+
+    await act(async () => {
+      staleSearch.resolve({
+        data: [{ ...MOCK_HOTEL_RESULTS[0], name: "Stale Hotel" }],
+        ok: true,
+      });
+      await staleSearch.promise;
+    });
+
+    expect(screen.getByText("Latest Hotel")).toBeInTheDocument();
+    expect(screen.queryByText("Stale Hotel")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/dashboard/search/unified/unified-search-client.tsx
+++ b/src/app/(app)/dashboard/search/unified/unified-search-client.tsx
@@ -24,7 +24,7 @@ import {
   ZapIcon,
 } from "lucide-react";
 import Link from "next/link";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { type ReactNode, useState } from "react";
 import { SearchLayout } from "@/components/layouts/search-layout";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -44,6 +44,12 @@ import { FlightSearchForm } from "@/features/search/components/forms/flight-sear
 import { HotelSearchForm } from "@/features/search/components/forms/hotel-search-form";
 import { FlightResults } from "@/features/search/components/results/flight-results";
 import { HotelResults } from "@/features/search/components/results/hotel-results";
+import {
+  isAbortError,
+  toggleStringSetValue,
+  useAbortableSearchTask,
+  usePersistentStringSet,
+} from "@/features/search/hooks/search/use-search-client-state";
 import { getErrorMessage } from "@/lib/api/error-types";
 import type { Result, ResultError } from "@/lib/result";
 import { ROUTES } from "@/lib/routes";
@@ -75,37 +81,14 @@ export default function UnifiedSearchClient({
   const [selectedHotel, setSelectedHotel] = useState<HotelResult | null>(null);
   const [comparisonFlights, setComparisonFlights] = useState<FlightResult[]>([]);
   const [isComparisonOpen, setIsComparisonOpen] = useState(false);
-  const [wishlistHotelIds, setWishlistHotelIds] = useState<Set<string>>(new Set());
+  const [wishlistHotelIds, setWishlistHotelIds] = usePersistentStringSet(
+    "unifiedSearch:wishlistHotels"
+  );
   const { toast } = useToast();
-  const currentSearchController = useRef<AbortController | null>(null);
-
-  useEffect(() => {
-    return () => {
-      currentSearchController.current?.abort();
-      currentSearchController.current = null;
-    };
-  }, []);
-
-  useEffect(() => {
-    try {
-      const stored = window.localStorage.getItem("unifiedSearch:wishlistHotels");
-      if (!stored) return;
-      const parsed: unknown = JSON.parse(stored);
-      if (Array.isArray(parsed) && parsed.every((value) => typeof value === "string")) {
-        setWishlistHotelIds(new Set(parsed));
-      }
-    } catch {
-      // ignore
-    }
-  }, []);
-
-  const isAbortError = (error: unknown): boolean =>
-    error instanceof Error && error.name === "AbortError";
+  const { clearSearchController, startSearchController } = useAbortableSearchTask();
 
   const handleFlightSearch = async (params: FlightSearchFormData): Promise<void> => {
-    currentSearchController.current?.abort();
-    const controller = new AbortController();
-    currentSearchController.current = controller;
+    const controller = startSearchController();
     setIsSearching(true);
     setErrorMessage(null);
     try {
@@ -113,11 +96,12 @@ export default function UnifiedSearchClient({
         throw new Error("Flight search is not implemented yet.");
       }
       const results = await onSearchFlights(params, controller.signal);
+      if (controller.signal.aborted) return;
       setFlightResults(results);
       setLastUpdated(new Date());
       setShowResults(true);
     } catch (error) {
-      if (isAbortError(error)) {
+      if (controller.signal.aborted || isAbortError(error)) {
         return;
       }
       const message =
@@ -132,8 +116,8 @@ export default function UnifiedSearchClient({
         variant: "destructive",
       });
     } finally {
-      if (currentSearchController.current === controller) {
-        currentSearchController.current = null;
+      clearSearchController(controller);
+      if (!controller.signal.aborted) {
         setIsSearching(false);
       }
     }
@@ -150,13 +134,12 @@ export default function UnifiedSearchClient({
   };
 
   const handleHotelSearch = async (params: HotelSearchFormData): Promise<void> => {
-    currentSearchController.current?.abort();
-    const controller = new AbortController();
-    currentSearchController.current = controller;
+    const controller = startSearchController();
     setIsSearching(true);
     setErrorMessage(null);
     try {
       const results = await onSearchHotels(params, controller.signal);
+      if (controller.signal.aborted) return;
       if (!results.ok) {
         setHotelResults([]);
         setLastUpdated(null);
@@ -175,7 +158,7 @@ export default function UnifiedSearchClient({
       setLastUpdated(new Date());
       setShowResults(true);
     } catch (error) {
-      if (isAbortError(error)) {
+      if (controller.signal.aborted || isAbortError(error)) {
         return;
       }
       setHotelResults([]);
@@ -189,8 +172,8 @@ export default function UnifiedSearchClient({
         variant: "destructive",
       });
     } finally {
-      if (currentSearchController.current === controller) {
-        currentSearchController.current = null;
+      clearSearchController(controller);
+      if (!controller.signal.aborted) {
         setIsSearching(false);
       }
     }
@@ -220,28 +203,14 @@ export default function UnifiedSearchClient({
   };
 
   const handleSaveToWishlist = (hotelId: string) => {
-    let isNowSaved = false;
-    setWishlistHotelIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(hotelId)) {
-        next.delete(hotelId);
-        isNowSaved = false;
-      } else {
-        next.add(hotelId);
-        isNowSaved = true;
-      }
-      try {
-        window.localStorage.setItem(
-          "unifiedSearch:wishlistHotels",
-          JSON.stringify([...next])
-        );
-      } catch {
-        // ignore
-      }
-      return next;
+    let wasPresent = false;
+    setWishlistHotelIds((currentValues) => {
+      const toggled = toggleStringSetValue(currentValues, hotelId);
+      wasPresent = toggled.wasPresent;
+      return toggled.nextValues;
     });
     toast({
-      description: isNowSaved ? "Saved to wishlist" : "Removed from wishlist",
+      description: wasPresent ? "Removed from wishlist" : "Saved to wishlist",
       title: "Wishlist updated",
     });
   };
@@ -383,7 +352,6 @@ export default function UnifiedSearchClient({
           </DialogContent>
         </Dialog>
 
-        {/* Hero Section */}
         <Card className="bg-linear-to-r from-info/10 to-success/10 border-none">
           <CardContent className="p-8">
             <div className="text-center space-y-4">
@@ -430,7 +398,6 @@ export default function UnifiedSearchClient({
           </div>
         ) : null}
 
-        {/* Search Interface */}
         <Tabs
           value={activeTab}
           onValueChange={(value) => setActiveTab(value as "flights" | "hotels")}
@@ -506,7 +473,6 @@ export default function UnifiedSearchClient({
           </div>
         </Tabs>
 
-        {/* Features Showcase */}
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
@@ -550,7 +516,6 @@ export default function UnifiedSearchClient({
           </CardContent>
         </Card>
 
-        {/* Implementation Notes */}
         <Card className="bg-muted/50">
           <CardHeader>
             <CardTitle>Implementation Highlights</CardTitle>

--- a/src/app/(app)/dashboard/search/unified/unified-search-client.tsx
+++ b/src/app/(app)/dashboard/search/unified/unified-search-client.tsx
@@ -45,6 +45,7 @@ import { HotelSearchForm } from "@/features/search/components/forms/hotel-search
 import { FlightResults } from "@/features/search/components/results/flight-results";
 import { HotelResults } from "@/features/search/components/results/hotel-results";
 import {
+  HOTEL_WISHLIST_STORAGE_KEY,
   isAbortError,
   toggleStringSetValue,
   useAbortableSearchTask,
@@ -82,7 +83,7 @@ export default function UnifiedSearchClient({
   const [comparisonFlights, setComparisonFlights] = useState<FlightResult[]>([]);
   const [isComparisonOpen, setIsComparisonOpen] = useState(false);
   const [wishlistHotelIds, setWishlistHotelIds] = usePersistentStringSet(
-    "unifiedSearch:wishlistHotels"
+    HOTEL_WISHLIST_STORAGE_KEY
   );
   const { toast } = useToast();
   const { clearSearchController, startSearchController } = useAbortableSearchTask();

--- a/src/features/search/hooks/search/__tests__/use-search-client-state.test.ts
+++ b/src/features/search/hooks/search/__tests__/use-search-client-state.test.ts
@@ -17,8 +17,11 @@ describe("search client state helpers", () => {
   it("detects abort errors", () => {
     const abortError = new Error("cancelled");
     abortError.name = "AbortError";
+    const abortException = new DOMException("cancelled", "AbortError");
 
     expect(isAbortError(abortError)).toBe(true);
+    expect(isAbortError(abortException)).toBe(true);
+    expect(isAbortError({ name: "AbortError" })).toBe(true);
     expect(isAbortError(new Error("other"))).toBe(false);
     expect(isAbortError("AbortError")).toBe(false);
   });

--- a/src/features/search/hooks/search/__tests__/use-search-client-state.test.ts
+++ b/src/features/search/hooks/search/__tests__/use-search-client-state.test.ts
@@ -1,0 +1,102 @@
+/** @vitest-environment jsdom */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  isAbortError,
+  toggleStringSetValue,
+  useAbortableSearchTask,
+  usePersistentStringSet,
+} from "../use-search-client-state";
+
+describe("search client state helpers", () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("detects abort errors", () => {
+    const abortError = new Error("cancelled");
+    abortError.name = "AbortError";
+
+    expect(isAbortError(abortError)).toBe(true);
+    expect(isAbortError(new Error("other"))).toBe(false);
+    expect(isAbortError("AbortError")).toBe(false);
+  });
+
+  it("aborts the previous search task and cleans up the active task on unmount", () => {
+    const { result, unmount } = renderHook(() => useAbortableSearchTask());
+
+    const firstController = result.current.startSearchController();
+    expect(firstController.signal.aborted).toBe(false);
+
+    const secondController = result.current.startSearchController();
+    expect(firstController.signal.aborted).toBe(true);
+    expect(secondController.signal.aborted).toBe(false);
+
+    result.current.clearSearchController(firstController);
+    unmount();
+
+    expect(secondController.signal.aborted).toBe(true);
+  });
+
+  it("loads and persists string sets", async () => {
+    window.localStorage.setItem("search:test", JSON.stringify(["hotel-1"]));
+
+    const { result } = renderHook(() => usePersistentStringSet("search:test"));
+
+    await waitFor(() => expect(result.current[0].has("hotel-1")).toBe(true));
+
+    act(() => {
+      result.current[1](new Set(["hotel-2", "hotel-3"]));
+    });
+
+    expect(result.current[0]).toEqual(new Set(["hotel-2", "hotel-3"]));
+    expect(window.localStorage.getItem("search:test")).toBe(
+      JSON.stringify(["hotel-2", "hotel-3"])
+    );
+  });
+
+  it("persists functional string-set updates from the latest value", async () => {
+    const { result } = renderHook(() => usePersistentStringSet("search:test"));
+
+    act(() => {
+      result.current[1]((currentValues) => {
+        const toggled = toggleStringSetValue(currentValues, "hotel-1");
+        return toggled.nextValues;
+      });
+      result.current[1]((currentValues) => {
+        const toggled = toggleStringSetValue(currentValues, "hotel-2");
+        return toggled.nextValues;
+      });
+    });
+
+    await waitFor(() =>
+      expect(result.current[0]).toEqual(new Set(["hotel-1", "hotel-2"]))
+    );
+    expect(window.localStorage.getItem("search:test")).toBe(
+      JSON.stringify(["hotel-1", "hotel-2"])
+    );
+  });
+
+  it("ignores invalid persisted string-set payloads", async () => {
+    window.localStorage.setItem("search:test", JSON.stringify(["hotel-1", 42]));
+
+    const { result } = renderHook(() => usePersistentStringSet("search:test"));
+
+    await waitFor(() => expect(result.current[0].size).toBe(0));
+  });
+
+  it("toggles set values without mutating the source set", () => {
+    const source = new Set(["hotel-1"]);
+
+    const removed = toggleStringSetValue(source, "hotel-1");
+    const added = toggleStringSetValue(source, "hotel-2");
+
+    expect(source).toEqual(new Set(["hotel-1"]));
+    expect(removed).toEqual({ nextValues: new Set(), wasPresent: true });
+    expect(added).toEqual({
+      nextValues: new Set(["hotel-1", "hotel-2"]),
+      wasPresent: false,
+    });
+  });
+});

--- a/src/features/search/hooks/search/use-search-client-state.ts
+++ b/src/features/search/hooks/search/use-search-client-state.ts
@@ -1,0 +1,102 @@
+/**
+ * @fileoverview Shared client-state helpers for search pages.
+ */
+
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type StringSetUpdate = Set<string> | ((values: ReadonlySet<string>) => Set<string>);
+
+/** Returns true for DOM abort errors produced by cancelled client searches. */
+export function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+/** Creates a small lifecycle helper for one in-flight search task. */
+export function useAbortableSearchTask() {
+  const currentController = useRef<AbortController | null>(null);
+
+  const clearSearchController = useCallback((controller: AbortController) => {
+    if (currentController.current === controller) {
+      currentController.current = null;
+    }
+  }, []);
+
+  const abortCurrentSearch = useCallback(() => {
+    currentController.current?.abort();
+    currentController.current = null;
+  }, []);
+
+  const startSearchController = useCallback(() => {
+    abortCurrentSearch();
+    const controller = new AbortController();
+    currentController.current = controller;
+    return controller;
+  }, [abortCurrentSearch]);
+
+  useEffect(() => abortCurrentSearch, [abortCurrentSearch]);
+
+  return { clearSearchController, startSearchController };
+}
+
+function readStoredStringSet(key: string): Set<string> {
+  try {
+    const stored = window.localStorage.getItem(key) ?? "[]";
+    const parsed: unknown = JSON.parse(stored);
+    return Array.isArray(parsed) && parsed.every((value) => typeof value === "string")
+      ? new Set(parsed)
+      : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function writeStoredStringSet(key: string, values: ReadonlySet<string>): void {
+  try {
+    window.localStorage.setItem(key, JSON.stringify([...values]));
+  } catch {
+    return;
+  }
+}
+
+/** Persists a string Set to localStorage while keeping the caller API Set-based. */
+export function usePersistentStringSet(
+  key: string
+): readonly [Set<string>, (update: StringSetUpdate) => Set<string>] {
+  const [values, setValues] = useState<Set<string>>(new Set());
+  const valuesRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const storedValues = readStoredStringSet(key);
+    valuesRef.current = storedValues;
+    setValues(storedValues);
+  }, [key]);
+
+  const setStoredValues = useCallback(
+    (update: StringSetUpdate) => {
+      const nextValues =
+        typeof update === "function" ? update(valuesRef.current) : update;
+      valuesRef.current = nextValues;
+      setValues(nextValues);
+      writeStoredStringSet(key, nextValues);
+      return nextValues;
+    },
+    [key]
+  );
+
+  return [values, setStoredValues] as const;
+}
+
+/** Toggles one value in a Set without mutating the caller's Set. */
+export function toggleStringSetValue(
+  values: ReadonlySet<string>,
+  value: string
+): { nextValues: Set<string>; wasPresent: boolean } {
+  const nextValues = new Set(values);
+  const wasPresent = nextValues.delete(value);
+  if (!wasPresent) {
+    nextValues.add(value);
+  }
+  return { nextValues, wasPresent };
+}

--- a/src/features/search/hooks/search/use-search-client-state.ts
+++ b/src/features/search/hooks/search/use-search-client-state.ts
@@ -8,7 +8,15 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 type StringSetUpdate = Set<string> | ((values: ReadonlySet<string>) => Set<string>);
 
-/** Returns true for DOM abort errors produced by cancelled client searches. */
+/** Local storage key shared by hotel search surfaces for saved hotel state. */
+export const HOTEL_WISHLIST_STORAGE_KEY = "hotelsSearch:wishlistHotels";
+
+/**
+ * Checks whether an unknown thrown value represents a cancelled client search.
+ *
+ * @param error - Unknown error value thrown by an abortable async operation.
+ * @returns `true` when the value exposes the standard AbortError name.
+ */
 export function isAbortError(error: unknown): boolean {
   return (
     typeof error === "object" &&
@@ -18,7 +26,11 @@ export function isAbortError(error: unknown): boolean {
   );
 }
 
-/** Creates a small lifecycle helper for one in-flight search task. */
+/**
+ * Creates lifecycle helpers for one in-flight search task.
+ *
+ * @returns Controller helpers that abort the previous task before a new task starts.
+ */
 export function useAbortableSearchTask() {
   const currentController = useRef<AbortController | null>(null);
 
@@ -65,7 +77,12 @@ function writeStoredStringSet(key: string, values: ReadonlySet<string>): void {
   }
 }
 
-/** Persists a string Set to localStorage while keeping the caller API Set-based. */
+/**
+ * Persists a string Set to localStorage while keeping the caller API Set-based.
+ *
+ * @param key - Local storage key that owns the persisted Set payload.
+ * @returns Current values and a setter that accepts either a Set or functional update.
+ */
 export function usePersistentStringSet(
   key: string
 ): readonly [Set<string>, (update: StringSetUpdate) => Set<string>] {
@@ -93,7 +110,13 @@ export function usePersistentStringSet(
   return [values, setStoredValues] as const;
 }
 
-/** Toggles one value in a Set without mutating the caller's Set. */
+/**
+ * Toggles one value in a Set without mutating the caller's Set.
+ *
+ * @param values - Source Set to copy before toggling.
+ * @param value - String value to add or remove.
+ * @returns The copied Set and whether the value was already present.
+ */
 export function toggleStringSetValue(
   values: ReadonlySet<string>,
   value: string

--- a/src/features/search/hooks/search/use-search-client-state.ts
+++ b/src/features/search/hooks/search/use-search-client-state.ts
@@ -10,7 +10,12 @@ type StringSetUpdate = Set<string> | ((values: ReadonlySet<string>) => Set<strin
 
 /** Returns true for DOM abort errors produced by cancelled client searches. */
 export function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    error.name === "AbortError"
+  );
 }
 
 /** Creates a small lifecycle helper for one in-flight search task. */


### PR DESCRIPTION
Closes #742

## Summary
- Consolidates repeated search-client abort-controller lifecycle into `useAbortableSearchTask`.
- Consolidates repeated wishlist string-set `localStorage` handling into `usePersistentStringSet` with functional updates for rapid toggles.
- Adds abort-after-await guards across search clients so stale validations/results do not toast or overwrite newer UI state.
- Removes low-signal JSX section comments in the touched client islands.

## Validation Evidence
- `pnpm biome:fix`
- `pnpm type-check`
- `pnpm test:affected`
- `pnpm exec vitest run src/features/search/hooks/search/__tests__/use-search-client-state.test.ts 'src/app/(app)/dashboard/search/unified/__tests__/unified-search-client.test.tsx'`
- `pnpm check:no-new-unknown-casts`
- `pnpm check:no-secrets:full`
- `pnpm check:zod-v4`
- `pnpm check:api-route-errors`
- `git diff --check`
- `pnpm build`

## Pre-PR Review Evidence
- Bun/TypeScript reviewer: no findings.
- React reviewer: found stale unified search completion risk; fixed with abort guards and component regression coverage; follow-up clean.
- Runtime reviewer: found functional persistent-set race and abort-after-await gaps; fixed; final follow-up clean.

## Docs Impact
- No docs changes. This is an internal client-state refactor with focused regression coverage.

## Provider / Deploy Notes
- No environment, provider, database, or deployment configuration changes.

## Screenshots
- Not included; no intended visual or layout changes. The UI changes are behavior-only cleanup and comment removal.

## Residual Risks
- Browser screenshot pass was not run because the diff does not intentionally alter rendered layout; local component regressions and production build cover the touched client behavior.
