### PR TITLE
fix(ui): report proxied image dimension errors

### DIFF
--- a/src/components/ui/__tests__/proxied-image.test.tsx
+++ b/src/components/ui/__tests__/proxied-image.test.tsx
@@ -1,0 +1,84 @@
+/** @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProxiedImage } from "@/components/ui/proxied-image";
+import { render, screen } from "@/test/test-utils";
+
+const { mockRecordClientErrorOnActiveSpan } = vi.hoisted(() => ({
+  mockRecordClientErrorOnActiveSpan: vi.fn(),
+}));
+
+vi.mock("@/lib/telemetry/client-errors", () => ({
+  recordClientErrorOnActiveSpan: mockRecordClientErrorOnActiveSpan,
+}));
+
+describe("ProxiedImage", () => {
+  beforeEach(() => {
+    mockRecordClientErrorOnActiveSpan.mockReset();
+  });
+
+  it("renders proxied remote images when dimensions are provided", () => {
+    render(
+      <ProxiedImage
+        src="https://images.example.com/photo.jpg"
+        alt="Mountain hotel"
+        width={640}
+        height={360}
+      />
+    );
+
+    expect(screen.getByRole("img", { name: "Mountain hotel" })).toHaveAttribute(
+      "src",
+      "/api/images/proxy?url=https%3A%2F%2Fimages.example.com%2Fphoto.jpg"
+    );
+    expect(mockRecordClientErrorOnActiveSpan).not.toHaveBeenCalled();
+  });
+
+  it("reports missing dimensions through telemetry and renders fallback content", () => {
+    render(
+      <ProxiedImage
+        src="/hotel.jpg"
+        alt="Hotel"
+        width={640}
+        fallback={<span>Image unavailable</span>}
+      />
+    );
+
+    expect(screen.getByText("Image unavailable")).toBeInTheDocument();
+    expect(screen.queryByRole("img", { name: "Hotel" })).not.toBeInTheDocument();
+    expect(mockRecordClientErrorOnActiveSpan).toHaveBeenCalledWith(expect.any(Error), {
+      action: "validateDimensions",
+      context: "ProxiedImage",
+      hasHeight: false,
+      hasWidth: true,
+    });
+  });
+
+  it("keeps fallback rendering when telemetry recording fails", () => {
+    mockRecordClientErrorOnActiveSpan.mockImplementationOnce(() => {
+      throw new Error("telemetry unavailable");
+    });
+
+    render(<ProxiedImage src="/hotel.jpg" alt="Hotel" />);
+
+    expect(screen.getByText("No image")).toBeInTheDocument();
+    expect(screen.queryByRole("img", { name: "Hotel" })).not.toBeInTheDocument();
+    expect(mockRecordClientErrorOnActiveSpan).toHaveBeenCalledWith(expect.any(Error), {
+      action: "validateDimensions",
+      context: "ProxiedImage",
+      hasHeight: false,
+      hasWidth: false,
+    });
+  });
+
+  it("allows fill images without explicit dimensions", () => {
+    render(
+      <div className="relative h-40 w-40">
+        <ProxiedImage src="/hotel.jpg" alt="Hotel" fill />
+      </div>
+    );
+
+    expect(screen.getByRole("img", { name: "Hotel" })).toBeInTheDocument();
+    expect(mockRecordClientErrorOnActiveSpan).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/proxied-image.tsx
+++ b/src/components/ui/proxied-image.tsx
@@ -12,6 +12,7 @@ import {
   isAbsoluteHttpUrl,
   normalizeNextImageSrc,
 } from "@/lib/images/image-proxy";
+import { recordClientErrorOnActiveSpan } from "@/lib/telemetry/client-errors";
 
 const DEFAULT_FALLBACK = (
   <div className="flex items-center justify-center h-full text-muted-foreground text-xs">
@@ -30,6 +31,28 @@ export interface ProxiedImageProps {
   height?: number;
   preload?: boolean;
   fallback?: ReactNode;
+}
+
+function ReportMissingDimensions({
+  hasHeight,
+  hasWidth,
+}: {
+  hasHeight: boolean;
+  hasWidth: boolean;
+}): void {
+  try {
+    recordClientErrorOnActiveSpan(
+      new Error("ProxiedImage requires width and height when fill is false."),
+      {
+        action: "validateDimensions",
+        context: "ProxiedImage",
+        hasHeight,
+        hasWidth,
+      }
+    );
+  } catch {
+    // Preserve image fallback rendering if telemetry is unavailable.
+  }
 }
 
 /**
@@ -66,13 +89,7 @@ export function ProxiedImage({
   }
 
   if (!fill && (width == null || height == null)) {
-    if (process.env.NODE_ENV === "development") {
-      console.warn("ProxiedImage requires width and height when fill is false.", {
-        alt,
-        height,
-        width,
-      });
-    }
+    ReportMissingDimensions({ hasHeight: height != null, hasWidth: width != null });
     return fallback ?? DEFAULT_FALLBACK;
   }
 

--- a/src/components/ui/proxied-image.tsx
+++ b/src/components/ui/proxied-image.tsx
@@ -7,6 +7,7 @@
 import type { StaticImageData } from "next/image";
 import Image from "next/image";
 import type { ReactNode } from "react";
+import { useEffect } from "react";
 import {
   buildImageProxyUrl,
   isAbsoluteHttpUrl,
@@ -55,6 +56,22 @@ function ReportMissingDimensions({
   }
 }
 
+function MissingDimensionsFallback({
+  fallback,
+  hasHeight,
+  hasWidth,
+}: {
+  fallback?: ReactNode;
+  hasHeight: boolean;
+  hasWidth: boolean;
+}) {
+  useEffect(() => {
+    ReportMissingDimensions({ hasHeight, hasWidth });
+  }, [hasHeight, hasWidth]);
+
+  return fallback ?? DEFAULT_FALLBACK;
+}
+
 /**
  * Renders a Next.js Image using the proxy for remote URLs with a fallback.
  *
@@ -89,8 +106,13 @@ export function ProxiedImage({
   }
 
   if (!fill && (width == null || height == null)) {
-    ReportMissingDimensions({ hasHeight: height != null, hasWidth: width != null });
-    return fallback ?? DEFAULT_FALLBACK;
+    return (
+      <MissingDimensionsFallback
+        fallback={fallback}
+        hasHeight={height != null}
+        hasWidth={width != null}
+      />
+    );
   }
 
   if (fill) {


### PR DESCRIPTION
## Summary
- Replace the `ProxiedImage` missing-dimensions development console warning with client telemetry reporting.
- Preserve fallback rendering when width or height is missing and `fill` is false.
- Add focused jsdom coverage for proxied remote image rendering, missing-dimension telemetry, telemetry failure fallback, and `fill` images.

## Why
- `ProxiedImage` should avoid raw browser console diagnostics and use the existing client telemetry path for actionable error context.

## Scope
### Included
- `src/components/ui/proxied-image.tsx`
- `src/components/ui/__tests__/proxied-image.test.tsx`

### Not included
- No changes to the image proxy API route.
- No changes to unrelated telemetry, UI, dependency, workflow, or documentation dirty-tree items.

## Release Please version impact
Versioning track:
- [ ] Pre-1.0 development track
- [x] Stable 1.0+ SemVer track
- [ ] Explicit repo override applies

Expected Release Please bump after merge to `main`:
- [ ] None
- [x] Patch
- [ ] Minor
- [ ] Major

Public API impact:
- [x] No public API change
- [ ] Public API added
- [ ] Public API changed, backward compatible
- [ ] Public API changed, breaking

Breaking changes:
- [x] None
- [ ] Yes

If breaking, describe the change, affected users/systems, and required migration steps:
- N/A

## Related issues / context
- Follow-up branch from the remaining dirty tree after PR #771.

## Implementation notes
- Uses `recordClientErrorOnActiveSpan` with boolean dimension metadata instead of logging `alt`, `width`, or `height` to the console.
- Catches telemetry failures so the existing fallback UI path remains resilient.

## Review guide
Recommended review order:
1. `src/components/ui/proxied-image.tsx`
2. `src/components/ui/__tests__/proxied-image.test.tsx`

Areas needing extra attention:
- Confirm the telemetry call remains client-safe and does not prevent fallback rendering.

Specific feedback requested:
- [x] Correctness
- [ ] Architecture
- [ ] API design
- [ ] Performance
- [ ] Security
- [x] Backward compatibility / migration
- [ ] UX / accessibility / copy

## Validation
### Automated
- [x] Tests added or updated
- [x] Type checks pass
- [x] Lint passes
- [ ] Build passes

Commands run:
- `pnpm install --frozen-lockfile`
- `pnpm biome:fix`
- `pnpm exec vitest run src/components/ui/__tests__/proxied-image.test.tsx`
- `pnpm type-check`
- `pnpm test:affected`
- `pnpm check:zod-v4`
- `pnpm check:api-route-errors`

### Manual
1. Verified the validation worktree stayed clean after formatting and tests.

## Risk
- Low.
- Main failure mode is telemetry recording throwing; this is caught and preserves fallback rendering.

## Rollout / rollback
- Roll out through the normal frontend deployment path.
- Roll back by reverting this PR; the component will return to the previous fallback behavior and development console warning.
