### PR TITLE
fix(url): remove client origin fallback console warning

### DIFF
--- a/src/lib/url/__tests__/client-origin.test.ts
+++ b/src/lib/url/__tests__/client-origin.test.ts
@@ -8,7 +8,7 @@ const REQUIRED_PUBLIC_ENV = {
   NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",
 } as const;
 
-function LoadClientOrigin() {
+function loadClientOrigin() {
   return import("../client-origin");
 }
 
@@ -22,7 +22,7 @@ describe("client-origin", () => {
         NEXT_PUBLIC_SITE_URL: "https://site.example.com",
       },
       async () => {
-        const { getClientOrigin } = await LoadClientOrigin();
+        const { getClientOrigin } = await loadClientOrigin();
         expect(getClientOrigin()).toBe("https://site.example.com");
       }
     );
@@ -37,7 +37,7 @@ describe("client-origin", () => {
         NEXT_PUBLIC_SITE_URL: undefined,
       },
       async () => {
-        const { getClientOrigin } = await LoadClientOrigin();
+        const { getClientOrigin } = await loadClientOrigin();
         expect(getClientOrigin()).toBe("https://base.example.com");
       }
     );
@@ -50,7 +50,7 @@ describe("client-origin", () => {
         NEXT_PUBLIC_SITE_URL: undefined,
       },
       async () => {
-        const { getClientOrigin } = await LoadClientOrigin();
+        const { getClientOrigin } = await loadClientOrigin();
         expect(getClientOrigin()).toBe("https://app.example.com");
       }
     );
@@ -63,14 +63,21 @@ describe("client-origin", () => {
         NEXT_PUBLIC_APP_URL: undefined,
         NEXT_PUBLIC_BASE_URL: undefined,
         NEXT_PUBLIC_SITE_URL: undefined,
+        NODE_ENV: "development",
       },
       async () => {
         const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-        const { getClientOrigin } = await LoadClientOrigin();
+        vi.stubGlobal("window", { location: {} });
 
-        expect(getClientOrigin()).toBe("http://localhost:3000");
-        expect(warnSpy).not.toHaveBeenCalled();
-        warnSpy.mockRestore();
+        try {
+          const { getClientOrigin } = await loadClientOrigin();
+
+          expect(getClientOrigin()).toBe("http://localhost:3000");
+          expect(warnSpy).not.toHaveBeenCalled();
+        } finally {
+          warnSpy.mockRestore();
+          vi.unstubAllGlobals();
+        }
       }
     );
   });
