### PR TITLE
fix(ui): keep input group addons out of button navigation

### DIFF
--- a/src/components/ui/__tests__/input-group.test.tsx
+++ b/src/components/ui/__tests__/input-group.test.tsx
@@ -24,4 +24,24 @@ describe("InputGroup", () => {
 
     expect(document.activeElement).toBe(input);
   });
+
+  it("does not forward focus when the addon target is a nested button", () => {
+    render(
+      <InputGroup>
+        <InputGroupAddon>
+          <button type="button">Action</button>
+        </InputGroupAddon>
+        <InputGroupInput aria-label="Destination" />
+      </InputGroup>
+    );
+
+    const button = screen.getByRole("button", { name: "Action" });
+    const input = screen.getByRole("textbox", { name: "Destination" });
+    button.focus();
+
+    fireEvent.mouseDown(button);
+
+    expect(document.activeElement).not.toBe(input);
+    expect(document.activeElement).toBe(button);
+  });
 });

--- a/src/components/ui/__tests__/input-group.test.tsx
+++ b/src/components/ui/__tests__/input-group.test.tsx
@@ -1,0 +1,27 @@
+/** @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+
+describe("InputGroup", () => {
+  it("keeps addons out of button navigation while preserving pointer focus", () => {
+    render(
+      <InputGroup>
+        <InputGroupAddon data-testid="input-addon">Prefix</InputGroupAddon>
+        <InputGroupInput aria-label="Destination" />
+      </InputGroup>
+    );
+
+    expect(screen.queryByRole("button", { name: "Prefix" })).toBeNull();
+
+    const input = screen.getByRole("textbox", { name: "Destination" });
+    fireEvent.mouseDown(screen.getByTestId("input-addon"));
+
+    expect(document.activeElement).toBe(input);
+  });
+});

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -75,8 +75,8 @@ const InputGroupAddonVariants = cva(
 /**
  * Addon region placed inline or in block areas of the input group.
  *
- * @param className Optional extra classes.
- * @param align Alignment of the addon within the group.
+ * @param className - Optional extra classes.
+ * @param align - Alignment of the addon within the group.
  * @returns A grouped addon region that forwards mouse focus to the input.
  */
 function InputGroupAddon({

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -21,6 +21,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="input-group"
+      role="group"
       className={cn(
         "group/input-group border-input dark:bg-input/30 relative flex w-full items-center rounded-md border shadow-xs transition-[color,box-shadow] outline-none",
         "h-9 min-w-0 has-[>textarea]:h-auto",
@@ -76,7 +77,7 @@ const InputGroupAddonVariants = cva(
  *
  * @param className Optional extra classes.
  * @param align Alignment of the addon within the group.
- * @returns A div that forwards clicks to focus the input.
+ * @returns A grouped addon region that forwards mouse focus to the input.
  */
 function InputGroupAddon({
   className,
@@ -88,22 +89,15 @@ function InputGroupAddon({
       data-slot="input-group-addon"
       data-align={align}
       className={cn(InputGroupAddonVariants({ align }), className)}
-      role="button"
-      tabIndex={0}
-      onClick={(e) => {
+      role="group"
+      onMouseDown={(e) => {
         if ((e.target as HTMLElement).closest("button")) {
           return;
         }
-        e.currentTarget.parentElement?.querySelector("input")?.focus();
-      }}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          if ((e.target as HTMLElement).closest("button")) {
-            return;
-          }
-          e.currentTarget.parentElement?.querySelector("input")?.focus();
-        }
+        e.preventDefault();
+        e.currentTarget.parentElement
+          ?.querySelector<HTMLInputElement | HTMLTextAreaElement>("input, textarea")
+          ?.focus();
       }}
       {...props}
     />

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -91,7 +91,8 @@ function InputGroupAddon({
       className={cn(InputGroupAddonVariants({ align }), className)}
       role="group"
       onMouseDown={(e) => {
-        if ((e.target as HTMLElement).closest("button")) {
+        const target = e.target;
+        if (!(target instanceof Element) || target.closest("button")) {
           return;
         }
         e.preventDefault();


### PR DESCRIPTION
## Summary
- Removes the faux `button` role and keyboard activation behavior from `InputGroupAddon`.
- Keeps pointer focus behavior for inputs and textareas using `onMouseDown`.
- Adds focused jsdom coverage proving addons stay out of button navigation while preserving focus handoff.

## Why
- Input group addons are layout/accessory regions, not commands. Exposing them as buttons creates misleading navigation semantics for assistive tech and keyboard users.
- The focus behavior is still useful when users click the addon area, so this keeps the ergonomic pointer path without advertising a non-command control.

## Scope
### Included
- `src/components/ui/input-group.tsx`
- `src/components/ui/__tests__/input-group.test.tsx`

### Not included
- Existing unrelated dirty-tree changes in CI, package metadata, docs, AI tools, telemetry cleanup, hooks, cache behavior, e2e tests, and other UI components.
- No dependency, lockfile, route, schema, or public API changes.

## Release Please version impact
Versioning track:
- [x] Pre-1.0 development track
- [ ] Stable 1.0+ SemVer track
- [ ] Explicit repo override applies

Expected Release Please bump after merge to `main`:
- [ ] None
- [x] Patch
- [ ] Minor
- [ ] Major

Public API impact:
- [x] No public API change
- [ ] Public API added
- [ ] Public API changed, backward compatible
- [ ] Public API changed, breaking

Breaking changes:
- [x] None
- [ ] Yes

If breaking, describe the change, affected users/systems, and required migration steps:
- N/A

## Related issues / context
- Follows PR #770 as the next small branch split from the existing dirty tree.

## Implementation notes
- `InputGroup` and `InputGroupAddon` now expose group semantics instead of addon-as-button semantics.
- `InputGroupAddon` focuses the nearest `input` or `textarea` on pointer down unless the pointer target is already inside an actual button.

## Review guide
Recommended review order:
1. `src/components/ui/input-group.tsx`
2. `src/components/ui/__tests__/input-group.test.tsx`

Areas needing extra attention:
- Confirm the ARIA semantics match expected addon behavior.
- Confirm pointer focus still works for addon clicks.

Specific feedback requested:
- [x] Correctness
- [ ] Architecture
- [ ] API design
- [ ] Performance
- [ ] Security
- [x] Backward compatibility / migration
- [x] UX / accessibility / copy

## Validation
### Automated
- [x] Tests added or updated
- [x] Type checks pass
- [x] Lint passes
- [ ] Build passes

Commands run from clean detached worktree `../tripsage-ai-validate-input-group` at commit `5a4b2bd3`:
- `rtk err pnpm install --frozen-lockfile` passed; pnpm emitted existing config warning and a non-fatal Husky prepare warning because linked worktree `.git` is a file.
- `rtk err pnpm biome:fix` passed; no files changed.
- `rtk test pnpm exec vitest run src/components/ui/__tests__/input-group.test.tsx` passed.
- `rtk err pnpm type-check` passed.
- `rtk test pnpm test:affected` passed.
- `rtk err pnpm check:zod-v4` passed.
- `rtk err pnpm check:api-route-errors` passed.

### Manual
1. Verified remote branch compare `main...fix/input-group-addon-focus` contains only:
   - `A src/components/ui/__tests__/input-group.test.tsx`
   - `M src/components/ui/input-group.tsx`

## Risk
- Low.
- Failure mode: consumers relying on addon keyboard activation would no longer get that behavior, but addons are non-command regions and actual buttons inside addons remain ignored by the focus handoff.

## Rollout / rollback
- No deployment constraints or feature flags.
- Roll back by reverting this single commit if the addon semantics need to be restored.