@@ -84,7 +91,7 @@ describe("client-origin", () => {
         NEXT_PUBLIC_SITE_URL: "https://site.example.com",
       },
       async () => {
-        const { toClientAbsoluteUrl } = await LoadClientOrigin();
+        const { toClientAbsoluteUrl } = await loadClientOrigin();
 
         expect(toClientAbsoluteUrl("/dashboard")).toBe(
           "https://site.example.com/dashboard"

--- a/src/lib/url/__tests__/client-origin.test.ts
+++ b/src/lib/url/__tests__/client-origin.test.ts
@@ -1,0 +1,98 @@
+/** @vitest-environment node */
+
+import { describe, expect, it, vi } from "vitest";
+import { withEnv } from "@/test/utils/with-env";
+
+const REQUIRED_PUBLIC_ENV = {
+  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "test-publishable-key",
+  NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",
+} as const;
+
+function LoadClientOrigin() {
+  return import("../client-origin");
+}
+
+describe("client-origin", () => {
+  it("prefers NEXT_PUBLIC_SITE_URL", async () => {
+    await withEnv(
+      {
+        ...REQUIRED_PUBLIC_ENV,
+        NEXT_PUBLIC_APP_URL: "https://app.example.com",
+        NEXT_PUBLIC_BASE_URL: "https://base.example.com",
+        NEXT_PUBLIC_SITE_URL: "https://site.example.com",
+      },
+      async () => {
+        const { getClientOrigin } = await LoadClientOrigin();
+        expect(getClientOrigin()).toBe("https://site.example.com");
+      }
+    );
+  });
+
+  it("falls back through base URL and app URL", async () => {
+    await withEnv(
+      {
+        ...REQUIRED_PUBLIC_ENV,
+        NEXT_PUBLIC_APP_URL: "https://app.example.com",
+        NEXT_PUBLIC_BASE_URL: "https://base.example.com",
+        NEXT_PUBLIC_SITE_URL: undefined,
+      },
+      async () => {
+        const { getClientOrigin } = await LoadClientOrigin();
+        expect(getClientOrigin()).toBe("https://base.example.com");
+      }
+    );
+
+    await withEnv(
+      {
+        ...REQUIRED_PUBLIC_ENV,
+        NEXT_PUBLIC_APP_URL: "https://app.example.com",
+        NEXT_PUBLIC_BASE_URL: undefined,
+        NEXT_PUBLIC_SITE_URL: undefined,
+      },
+      async () => {
+        const { getClientOrigin } = await LoadClientOrigin();
+        expect(getClientOrigin()).toBe("https://app.example.com");
+      }
+    );
+  });
+
+  it("falls back to localhost without logging raw diagnostics", async () => {
+    await withEnv(
+      {
+        ...REQUIRED_PUBLIC_ENV,
+        NEXT_PUBLIC_APP_URL: undefined,
+        NEXT_PUBLIC_BASE_URL: undefined,
+        NEXT_PUBLIC_SITE_URL: undefined,
+      },
+      async () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+        const { getClientOrigin } = await LoadClientOrigin();
+
+        expect(getClientOrigin()).toBe("http://localhost:3000");
+        expect(warnSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+      }
+    );
+  });
+
+  it("converts relative paths to absolute URLs", async () => {
+    await withEnv(
+      {
+        ...REQUIRED_PUBLIC_ENV,
+        NEXT_PUBLIC_APP_URL: undefined,
+        NEXT_PUBLIC_BASE_URL: undefined,
+        NEXT_PUBLIC_SITE_URL: "https://site.example.com",
+      },
+      async () => {
+        const { toClientAbsoluteUrl } = await LoadClientOrigin();
+
+        expect(toClientAbsoluteUrl("/dashboard")).toBe(
+          "https://site.example.com/dashboard"
+        );
+        expect(toClientAbsoluteUrl("https://other.example.com/path")).toBe(
+          "https://other.example.com/path"
+        );
+      }
+    );
+  });
+});

--- a/src/lib/url/client-origin.ts
+++ b/src/lib/url/client-origin.ts
@@ -31,13 +31,6 @@ export function getClientOrigin(): string {
     return appUrl;
   }
 
-  if (process.env.NODE_ENV === "development" && typeof window !== "undefined") {
-    // Dev-only nudge to configure site/base URL; avoids server-side console usage
-    console.warn(
-      "[client-origin] No NEXT_PUBLIC_SITE_URL or NEXT_PUBLIC_BASE_URL configured. Falling back to http://localhost:3000"
-    );
-  }
-
   return DEFAULT_LOCALHOST_ORIGIN;
 }
 


### PR DESCRIPTION
## Summary
- Removes the development-only raw `console.warn` from `getClientOrigin()` fallback handling.
- Adds focused node-environment coverage for public URL precedence, localhost fallback, and absolute URL conversion.
- Keeps the PR limited to `src/lib/url/client-origin.ts` and its new test file.

## Why
- Client URL fallback should remain deterministic without emitting raw browser console diagnostics.
- The fallback chain was previously untested, making future changes to public origin resolution harder to review safely.

## Scope
### Included
- `getClientOrigin()` no longer logs when public origin env vars are absent.
- `client-origin` tests cover `NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_BASE_URL`, `NEXT_PUBLIC_APP_URL`, localhost fallback, and `toClientAbsoluteUrl()`.

### Not included
- Existing unrelated dirty-tree changes in CI, dependency config, docs, UI telemetry, e2e tests, hooks, cache behavior, and deleted legacy components/utilities.
- No package, lockfile, API route, schema, or runtime config changes.

## Release Please version impact
Versioning track:
- [x] Pre-1.0 development track
- [ ] Stable 1.0+ SemVer track
- [ ] Explicit repo override applies

Expected Release Please bump after merge to `main`:
- [ ] None
- [x] Patch
- [ ] Minor
- [ ] Major

Public API impact:
- [x] No public API change
- [ ] Public API added
- [ ] Public API changed, backward compatible
- [ ] Public API changed, breaking

Breaking changes:
- [x] None
- [ ] Yes

If breaking, describe the change, affected users/systems, and required migration steps:
- N/A

## Related issues / context
- N/A

## Implementation notes
- The fallback still returns `http://localhost:3000` when no public origin environment variable is configured.
- The new test spies on `console.warn` to lock in the no-raw-diagnostic behavior.

## Review guide
Recommended review order:
1. `src/lib/url/client-origin.ts`
2. `src/lib/url/__tests__/client-origin.test.ts`

Areas needing extra attention:
- Confirm removing the dev-only warning is acceptable for local missing-env fallback behavior.

Specific feedback requested:
- [x] Correctness
- [ ] Architecture
- [ ] API design
- [ ] Performance
- [ ] Security
- [x] Backward compatibility / migration
- [ ] UX / accessibility / copy

## Validation
### Automated
- [x] Tests added or updated
- [x] Type checks pass
- [x] Lint passes
- [ ] Build passes

Commands run from clean detached worktree `../tripsage-ai-validate-client-origin` at commit `8063126c`:
- `rtk err pnpm install --frozen-lockfile` passed; pnpm emitted existing config warning and a non-fatal Husky prepare warning because linked worktree `.git` is a file.
- `rtk err pnpm biome:fix` passed; no files changed.
- `rtk err pnpm type-check` passed.
- `rtk test pnpm test:affected` passed.
- `rtk err pnpm check:zod-v4` passed.
- `rtk err pnpm check:api-route-errors` passed.

### Manual
1. Verified `git diff --name-status origin/main..HEAD` contains only:
   - `A src/lib/url/__tests__/client-origin.test.ts`
   - `M src/lib/url/client-origin.ts`

## Risk
- Low.
- Failure mode: developers no longer get a raw console warning when public origin env vars are absent; localhost fallback behavior is unchanged and covered by tests.

## Rollout / rollback
- No deployment constraints or feature flags.
- Roll back by reverting this single commit if the warning is still desired.
