### PR TITLE
fix(client): route diagnostics through telemetry

### DIFF
--- a/src/__tests__/realtime-auth-provider.test.tsx
+++ b/src/__tests__/realtime-auth-provider.test.tsx
@@ -6,40 +6,56 @@ import { RealtimeAuthProvider } from "@/components/providers/realtime-auth-provi
 import { unsafeCast } from "@/test/helpers/unsafe-cast";
 import { render } from "@/test/test-utils";
 
-/** Mock setAuth function for testing */
-const mockSetAuth = vi.fn();
+const {
+  mockGetBrowserClient,
+  mockGetSession,
+  mockOnAuthStateChange,
+  mockRecordClientErrorOnActiveSpan,
+  mockSetAuth,
+} = vi.hoisted(() => ({
+  mockGetBrowserClient: vi.fn(),
+  mockGetSession: vi.fn(),
+  mockOnAuthStateChange: vi.fn(),
+  mockRecordClientErrorOnActiveSpan: vi.fn(),
+  mockSetAuth: vi.fn(),
+}));
 
-/** Mock getSession function for testing */
-const mockGetSession = vi.fn().mockResolvedValue({
-  data: {
-    session: {
-      access_token: "initial-token",
-      user: { id: "user-id" },
+function setupDefaultSupabaseClientMocks(): void {
+  mockGetSession.mockResolvedValue({
+    data: {
+      session: {
+        access_token: "initial-token",
+        user: { id: "user-id" },
+      },
     },
-  },
-  error: null,
-});
-
-/** Mock onAuthStateChange function for testing */
-const mockOnAuthStateChange = vi
-  .fn()
-  .mockImplementation((_event: AuthChangeEvent, _session: Session | null) => ({
-    data: { subscription: { unsubscribe: vi.fn() } },
-  }));
-
-vi.mock("@/lib/supabase", () => ({
-  getBrowserClient: () => ({
+    error: null,
+  });
+  mockOnAuthStateChange.mockImplementation(
+    (_event: AuthChangeEvent, _session: Session | null) => ({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    })
+  );
+  mockGetBrowserClient.mockReturnValue({
     auth: {
       getSession: mockGetSession,
       onAuthStateChange: mockOnAuthStateChange,
     },
     realtime: { setAuth: mockSetAuth },
-  }),
+  });
+}
+
+vi.mock("@/lib/supabase", () => ({
+  getBrowserClient: mockGetBrowserClient,
+}));
+
+vi.mock("@/lib/telemetry/client-errors", () => ({
+  recordClientErrorOnActiveSpan: mockRecordClientErrorOnActiveSpan,
 }));
 
 describe("RealtimeAuthProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setupDefaultSupabaseClientMocks();
   });
 
   afterEach(() => {
@@ -107,5 +123,35 @@ describe("RealtimeAuthProvider", () => {
 
     // Unmount cleanup should call setAuth("") immediately
     expect(mockSetAuth).toHaveBeenCalledWith("");
+  });
+
+  it("reports initial session failures through telemetry", async () => {
+    const sessionError = new Error("session unavailable");
+    mockGetSession.mockRejectedValueOnce(sessionError);
+
+    render(<RealtimeAuthProvider />);
+
+    await vi.waitFor(() => {
+      expect(mockRecordClientErrorOnActiveSpan).toHaveBeenCalledWith(sessionError, {
+        action: "getInitialSession",
+        context: "RealtimeAuthProvider",
+      });
+    });
+  });
+
+  it("reports initializer failures through telemetry", async () => {
+    const initializeError = new Error("client unavailable");
+    mockGetBrowserClient.mockImplementationOnce(() => {
+      throw initializeError;
+    });
+
+    render(<RealtimeAuthProvider />);
+
+    await vi.waitFor(() => {
+      expect(mockRecordClientErrorOnActiveSpan).toHaveBeenCalledWith(initializeError, {
+        action: "initialize",
+        context: "RealtimeAuthProvider",
+      });
+    });
   });
 });

--- a/src/app/(app)/dashboard/error.tsx
+++ b/src/app/(app)/dashboard/error.tsx
@@ -6,11 +6,7 @@
 
 import { useEffect } from "react";
 import { ErrorFallback } from "@/components/error/error-fallback";
-import { normalizeThrownError } from "@/lib/client/normalize-thrown-error";
-import { getSessionId } from "@/lib/client/session";
-import { getUserIdFromUserStore } from "@/lib/client/user-store";
-import { errorService } from "@/lib/error-service";
-import { fireAndForget } from "@/lib/utils";
+import { reportRouteErrorBoundaryError } from "@/lib/telemetry/route-error-boundary";
 
 /**
  * Dashboard-level error boundary
@@ -24,19 +20,9 @@ export default function DashboardError({
   reset: () => void;
 }) {
   useEffect(() => {
-    const normalized = normalizeThrownError(error);
-    // Report the dashboard error
-    const errorReport = errorService.createErrorReport(normalized, undefined, {
-      sessionId: getSessionId(),
-      userId: getUserIdFromUserStore(),
+    reportRouteErrorBoundaryError(error, {
+      context: "DashboardErrorBoundary",
     });
-
-    fireAndForget(errorService.reportError(errorReport));
-
-    // Log error in development
-    if (process.env.NODE_ENV === "development") {
-      console.error("Dashboard error boundary caught error:", normalized);
-    }
   }, [error]);
 
   return <ErrorFallback error={error} reset={reset} />;

--- a/src/app/(auth)/error.tsx
+++ b/src/app/(auth)/error.tsx
@@ -6,10 +6,7 @@
 
 import { useEffect } from "react";
 import { ErrorFallback } from "@/components/error/error-fallback";
-import { normalizeThrownError } from "@/lib/client/normalize-thrown-error";
-import { getSessionId } from "@/lib/client/session";
-import { errorService } from "@/lib/error-service";
-import { fireAndForget } from "@/lib/utils";
+import { reportRouteErrorBoundaryError } from "@/lib/telemetry/route-error-boundary";
 
 /**
  * Authentication-level error boundary
@@ -23,18 +20,10 @@ export default function AuthError({
   reset: () => void;
 }) {
   useEffect(() => {
-    const normalized = normalizeThrownError(error);
-    // Report the auth error
-    const errorReport = errorService.createErrorReport(normalized, undefined, {
-      sessionId: getSessionId(),
+    reportRouteErrorBoundaryError(error, {
+      context: "AuthErrorBoundary",
+      includeUserId: false,
     });
-
-    fireAndForget(errorService.reportError(errorReport));
-
-    // Log error in development
-    if (process.env.NODE_ENV === "development") {
-      console.error("Auth error boundary caught error:", normalized);
-    }
   }, [error]);
 
   return <ErrorFallback error={error} reset={reset} />;

--- a/src/app/__tests__/error-boundaries-integration.test.tsx
+++ b/src/app/__tests__/error-boundaries-integration.test.tsx
@@ -58,23 +58,27 @@ import { errorService as mockErrorService } from "@/lib/error-service";
 const mockedErrorService = vi.mocked(mockErrorService);
 
 const WAIT_OPTIONS = { interval: 10, timeout: 1000 } as const;
-const globalErrorRoots = new Set<Root>();
+const globalErrorRoots = new Map<Root, HTMLElement>();
 
 function renderGlobalError(error: unknown, reset: () => void) {
-  const root = createRoot(document);
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
 
   act(() => {
     root.render(<GlobalError error={error} reset={reset} />);
   });
 
-  globalErrorRoots.add(root);
+  globalErrorRoots.set(root, container);
 
   return {
+    container,
     unmount: () => {
       if (!globalErrorRoots.delete(root)) return;
       act(() => {
         root.unmount();
       });
+      container.remove();
     },
   };
 }
@@ -90,7 +94,9 @@ async function waitForTelemetry() {
   const [error, errorInfo, metadata] = await waitForMockCall(
     mockedErrorService.createErrorReport
   );
-  const [reportPayload] = await waitForMockCall(mockedErrorService.reportError);
+  const [reportPayload, spanMetadata] = await waitForMockCall(
+    mockedErrorService.reportError
+  );
 
   return {
     create: {
@@ -99,6 +105,7 @@ async function waitForTelemetry() {
       metadata,
     },
     reported: reportPayload as ErrorReport,
+    spanMetadata,
   };
 }
 
@@ -134,10 +141,11 @@ describe("Next.js Error Boundaries Integration", () => {
   });
 
   afterEach(() => {
-    for (const root of globalErrorRoots) {
+    for (const [root, container] of globalErrorRoots) {
       act(() => {
         root.unmount();
       });
+      container.remove();
     }
     globalErrorRoots.clear();
   });
@@ -165,7 +173,7 @@ describe("Next.js Error Boundaries Integration", () => {
     it("should report error on mount", async () => {
       render(<ErrorComponent error={mockError} reset={mockReset} />);
 
-      const { create, reported } = await waitForTelemetry();
+      const { create, reported, spanMetadata } = await waitForTelemetry();
 
       expect(create.metadata).toEqual(
         expect.objectContaining({
@@ -177,10 +185,11 @@ describe("Next.js Error Boundaries Integration", () => {
           sessionId: "test_session_id",
         })
       );
-      expect(TELEMETRY_SPY).toHaveBeenCalledWith(expect.any(Error), {
+      expect(spanMetadata).toEqual({
         action: "render",
         context: "RootErrorBoundary",
       });
+      expect(TELEMETRY_SPY).not.toHaveBeenCalled();
     });
 
     // Removed brittle NODE_ENV mutation; rely on behavior assertions only.
@@ -208,26 +217,27 @@ describe("Next.js Error Boundaries Integration", () => {
     });
 
     it("should render minimal global error UI", () => {
-      renderGlobalError(mockError, mockReset);
+      const globalError = renderGlobalError(mockError, mockReset);
 
-      expect(document.documentElement).toHaveAttribute("lang", "en");
+      expect(globalError.container).toBeInstanceOf(HTMLElement);
       expect(screen.getByText("Application Error")).toBeInTheDocument();
     });
 
     it("should report critical error", async () => {
       renderGlobalError(mockError, mockReset);
 
-      const { reported } = await waitForTelemetry();
+      const { reported, spanMetadata } = await waitForTelemetry();
 
       expect(reported).toEqual(
         expect.objectContaining({
           sessionId: "test_session_id",
         })
       );
-      expect(TELEMETRY_SPY).toHaveBeenCalledWith(expect.any(Error), {
+      expect(spanMetadata).toEqual({
         action: "render",
         context: "GlobalErrorBoundary",
       });
+      expect(TELEMETRY_SPY).not.toHaveBeenCalled();
     });
 
     // Removed brittle NODE_ENV-dependent logging assertion.
@@ -248,7 +258,7 @@ describe("Next.js Error Boundaries Integration", () => {
     it("should report dashboard error", async () => {
       render(<DashboardError error={mockError} reset={mockReset} />);
 
-      const { create, reported } = await waitForTelemetry();
+      const { create, reported, spanMetadata } = await waitForTelemetry();
 
       expect(create.metadata).toEqual(
         expect.objectContaining({
@@ -260,10 +270,11 @@ describe("Next.js Error Boundaries Integration", () => {
           sessionId: "test_session_id",
         })
       );
-      expect(TELEMETRY_SPY).toHaveBeenCalledWith(expect.any(Error), {
+      expect(spanMetadata).toEqual({
         action: "render",
         context: "DashboardErrorBoundary",
       });
+      expect(TELEMETRY_SPY).not.toHaveBeenCalled();
     });
 
     // Removed brittle NODE_ENV mutation; implicit assertions elsewhere cover logging.
@@ -279,7 +290,7 @@ describe("Next.js Error Boundaries Integration", () => {
     it("should report auth error without user ID", async () => {
       render(<AuthError error={mockError} reset={mockReset} />);
 
-      const { create, reported } = await waitForTelemetry();
+      const { create, reported, spanMetadata } = await waitForTelemetry();
 
       expect(create.metadata).toEqual(
         expect.objectContaining({
@@ -288,10 +299,11 @@ describe("Next.js Error Boundaries Integration", () => {
       );
       expect(create.metadata?.userId).toBeUndefined();
       expect(reported.userId).toBeUndefined();
-      expect(TELEMETRY_SPY).toHaveBeenCalledWith(expect.any(Error), {
+      expect(spanMetadata).toEqual({
         action: "render",
         context: "AuthErrorBoundary",
       });
+      expect(TELEMETRY_SPY).not.toHaveBeenCalled();
     });
 
     // Logging behavior is environment dependent; skip direct console assertions here.

--- a/src/app/__tests__/error-boundaries-integration.test.tsx
+++ b/src/app/__tests__/error-boundaries-integration.test.tsx
@@ -1,7 +1,8 @@
 /** @vitest-environment jsdom */
 
 import type { ErrorReport } from "@schemas/errors";
-import { screen } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
+import { createRoot, type Root } from "react-dom/client";
 import type { MockInstance } from "vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MAIN_CONTENT_ID } from "@/lib/a11y/landmarks";
@@ -37,6 +38,7 @@ const { createErrorReportMock, reportErrorMock } = vi.hoisted(() => {
 
   return { createErrorReportMock: createErrorReport, reportErrorMock: reportError };
 });
+const TELEMETRY_SPY = vi.hoisted(() => vi.fn());
 
 // Mock the error service with deterministic implementations
 vi.mock("@/lib/error-service", () => ({
@@ -46,12 +48,36 @@ vi.mock("@/lib/error-service", () => ({
   },
 }));
 
+vi.mock("@/lib/telemetry/client-errors", () => ({
+  recordClientErrorOnActiveSpan: TELEMETRY_SPY,
+}));
+
 // Get the mocked error service
 import { errorService as mockErrorService } from "@/lib/error-service";
 
 const mockedErrorService = vi.mocked(mockErrorService);
 
 const WAIT_OPTIONS = { interval: 10, timeout: 1000 } as const;
+const globalErrorRoots = new Set<Root>();
+
+function renderGlobalError(error: unknown, reset: () => void) {
+  const root = createRoot(document);
+
+  act(() => {
+    root.render(<GlobalError error={error} reset={reset} />);
+  });
+
+  globalErrorRoots.add(root);
+
+  return {
+    unmount: () => {
+      if (!globalErrorRoots.delete(root)) return;
+      act(() => {
+        root.unmount();
+      });
+    },
+  };
+}
 
 async function waitForMockCall<TArgs extends unknown[]>(
   mockFn: MockInstance<(...args: TArgs) => unknown>
@@ -76,9 +102,6 @@ async function waitForTelemetry() {
   };
 }
 
-// Console spy setup moved to beforeEach to avoid global suppression issues
-let consoleSpy: MockInstance;
-
 // Mock sessionStorage - setup in beforeEach to avoid issues in node env
 let mockSessionStorage: {
   getItem: ReturnType<typeof vi.fn>;
@@ -93,6 +116,7 @@ describe("Next.js Error Boundaries Integration", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    TELEMETRY_SPY.mockClear();
 
     // Setup sessionStorage mock in beforeEach (only in jsdom environment)
     if (typeof window !== "undefined") {
@@ -107,16 +131,15 @@ describe("Next.js Error Boundaries Integration", () => {
       });
       mockSessionStorage.getItem.mockReturnValue("test_session_id");
     }
-
-    // Create fresh spy for each test
-    consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {
-      // Intentional no-op to avoid noise in tests
-    });
   });
 
   afterEach(() => {
-    // Restore console after each test
-    consoleSpy.mockRestore();
+    for (const root of globalErrorRoots) {
+      act(() => {
+        root.unmount();
+      });
+    }
+    globalErrorRoots.clear();
   });
 
   describe("Root Error Boundary (error.tsx)", () => {
@@ -154,6 +177,10 @@ describe("Next.js Error Boundaries Integration", () => {
           sessionId: "test_session_id",
         })
       );
+      expect(TELEMETRY_SPY).toHaveBeenCalledWith(expect.any(Error), {
+        action: "render",
+        context: "RootErrorBoundary",
+      });
     });
 
     // Removed brittle NODE_ENV mutation; rely on behavior assertions only.
@@ -170,7 +197,7 @@ describe("Next.js Error Boundaries Integration", () => {
 
   describe("Global Error Boundary (global-error.tsx)", () => {
     it("should render MinimalErrorFallback for global errors", () => {
-      render(<GlobalError error={mockError} reset={mockReset} />);
+      renderGlobalError(mockError, mockReset);
 
       expect(screen.getByText("Application Error")).toBeInTheDocument();
       expect(
@@ -181,13 +208,14 @@ describe("Next.js Error Boundaries Integration", () => {
     });
 
     it("should render minimal global error UI", () => {
-      render(<GlobalError error={mockError} reset={mockReset} />);
-      // JSDOM render() returns a fragment, not full html/body; assert semantic text instead
+      renderGlobalError(mockError, mockReset);
+
+      expect(document.documentElement).toHaveAttribute("lang", "en");
       expect(screen.getByText("Application Error")).toBeInTheDocument();
     });
 
     it("should report critical error", async () => {
-      render(<GlobalError error={mockError} reset={mockReset} />);
+      renderGlobalError(mockError, mockReset);
 
       const { reported } = await waitForTelemetry();
 
@@ -196,11 +224,13 @@ describe("Next.js Error Boundaries Integration", () => {
           sessionId: "test_session_id",
         })
       );
+      expect(TELEMETRY_SPY).toHaveBeenCalledWith(expect.any(Error), {
+        action: "render",
+        context: "GlobalErrorBoundary",
+      });
     });
 
-    // Removed brittle NODE_ENV-dependent console.error assertion;
-    // console logging is guarded by process.env.NODE_ENV === "development"
-    // and cannot be reliably tested in test environment.
+    // Removed brittle NODE_ENV-dependent logging assertion.
   });
 
   describe("Dashboard Error Boundary (dashboard/error.tsx)", () => {
@@ -230,6 +260,10 @@ describe("Next.js Error Boundaries Integration", () => {
           sessionId: "test_session_id",
         })
       );
+      expect(TELEMETRY_SPY).toHaveBeenCalledWith(expect.any(Error), {
+        action: "render",
+        context: "DashboardErrorBoundary",
+      });
     });
 
     // Removed brittle NODE_ENV mutation; implicit assertions elsewhere cover logging.
@@ -254,6 +288,10 @@ describe("Next.js Error Boundaries Integration", () => {
       );
       expect(create.metadata?.userId).toBeUndefined();
       expect(reported.userId).toBeUndefined();
+      expect(TELEMETRY_SPY).toHaveBeenCalledWith(expect.any(Error), {
+        action: "render",
+        context: "AuthErrorBoundary",
+      });
     });
 
     // Logging behavior is environment dependent; skip direct console assertions here.
@@ -388,11 +426,14 @@ describe("Next.js Error Boundaries Integration", () => {
   describe("Error Boundary Hierarchy", () => {
     it("should show different UI for different error levels", () => {
       // Global error shows minimal UI
-      const { rerender } = render(<GlobalError error={mockError} reset={mockReset} />);
+      const globalError = renderGlobalError(mockError, mockReset);
       expect(screen.getByText("Application Error")).toBeInTheDocument();
+      globalError.unmount();
 
       // Page error shows more detailed UI
-      rerender(<ErrorComponent error={mockError} reset={mockReset} />);
+      const { rerender } = render(
+        <ErrorComponent error={mockError} reset={mockReset} />
+      );
       expect(screen.getByText("Page Error")).toBeInTheDocument();
 
       // Component error shows standard UI

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -7,11 +7,7 @@
 import { useEffect } from "react";
 import { PageErrorFallback } from "@/components/error/error-fallback";
 import { MAIN_CONTENT_ID } from "@/lib/a11y/landmarks";
-import { normalizeThrownError } from "@/lib/client/normalize-thrown-error";
-import { getSessionId } from "@/lib/client/session";
-import { getUserIdFromUserStore } from "@/lib/client/user-store";
-import { errorService } from "@/lib/error-service";
-import { fireAndForget } from "@/lib/utils";
+import { reportRouteErrorBoundaryError } from "@/lib/telemetry/route-error-boundary";
 
 /**
  * Root-level error boundary for the app directory
@@ -25,19 +21,9 @@ export default function RootErrorBoundary({
   reset: () => void;
 }) {
   useEffect(() => {
-    const normalized = normalizeThrownError(error);
-    // Report the error
-    const errorReport = errorService.createErrorReport(normalized, undefined, {
-      sessionId: getSessionId(),
-      userId: getUserIdFromUserStore(),
+    reportRouteErrorBoundaryError(error, {
+      context: "RootErrorBoundary",
     });
-
-    fireAndForget(errorService.reportError(errorReport));
-
-    // Log error in development
-    if (process.env.NODE_ENV === "development") {
-      console.error("Root error boundary caught error:", normalized);
-    }
   }, [error]);
 
   return (

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -6,11 +6,7 @@
 
 import { useEffect } from "react";
 import { MinimalErrorFallback } from "@/components/error/error-fallback";
-import { normalizeThrownError } from "@/lib/client/normalize-thrown-error";
-import { getSessionId } from "@/lib/client/session";
-import { getUserIdFromUserStore } from "@/lib/client/user-store";
-import { errorService } from "@/lib/error-service";
-import { fireAndForget } from "@/lib/utils";
+import { reportRouteErrorBoundaryError } from "@/lib/telemetry/route-error-boundary";
 
 /**
  * Global error boundary for the app.
@@ -25,19 +21,9 @@ export default function GlobalError({
   reset: () => void;
 }) {
   useEffect(() => {
-    const normalized = normalizeThrownError(error);
-    // Report the critical error
-    const errorReport = errorService.createErrorReport(normalized, undefined, {
-      sessionId: getSessionId(),
-      userId: getUserIdFromUserStore(),
+    reportRouteErrorBoundaryError(error, {
+      context: "GlobalErrorBoundary",
     });
-
-    fireAndForget(errorService.reportError(errorReport));
-
-    // Log critical error in development (production uses errorService only)
-    if (process.env.NODE_ENV === "development") {
-      console.error("CRITICAL: Global error boundary caught error:", normalized);
-    }
   }, [error]);
 
   return (

--- a/src/components/auth/__tests__/reset-password-form.test.tsx
+++ b/src/components/auth/__tests__/reset-password-form.test.tsx
@@ -65,7 +65,39 @@ describe("ResetPasswordForm", () => {
           action: "parseResetResponse",
           context: "ResetPasswordForm",
           issueCount: expect.any(Number),
+          reason: "schema",
           status: 500,
+        }
+      );
+    });
+  });
+
+  it("reports non-JSON responses through telemetry and aborts processing", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("not json", {
+        headers: { "content-type": "text/plain" },
+        status: 502,
+        statusText: "Bad Gateway",
+      })
+    );
+
+    render(<ResetPasswordForm />);
+
+    fireEvent.change(screen.getByLabelText("Email Address"), {
+      target: { value: "traveler@example.com" },
+    });
+    fireEvent.submit(GetResetPasswordForm());
+
+    expect(await screen.findByText("Failed to send reset email")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockRecordClientErrorOnActiveSpan).toHaveBeenCalledWith(
+        expect.any(Error),
+        {
+          action: "parseResetResponse",
+          context: "ResetPasswordForm",
+          issueCount: 1,
+          reason: "json",
+          status: 502,
         }
       );
     });

--- a/src/components/auth/__tests__/reset-password-form.test.tsx
+++ b/src/components/auth/__tests__/reset-password-form.test.tsx
@@ -1,0 +1,73 @@
+/** @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ResetPasswordForm } from "@/components/auth/reset-password-form";
+import { fireEvent, render, screen, waitFor } from "@/test/test-utils";
+
+const { mockRecordClientErrorOnActiveSpan } = vi.hoisted(() => ({
+  mockRecordClientErrorOnActiveSpan: vi.fn(),
+}));
+
+vi.mock("@/lib/telemetry/client-errors", () => ({
+  recordClientErrorOnActiveSpan: mockRecordClientErrorOnActiveSpan,
+}));
+
+function GetResetPasswordForm(): HTMLFormElement {
+  const submitButton = screen.getByRole("button", {
+    name: /send reset instructions/i,
+  });
+  const form = submitButton.closest("form");
+  if (!form) {
+    throw new Error("Expected reset password form to be present");
+  }
+  return form;
+}
+
+describe("ResetPasswordForm", () => {
+  beforeEach(() => {
+    mockRecordClientErrorOnActiveSpan.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the password reset request form", () => {
+    render(<ResetPasswordForm />);
+
+    expect(
+      screen.getByRole("heading", { name: /reset your password/i })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Email Address")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /send reset instructions/i })
+    ).toBeInTheDocument();
+  });
+
+  it("reports malformed response payloads through telemetry and shows fallback error text", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify("unexpected response"), {
+        headers: { "content-type": "application/json" },
+        status: 500,
+        statusText: "Internal Server Error",
+      })
+    );
+
+    render(<ResetPasswordForm />);
+
+    fireEvent.change(screen.getByLabelText("Email Address"), {
+      target: { value: "traveler@example.com" },
+    });
+    fireEvent.submit(GetResetPasswordForm());
+
+    expect(await screen.findByText("Failed to send reset email")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockRecordClientErrorOnActiveSpan).toHaveBeenCalledWith(
+        expect.any(Error),
+        {
+          action: "parseResetResponse",
+          context: "ResetPasswordForm",
+          issueCount: expect.any(Number),
+          status: 500,
+        }
+      );
+    });
+  });
+});

--- a/src/components/auth/reset-password-form.tsx
+++ b/src/components/auth/reset-password-form.tsx
@@ -47,13 +47,18 @@ interface ResetPasswordFormProps {
 const DEFAULT_SUCCESS_MESSAGE =
   "Password reset instructions have been sent to your email";
 
-function ReportResetResponseValidationError(issueCount: number, status: number): void {
+function ReportResetResponseValidationError(
+  issueCount: number,
+  status: number,
+  reason = "schema"
+): void {
   recordClientErrorOnActiveSpan(
     new Error("Reset password response validation failed"),
     {
       action: "parseResetResponse",
       context: "ResetPasswordForm",
       issueCount,
+      reason,
       status,
     }
   );
@@ -103,7 +108,15 @@ export function ResetPasswordForm({ className }: ResetPasswordFormProps) {
         method: "POST",
       });
       // Parse and validate response with Zod for runtime guarantees
-      const rawData = await response.json().catch(() => ({}));
+      let rawData: unknown;
+      try {
+        rawData = await response.json();
+      } catch {
+        ReportResetResponseValidationError(1, response.status, "json");
+        setError("Failed to send reset email");
+        setIsLoading(false);
+        return;
+      }
       const parseResult = ResetResponseSchema.safeParse(rawData);
       const data = parseResult.success
         ? parseResult.data

--- a/src/components/auth/reset-password-form.tsx
+++ b/src/components/auth/reset-password-form.tsx
@@ -26,6 +26,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { getClientEnv } from "@/lib/env/client";
+import { recordClientErrorOnActiveSpan } from "@/lib/telemetry/client-errors";
 import { cn } from "@/lib/utils";
 import { statusVariants } from "@/lib/variants/status";
 
@@ -45,6 +46,19 @@ interface ResetPasswordFormProps {
 
 const DEFAULT_SUCCESS_MESSAGE =
   "Password reset instructions have been sent to your email";
+
+function ReportResetResponseValidationError(issueCount: number, status: number): void {
+  recordClientErrorOnActiveSpan(
+    new Error("Reset password response validation failed"),
+    {
+      action: "parseResetResponse",
+      context: "ResetPasswordForm",
+      issueCount,
+      status,
+    }
+  );
+}
+
 /**
  * Password reset form component.
  *
@@ -94,10 +108,10 @@ export function ResetPasswordForm({ className }: ResetPasswordFormProps) {
       const data = parseResult.success
         ? parseResult.data
         : { error: undefined, message: undefined };
-      if (!parseResult.success && process.env.NODE_ENV === "development") {
-        console.warn(
-          "Reset password response validation failed:",
-          parseResult.error.issues
+      if (!parseResult.success) {
+        ReportResetResponseValidationError(
+          parseResult.error.issues.length,
+          response.status
         );
       }
       if (!response.ok) {

--- a/src/components/error/__tests__/error-boundary.test.tsx
+++ b/src/components/error/__tests__/error-boundary.test.tsx
@@ -6,12 +6,18 @@ import { errorService } from "@/lib/error-service";
 import { fireEvent, renderWithProviders, screen, waitFor } from "@/test/test-utils";
 import { ErrorBoundary, WithErrorBoundary } from "../error-boundary";
 
+const TelemetrySpy = vi.hoisted(() => vi.fn());
+
 // Mock the error service
 vi.mock("@/lib/error-service", () => ({
   errorService: {
     createErrorReport: vi.fn(),
     reportError: vi.fn(),
   },
+}));
+
+vi.mock("@/lib/telemetry/client-errors", () => ({
+  recordClientErrorOnActiveSpan: TelemetrySpy,
 }));
 
 // Console spy refs (setup in beforeEach to ensure fresh spies per test)
@@ -45,6 +51,7 @@ describe("ErrorBoundary", () => {
   beforeEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
+    TelemetrySpy.mockClear();
 
     // Setup fresh console spies for each test
     ConsoleSpy = {
@@ -150,20 +157,19 @@ describe("ErrorBoundary", () => {
       );
     });
 
-    it("should log errors in development mode", () => {
-      const originalEnv = process.env.NODE_ENV;
-      vi.stubEnv("NODE_ENV", "development");
-
+    it("should record client telemetry when an error occurs", () => {
       renderWithProviders(
-        <ErrorBoundary>
+        <ErrorBoundary level="component">
           <ThrowError shouldThrow={true} />
         </ErrorBoundary>
       );
 
-      expect(ConsoleSpy.error).toHaveBeenCalled();
-      // Group logging may be suppressed in some environments; ensure at least one dev log occurred.
-
-      vi.stubEnv("NODE_ENV", originalEnv ?? "test");
+      expect(TelemetrySpy).toHaveBeenCalledWith(expect.any(Error), {
+        action: "render",
+        componentStack: expect.any(String),
+        context: "ErrorBoundary",
+        level: "component",
+      });
     });
   });
 

--- a/src/components/error/__tests__/error-boundary.test.tsx
+++ b/src/components/error/__tests__/error-boundary.test.tsx
@@ -108,6 +108,7 @@ describe("ErrorBoundary", () => {
 
       expect(errorService.createErrorReport).not.toHaveBeenCalled();
       expect(errorService.reportError).not.toHaveBeenCalled();
+      expect(TelemetrySpy).not.toHaveBeenCalled();
     });
   });
 
@@ -137,7 +138,14 @@ describe("ErrorBoundary", () => {
           sessionId: expect.any(String),
         })
       );
-      expect(errorService.reportError).toHaveBeenCalled();
+      expect(errorService.reportError).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          action: "render",
+          componentStack: expect.any(String),
+          context: "ErrorBoundary",
+        })
+      );
     });
 
     it("should call custom onError callback", () => {
@@ -157,19 +165,20 @@ describe("ErrorBoundary", () => {
       );
     });
 
-    it("should record client telemetry when an error occurs", () => {
+    it("should pass span metadata through error reporting when an error occurs", () => {
       renderWithProviders(
         <ErrorBoundary level="component">
           <ThrowError shouldThrow={true} />
         </ErrorBoundary>
       );
 
-      expect(TelemetrySpy).toHaveBeenCalledWith(expect.any(Error), {
+      expect(errorService.reportError).toHaveBeenCalledWith(expect.any(Object), {
         action: "render",
         componentStack: expect.any(String),
         context: "ErrorBoundary",
         level: "component",
       });
+      expect(TelemetrySpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/error/__tests__/error-fallback.test.tsx
+++ b/src/components/error/__tests__/error-fallback.test.tsx
@@ -23,6 +23,8 @@ describe("Error Fallback Components", () => {
   const mockError = new Error("Test error message") as Error & {
     digest?: string;
   };
+  const mockGoHome = vi.fn();
+  const mockReload = vi.fn();
   const mockReset = vi.fn();
   const mockRetry = vi.fn();
 
@@ -102,24 +104,30 @@ describe("Error Fallback Components", () => {
       expect(mockRetry).toHaveBeenCalledTimes(1);
     });
 
-    /** Test that the reload page button is handled without throwing */
+    /** Test that the reload page button invokes the recovery action */
     it("should handle reload page button", () => {
-      render(<ErrorFallback error={mockError} reset={mockReset} />);
+      render(
+        <ErrorFallback error={mockError} onReload={mockReload} reset={mockReset} />
+      );
 
       const reloadButton = screen.getByRole("button", { name: /reload page/i });
       expect(reloadButton).toBeInTheDocument();
 
-      expect(() => fireEvent.click(reloadButton)).not.toThrow();
+      fireEvent.click(reloadButton);
+      expect(mockReload).toHaveBeenCalledTimes(1);
     });
 
-    /** Test that the go home button is handled */
+    /** Test that the go home button invokes the recovery action */
     it("should handle go home button", () => {
-      render(<ErrorFallback error={mockError} reset={mockReset} />);
+      render(
+        <ErrorFallback error={mockError} onGoHome={mockGoHome} reset={mockReset} />
+      );
 
       const homeButton = screen.getByRole("button", { name: /go home/i });
       expect(homeButton).toBeInTheDocument();
 
-      expect(() => fireEvent.click(homeButton)).not.toThrow();
+      fireEvent.click(homeButton);
+      expect(mockGoHome).toHaveBeenCalledTimes(1);
     });
 
     /** Test that no buttons are rendered when no functions are provided */
@@ -207,14 +215,17 @@ describe("Error Fallback Components", () => {
 
     /** Test that the go to dashboard button is rendered */
     it("should render go to dashboard button", () => {
-      render(<PageErrorFallback error={mockError} reset={mockReset} />);
+      render(
+        <PageErrorFallback error={mockError} onGoHome={mockGoHome} reset={mockReset} />
+      );
 
       const dashboardButton = screen.getByRole("button", {
         name: /go to dashboard/i,
       });
       expect(dashboardButton).toBeInTheDocument();
 
-      expect(() => fireEvent.click(dashboardButton)).not.toThrow();
+      fireEvent.click(dashboardButton);
+      expect(mockGoHome).toHaveBeenCalledTimes(1);
     });
 
     /** Test that the error stack is shown in development mode */

--- a/src/components/error/error-boundary.tsx
+++ b/src/components/error/error-boundary.tsx
@@ -15,7 +15,6 @@ import { normalizeThrownError } from "@/lib/client/normalize-thrown-error";
 import { getSessionId } from "@/lib/client/session";
 import { getUserIdFromUserStore } from "@/lib/client/user-store";
 import { errorService } from "@/lib/error-service";
-import { recordClientErrorOnActiveSpan } from "@/lib/telemetry/client-errors";
 import { fireAndForget } from "@/lib/utils";
 import { ErrorFallback } from "./error-fallback";
 
@@ -46,19 +45,6 @@ function GetFallbackComponent(
   retry?: () => void;
 }> {
   return fallback ?? ErrorFallback;
-}
-
-function RecordClientTelemetry(
-  error: Error,
-  info: ErrorInfo,
-  level: ErrorBoundaryProps["level"]
-): void {
-  recordClientErrorOnActiveSpan(error, {
-    action: "render",
-    componentStack: info.componentStack,
-    context: COMPONENT_CONTEXT,
-    level,
-  });
 }
 
 export function ErrorBoundary({
@@ -94,8 +80,6 @@ export function ErrorBoundary({
           level,
         })
       );
-
-      RecordClientTelemetry(normalized, schemaInfo, level);
     },
     [level, onError]
   );

--- a/src/components/error/error-boundary.tsx
+++ b/src/components/error/error-boundary.tsx
@@ -15,6 +15,7 @@ import { normalizeThrownError } from "@/lib/client/normalize-thrown-error";
 import { getSessionId } from "@/lib/client/session";
 import { getUserIdFromUserStore } from "@/lib/client/user-store";
 import { errorService } from "@/lib/error-service";
+import { recordClientErrorOnActiveSpan } from "@/lib/telemetry/client-errors";
 import { fireAndForget } from "@/lib/utils";
 import { ErrorFallback } from "./error-fallback";
 
@@ -45,6 +46,19 @@ function GetFallbackComponent(
   retry?: () => void;
 }> {
   return fallback ?? ErrorFallback;
+}
+
+function RecordClientTelemetry(
+  error: Error,
+  info: ErrorInfo,
+  level: ErrorBoundaryProps["level"]
+): void {
+  recordClientErrorOnActiveSpan(error, {
+    action: "render",
+    componentStack: info.componentStack,
+    context: COMPONENT_CONTEXT,
+    level,
+  });
 }
 
 export function ErrorBoundary({
@@ -81,9 +95,7 @@ export function ErrorBoundary({
         })
       );
 
-      if (process.env.NODE_ENV === "development") {
-        console.error("ErrorBoundary caught error:", normalized);
-      }
+      RecordClientTelemetry(normalized, schemaInfo, level);
     },
     [level, onError]
   );

--- a/src/components/error/error-fallback.tsx
+++ b/src/components/error/error-fallback.tsx
@@ -18,7 +18,7 @@ import {
 import { normalizeThrownError } from "@/lib/client/normalize-thrown-error";
 
 /**
- * Default error fallback component for error boundaries
+ * Default error fallback component for error boundaries.
  */
 export function ErrorFallback({
   error,
@@ -140,7 +140,7 @@ export function MinimalErrorFallback({ error: _error, reset }: ErrorFallbackProp
 }
 
 /**
- * Page-level error fallback
+ * Page-level error fallback.
  */
 export function PageErrorFallback({ error, onGoHome, reset }: ErrorFallbackProps) {
   const normalized = normalizeThrownError(error);

--- a/src/components/error/error-fallback.tsx
+++ b/src/components/error/error-fallback.tsx
@@ -20,15 +20,29 @@ import { normalizeThrownError } from "@/lib/client/normalize-thrown-error";
 /**
  * Default error fallback component for error boundaries
  */
-export function ErrorFallback({ error, reset, retry }: ErrorFallbackProps) {
+export function ErrorFallback({
+  error,
+  onGoHome,
+  onReload,
+  reset,
+  retry,
+}: ErrorFallbackProps) {
   const isDev = process.env.NODE_ENV === "development";
   const normalized = normalizeThrownError(error);
 
   const handleGoHome = () => {
+    if (onGoHome) {
+      onGoHome();
+      return;
+    }
     window.location.href = "/";
   };
 
   const handleReload = () => {
+    if (onReload) {
+      onReload();
+      return;
+    }
     window.location.reload();
   };
 
@@ -128,8 +142,16 @@ export function MinimalErrorFallback({ error: _error, reset }: ErrorFallbackProp
 /**
  * Page-level error fallback
  */
-export function PageErrorFallback({ error, reset }: ErrorFallbackProps) {
+export function PageErrorFallback({ error, onGoHome, reset }: ErrorFallbackProps) {
   const normalized = normalizeThrownError(error);
+  const handleGoHome = () => {
+    if (onGoHome) {
+      onGoHome();
+      return;
+    }
+    window.location.href = "/";
+  };
+
   return (
     <div className="container mx-auto px-4 py-16">
       <div className="max-w-2xl mx-auto text-center space-y-6">
@@ -149,13 +171,7 @@ export function PageErrorFallback({ error, reset }: ErrorFallbackProps) {
               Try Again
             </Button>
           )}
-          <Button
-            onClick={() => {
-              window.location.href = "/";
-            }}
-            variant="outline"
-            size="lg"
-          >
+          <Button onClick={handleGoHome} variant="outline" size="lg">
             <HomeIcon aria-hidden="true" className="mr-2 h-5 w-5" />
             Go to Dashboard
           </Button>

--- a/src/components/providers/__tests__/botid-client.test.tsx
+++ b/src/components/providers/__tests__/botid-client.test.tsx
@@ -6,18 +6,25 @@ import { renderWithProviders, waitFor } from "@/test/test-utils";
 import { BotIdClientProvider } from "../botid-client";
 
 const INIT_SPY = vi.hoisted(() => vi.fn());
+const RECORD_CLIENT_ERROR_SPY = vi.hoisted(() => vi.fn());
 const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
 
 vi.mock("botid/client/core", () => ({
   initBotId: INIT_SPY,
 }));
 
+vi.mock("@/lib/telemetry/client-errors", () => ({
+  recordClientErrorOnActiveSpan: RECORD_CLIENT_ERROR_SPY,
+}));
+
 describe("BotIdClientProvider", () => {
   beforeEach(() => {
     vi.stubEnv("NODE_ENV", "development");
-    INIT_SPY.mockClear();
+    INIT_SPY.mockReset();
+    RECORD_CLIENT_ERROR_SPY.mockReset();
     globalThis.tripsageBotIdClientInitialized = undefined;
     globalThis.tripsageBotIdClientInitFailed = undefined;
+    globalThis.tripsageBotIdClientInitError = undefined;
   });
 
   afterAll(() => {
@@ -36,5 +43,41 @@ describe("BotIdClientProvider", () => {
     renderWithProviders(<BotIdClientProvider />);
 
     await waitFor(() => expect(INIT_SPY).toHaveBeenCalledTimes(1));
+  });
+
+  it("reports early instrumentation initialization failures through telemetry", async () => {
+    const earlyError = new Error("early init unavailable");
+    globalThis.tripsageBotIdClientInitFailed = true;
+    globalThis.tripsageBotIdClientInitError = earlyError;
+
+    renderWithProviders(<BotIdClientProvider />);
+
+    await waitFor(() => {
+      expect(RECORD_CLIENT_ERROR_SPY).toHaveBeenCalledWith(earlyError, {
+        action: "instrumentation-client",
+        context: "BotIdClientProvider",
+      });
+    });
+    expect(INIT_SPY).toHaveBeenCalledTimes(1);
+    expect(globalThis.tripsageBotIdClientInitFailed).toBe(false);
+    expect(globalThis.tripsageBotIdClientInitError).toBeUndefined();
+  });
+
+  it("reports provider initialization failures through telemetry", async () => {
+    const initError = new Error("provider init unavailable");
+    INIT_SPY.mockImplementationOnce(() => {
+      throw initError;
+    });
+
+    renderWithProviders(<BotIdClientProvider />);
+
+    await waitFor(() => {
+      expect(RECORD_CLIENT_ERROR_SPY).toHaveBeenCalledWith(initError, {
+        action: "ensureBotIdClientInitialized",
+        context: "BotIdClientProvider",
+      });
+    });
+    expect(globalThis.tripsageBotIdClientInitFailed).toBeUndefined();
+    expect(globalThis.tripsageBotIdClientInitError).toBeUndefined();
   });
 });

--- a/src/components/providers/__tests__/query-error-boundary.test.tsx
+++ b/src/components/providers/__tests__/query-error-boundary.test.tsx
@@ -2,7 +2,8 @@
 
 import { useQuery } from "@tanstack/react-query";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "@/lib/api/error-types";
 import {
   renderWithProviders,
@@ -14,6 +15,8 @@ import { QueryErrorBoundary } from "../query-error-boundary";
 
 const TELEMETRY_SPY = vi.hoisted(() => vi.fn());
 let retryAttempts = 0;
+let consoleErrorSpy: MockInstance<typeof console.error>;
+let unexpectedConsoleErrors: unknown[][] = [];
 
 vi.mock("@/lib/telemetry/client-errors", () => ({
   recordClientErrorOnActiveSpan: TELEMETRY_SPY,
@@ -41,11 +44,43 @@ const RecoveringQueryComponent = () => {
   return <div>{data}</div>;
 };
 
+function IsExpectedBoundaryDiagnostic(args: unknown[]): boolean {
+  const hasExpectedError = args.some(
+    (arg) =>
+      arg instanceof ApiError &&
+      ["auth", "boom", "denied", "server"].includes(arg.message)
+  );
+  const hasExpectedBoundaryText = args.some(
+    (arg) =>
+      typeof arg === "string" &&
+      (arg.includes("The above error occurred in the <ThrowingComponent>") ||
+        arg.includes("The above error occurred in the <RecoveringQueryComponent>") ||
+        arg.includes(
+          "React will try to recreate this component tree from scratch using the error boundary"
+        ))
+  );
+
+  return hasExpectedError && hasExpectedBoundaryText;
+}
+
 describe("QueryErrorBoundary", () => {
+  beforeEach(() => {
+    unexpectedConsoleErrors = [];
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation((...args) => {
+      if (IsExpectedBoundaryDiagnostic(args)) return;
+      unexpectedConsoleErrors.push(args);
+    });
+  });
+
   afterEach(() => {
-    TELEMETRY_SPY.mockClear();
-    retryAttempts = 0;
-    resetTestQueryClient();
+    try {
+      expect(unexpectedConsoleErrors).toEqual([]);
+    } finally {
+      consoleErrorSpy.mockRestore();
+      TELEMETRY_SPY.mockClear();
+      retryAttempts = 0;
+      resetTestQueryClient();
+    }
   });
 
   it("records telemetry with retry metadata when an error is thrown", async () => {

--- a/src/components/providers/__tests__/query-error-boundary.test.tsx
+++ b/src/components/providers/__tests__/query-error-boundary.test.tsx
@@ -44,6 +44,10 @@ const RecoveringQueryComponent = () => {
   return <div>{data}</div>;
 };
 
+/**
+ * Detects expected React error-boundary diagnostics by requiring both an
+ * expected ApiError and boundary-related console text.
+ */
 function IsExpectedBoundaryDiagnostic(args: unknown[]): boolean {
   const hasExpectedError = args.some(
     (arg) =>

--- a/src/components/providers/botid-client.tsx
+++ b/src/components/providers/botid-client.tsx
@@ -5,28 +5,36 @@
 "use client";
 
 import { useEffect } from "react";
-import { ensureBotIdClientInitialized } from "@/lib/security/botid-client";
+import {
+  consumeBotIdClientInitFailure,
+  ensureBotIdClientInitialized,
+} from "@/lib/security/botid-client";
 import { recordClientErrorOnActiveSpan } from "@/lib/telemetry/client-errors";
+
+function ReportBotIdInitFailure(error: Error, action: string): void {
+  recordClientErrorOnActiveSpan(error, {
+    action,
+    context: "BotIdClientProvider",
+  });
+}
 
 export function BotIdClientProvider() {
   useEffect(() => {
-    if (globalThis.tripsageBotIdClientInitFailed) {
-      globalThis.tripsageBotIdClientInitFailed = undefined;
-      recordClientErrorOnActiveSpan(new Error("BotID early initialization failed"), {
-        action: "instrumentation-client",
-        context: "BotIdClientProvider",
-      });
+    const earlyInitError = consumeBotIdClientInitFailure();
+    if (earlyInitError) {
+      ReportBotIdInitFailure(earlyInitError, "instrumentation-client");
     }
 
     try {
       ensureBotIdClientInitialized();
+      const providerInitError = consumeBotIdClientInitFailure();
+      if (providerInitError) {
+        ReportBotIdInitFailure(providerInitError, "ensureBotIdClientInitialized");
+      }
     } catch (error) {
       const exception =
         error instanceof Error ? error : new Error("BotID initialization failed");
-      recordClientErrorOnActiveSpan(exception, {
-        action: "ensureBotIdClientInitialized",
-        context: "BotIdClientProvider",
-      });
+      ReportBotIdInitFailure(exception, "ensureBotIdClientInitialized");
     }
   }, []);
 

--- a/src/components/providers/realtime-auth-provider.tsx
+++ b/src/components/providers/realtime-auth-provider.tsx
@@ -5,6 +5,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { recordClientErrorOnActiveSpan } from "@/lib/telemetry/client-errors";
 
 /**
  * Keeps Supabase Realtime authorized with the latest access token, reacting to
@@ -17,6 +18,17 @@ export function RealtimeAuthProvider(): null {
     let isMounted = true;
     let cleanupSubscription: (() => void) | null = null;
     let cleanupClientAuth: (() => void) | null = null;
+
+    const normalizeRealtimeAuthError = (error: unknown): Error => {
+      return error instanceof Error ? error : new Error(String(error));
+    };
+
+    const reportRealtimeAuthError = (error: unknown, action: string): void => {
+      recordClientErrorOnActiveSpan(normalizeRealtimeAuthError(error), {
+        action,
+        context: "RealtimeAuthProvider",
+      });
+    };
 
     // biome-ignore lint/style/useNamingConvention: Not a React hook
     async function initializeRealtimeAuthHandler(): Promise<void> {
@@ -49,17 +61,13 @@ export function RealtimeAuthProvider(): null {
         supabase.realtime.setAuth(token ?? "");
       } catch (error: unknown) {
         // Allow UI to operate; realtime auth will refresh when a valid token exists.
-        if (process.env.NODE_ENV === "development") {
-          console.error("Failed to get initial session:", error);
-        }
+        reportRealtimeAuthError(error, "getInitialSession");
       }
     }
 
     initializeRealtimeAuthHandler().catch((error: unknown) => {
       // Allow UI to operate; realtime auth will refresh when a valid token exists.
-      if (process.env.NODE_ENV === "development") {
-        console.error("initializeRealtimeAuthHandler failed:", error);
-      }
+      reportRealtimeAuthError(error, "initialize");
     });
 
     return () => {

--- a/src/domain/schemas/errors.ts
+++ b/src/domain/schemas/errors.ts
@@ -62,6 +62,8 @@ export type ErrorReport = z.infer<typeof errorReportSchema>;
  */
 export interface ErrorFallbackProps {
   error: unknown;
+  onGoHome?: () => void;
+  onReload?: () => void;
   reset?: () => void;
   retry?: () => void;
 }

--- a/src/features/search/components/cards/__tests__/amenities.test.tsx
+++ b/src/features/search/components/cards/__tests__/amenities.test.tsx
@@ -1,0 +1,21 @@
+/** @vitest-environment jsdom */
+
+import { describe, expect, it, vi } from "vitest";
+import { GetAmenityIcon } from "../amenities";
+
+describe("GetAmenityIcon", () => {
+  it("returns an icon component for supported amenities", () => {
+    const Icon = GetAmenityIcon("wifi");
+
+    expect(Icon).toBeDefined();
+  });
+
+  it("returns undefined for unknown amenities without logging raw diagnostics", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    expect(GetAmenityIcon("free_wifi")).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});

--- a/src/features/search/components/cards/__tests__/amenities.test.tsx
+++ b/src/features/search/components/cards/__tests__/amenities.test.tsx
@@ -1,9 +1,17 @@
 /** @vitest-environment jsdom */
 
-import { describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { GetAmenityIcon } from "../amenities";
 
 describe("GetAmenityIcon", () => {
+  let warnSpy: MockInstance<typeof console.warn> | undefined;
+
+  afterEach(() => {
+    warnSpy?.mockRestore();
+    warnSpy = undefined;
+  });
+
   it("returns an icon component for supported amenities", () => {
     const Icon = GetAmenityIcon("wifi");
 
@@ -11,11 +19,9 @@ describe("GetAmenityIcon", () => {
   });
 
   it("returns undefined for unknown amenities without logging raw diagnostics", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
     expect(GetAmenityIcon("free_wifi")).toBeUndefined();
     expect(warnSpy).not.toHaveBeenCalled();
-
-    warnSpy.mockRestore();
   });
 });

--- a/src/features/search/components/cards/amenities.tsx
+++ b/src/features/search/components/cards/amenities.tsx
@@ -41,10 +41,5 @@ const AmenityIconMap: Record<string, React.ComponentType<{ className?: string }>
 export function GetAmenityIcon(
   id: string
 ): React.ComponentType<{ className?: string }> | undefined {
-  if (process.env.NODE_ENV === "development" && !AmenityIconMap[id]) {
-    console.warn(
-      `Unknown amenity ID: "${id}". Supported IDs are: ${Object.keys(AmenityIconMap).join(", ")}`
-    );
-  }
   return AmenityIconMap[id];
 }

--- a/src/features/search/components/filters/__tests__/filter-range.test.tsx
+++ b/src/features/search/components/filters/__tests__/filter-range.test.tsx
@@ -1,0 +1,86 @@
+/** @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { FilterRange } from "../filter-range";
+
+const { mockRecordClientErrorOnActiveSpan } = vi.hoisted(() => ({
+  mockRecordClientErrorOnActiveSpan: vi.fn(),
+}));
+
+vi.mock("@/lib/telemetry/client-errors", () => ({
+  recordClientErrorOnActiveSpan: mockRecordClientErrorOnActiveSpan,
+}));
+
+describe("FilterRange", () => {
+  beforeEach(() => {
+    mockRecordClientErrorOnActiveSpan.mockReset();
+  });
+
+  it("renders the configured range label and current value", () => {
+    render(
+      <FilterRange
+        filterId="price_range"
+        label="Price"
+        min={0}
+        max={2000}
+        value={{ max: 500, min: 100 }}
+        onChange={vi.fn()}
+        formatValue={(value) => `$${value}`}
+      />
+    );
+
+    expect(screen.getByText("Price")).toBeInTheDocument();
+    expect(screen.getByText("$100 – $500")).toBeInTheDocument();
+    expect(mockRecordClientErrorOnActiveSpan).not.toHaveBeenCalled();
+  });
+
+  it("reports invalid configuration through telemetry and renders nothing", () => {
+    render(
+      <FilterRange
+        filterId="price_range"
+        label="Price"
+        min={100}
+        max={100}
+        step={0}
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText("Price")).not.toBeInTheDocument();
+    expect(mockRecordClientErrorOnActiveSpan).toHaveBeenCalledWith(expect.any(Error), {
+      action: "validateConfig",
+      context: "FilterRange",
+      filterId: "price_range",
+      max: 100,
+      min: 100,
+      step: 0,
+    });
+  });
+
+  it("keeps the null-render fallback when telemetry recording fails", () => {
+    mockRecordClientErrorOnActiveSpan.mockImplementationOnce(() => {
+      throw new Error("telemetry unavailable");
+    });
+
+    render(
+      <FilterRange
+        filterId="duration"
+        label="Duration"
+        min={60}
+        max={30}
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText("Duration")).not.toBeInTheDocument();
+    expect(mockRecordClientErrorOnActiveSpan).toHaveBeenCalledWith(expect.any(Error), {
+      action: "validateConfig",
+      context: "FilterRange",
+      filterId: "duration",
+      max: 30,
+      min: 60,
+      step: 1,
+    });
+  });
+});

--- a/src/features/search/components/filters/filter-range.tsx
+++ b/src/features/search/components/filters/filter-range.tsx
@@ -7,6 +7,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
+import { recordClientErrorOnActiveSpan } from "@/lib/telemetry/client-errors";
 
 export interface FilterRangeProps {
   /** Unique identifier for the filter */
@@ -33,6 +34,36 @@ export interface FilterRangeProps {
 
 /** Default value formatter */
 const DEFAULT_FORMAT_VALUE = (value: number) => value.toLocaleString();
+
+function ReportInvalidFilterRangeConfig({
+  filterId,
+  max,
+  min,
+  step,
+}: {
+  filterId: string;
+  max: number;
+  min: number;
+  step: number;
+}): void {
+  try {
+    recordClientErrorOnActiveSpan(
+      new Error(
+        "Invalid FilterRange props: min must be less than max and step must be positive."
+      ),
+      {
+        action: "validateConfig",
+        context: "FilterRange",
+        filterId,
+        max,
+        min,
+        step,
+      }
+    );
+  } catch {
+    // Preserve the existing null-render fallback if telemetry is unavailable.
+  }
+}
 
 /**
  * Range filter component with dual-thumb slider.
@@ -106,12 +137,12 @@ export function FilterRange({
     [filterId, onChange]
   );
 
+  useEffect(() => {
+    if (!hasInvalidConfig) return;
+    ReportInvalidFilterRangeConfig({ filterId, max, min, step });
+  }, [filterId, hasInvalidConfig, max, min, step]);
+
   if (hasInvalidConfig) {
-    if (process.env.NODE_ENV === "development") {
-      console.error(
-        `Invalid FilterRange props for "${filterId}": min (${min}) must be < max (${max}), and step (${step}) must be > 0`
-      );
-    }
     return null;
   }
 

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from "vitest";
-import { clampProgress } from "../utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clampProgress, fireAndForget } from "../utils";
+
+const FLUSH_MICROTASKS = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
 
 describe("clampProgress", () => {
   it("returns value within range unchanged", () => {
@@ -30,5 +38,28 @@ describe("clampProgress", () => {
     expect(clampProgress(Number.NaN)).toBe(0);
     expect(clampProgress(Number.POSITIVE_INFINITY)).toBe(100);
     expect(clampProgress(Number.NEGATIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe("fireAndForget", () => {
+  it("passes rejected errors to the explicit error handler", async () => {
+    const error = new Error("background task failed");
+    const onError = vi.fn();
+
+    fireAndForget(Promise.reject(error), onError);
+    await FLUSH_MICROTASKS();
+
+    expect(onError).toHaveBeenCalledWith(error);
+  });
+
+  it("swallows unhandled rejections without logging raw errors", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubGlobal("window", {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    fireAndForget(Promise.reject(new Error("sensitive background task failed")));
+    await FLUSH_MICROTASKS();
+
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/client/__tests__/clipboard.dom.test.ts
+++ b/src/lib/client/__tests__/clipboard.dom.test.ts
@@ -20,7 +20,7 @@ const ORIGINAL_EXEC_COMMAND_DESCRIPTOR = Object.getOwnPropertyDescriptor(
   "execCommand"
 );
 
-function RestoreProperty<T extends object>(
+function restoreProperty<T extends object>(
   target: T,
   property: keyof T,
   descriptor: PropertyDescriptor | undefined
@@ -33,14 +33,14 @@ function RestoreProperty<T extends object>(
   Reflect.deleteProperty(target, property);
 }
 
-function MockClipboardWriteText(writeText: (text: string) => Promise<void>): void {
+function mockClipboardWriteText(writeText: (text: string) => Promise<void>): void {
   Object.defineProperty(navigator, "clipboard", {
     configurable: true,
     value: { writeText },
   });
 }
 
-function MockExecCommand(result: boolean): void {
+function mockExecCommand(result: boolean): void {
   Object.defineProperty(document, "execCommand", {
     configurable: true,
     value: vi.fn(() => result),
@@ -54,14 +54,14 @@ describe("clipboard client helpers", () => {
   });
 
   afterEach(() => {
-    RestoreProperty(navigator, "clipboard", ORIGINAL_CLIPBOARD_DESCRIPTOR);
-    RestoreProperty(document, "execCommand", ORIGINAL_EXEC_COMMAND_DESCRIPTOR);
+    restoreProperty(navigator, "clipboard", ORIGINAL_CLIPBOARD_DESCRIPTOR);
+    restoreProperty(document, "execCommand", ORIGINAL_EXEC_COMMAND_DESCRIPTOR);
     vi.restoreAllMocks();
   });
 
   it("copies text through the Clipboard API when available", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
-    MockClipboardWriteText(writeText);
+    mockClipboardWriteText(writeText);
 
     await expect(copyTextToClipboard("share link")).resolves.toEqual({
       method: "clipboard",
@@ -73,8 +73,8 @@ describe("clipboard client helpers", () => {
 
   it("falls back to execCommand when Clipboard API writes fail", async () => {
     const writeText = vi.fn().mockRejectedValue(new Error("clipboard unavailable"));
-    MockClipboardWriteText(writeText);
-    MockExecCommand(true);
+    mockClipboardWriteText(writeText);
+    mockExecCommand(true);
 
     await expect(copyTextToClipboard("fallback link")).resolves.toEqual({
       method: "fallback",
@@ -88,8 +88,8 @@ describe("clipboard client helpers", () => {
     const copyError = new Error("clipboard failed");
     const writeText = vi.fn().mockRejectedValue(copyError);
     const toast = vi.fn();
-    MockClipboardWriteText(writeText);
-    MockExecCommand(false);
+    mockClipboardWriteText(writeText);
+    mockExecCommand(false);
 
     await expect(copyToClipboardWithToast("broken link", toast)).resolves.toEqual({
       error: copyError,

--- a/src/lib/client/__tests__/clipboard.dom.test.ts
+++ b/src/lib/client/__tests__/clipboard.dom.test.ts
@@ -1,0 +1,110 @@
+/** @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { copyTextToClipboard, copyToClipboardWithToast } from "@/lib/client/clipboard";
+
+const { mockRecordClientErrorOnActiveSpan } = vi.hoisted(() => ({
+  mockRecordClientErrorOnActiveSpan: vi.fn(),
+}));
+
+vi.mock("@/lib/telemetry/client-errors", () => ({
+  recordClientErrorOnActiveSpan: mockRecordClientErrorOnActiveSpan,
+}));
+
+const ORIGINAL_CLIPBOARD_DESCRIPTOR = Object.getOwnPropertyDescriptor(
+  navigator,
+  "clipboard"
+);
+const ORIGINAL_EXEC_COMMAND_DESCRIPTOR = Object.getOwnPropertyDescriptor(
+  document,
+  "execCommand"
+);
+
+function RestoreProperty<T extends object>(
+  target: T,
+  property: keyof T,
+  descriptor: PropertyDescriptor | undefined
+): void {
+  if (descriptor) {
+    Object.defineProperty(target, property, descriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(target, property);
+}
+
+function MockClipboardWriteText(writeText: (text: string) => Promise<void>): void {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+}
+
+function MockExecCommand(result: boolean): void {
+  Object.defineProperty(document, "execCommand", {
+    configurable: true,
+    value: vi.fn(() => result),
+  });
+}
+
+describe("clipboard client helpers", () => {
+  beforeEach(() => {
+    mockRecordClientErrorOnActiveSpan.mockReset();
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    RestoreProperty(navigator, "clipboard", ORIGINAL_CLIPBOARD_DESCRIPTOR);
+    RestoreProperty(document, "execCommand", ORIGINAL_EXEC_COMMAND_DESCRIPTOR);
+    vi.restoreAllMocks();
+  });
+
+  it("copies text through the Clipboard API when available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    MockClipboardWriteText(writeText);
+
+    await expect(copyTextToClipboard("share link")).resolves.toEqual({
+      method: "clipboard",
+      ok: true,
+    });
+    expect(writeText).toHaveBeenCalledWith("share link");
+    expect(mockRecordClientErrorOnActiveSpan).not.toHaveBeenCalled();
+  });
+
+  it("falls back to execCommand when Clipboard API writes fail", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("clipboard unavailable"));
+    MockClipboardWriteText(writeText);
+    MockExecCommand(true);
+
+    await expect(copyTextToClipboard("fallback link")).resolves.toEqual({
+      method: "fallback",
+      ok: true,
+    });
+    expect(document.execCommand).toHaveBeenCalledWith("copy");
+    expect(mockRecordClientErrorOnActiveSpan).not.toHaveBeenCalled();
+  });
+
+  it("reports generic copy failures through telemetry while preserving toast feedback", async () => {
+    const copyError = new Error("clipboard failed");
+    const writeText = vi.fn().mockRejectedValue(copyError);
+    const toast = vi.fn();
+    MockClipboardWriteText(writeText);
+    MockExecCommand(false);
+
+    await expect(copyToClipboardWithToast("broken link", toast)).resolves.toEqual({
+      error: copyError,
+      ok: false,
+      reason: "failed",
+    });
+    expect(toast).toHaveBeenCalledWith({
+      description: "Unable to copy. Please copy it manually.",
+      title: "Copy Failed",
+      variant: "destructive",
+    });
+    expect(mockRecordClientErrorOnActiveSpan).toHaveBeenCalledWith(copyError, {
+      action: "copyTextToClipboard",
+      context: "clipboard",
+      reason: "failed",
+    });
+  });
+});

--- a/src/lib/client/clipboard.ts
+++ b/src/lib/client/clipboard.ts
@@ -14,12 +14,12 @@ export type ClipboardCopyResult =
       error?: unknown;
     };
 
-function ToClipboardError(error: unknown): Error {
+function toClipboardError(error: unknown): Error {
   return error instanceof Error ? error : new Error("Clipboard copy failed");
 }
 
-function ReportClipboardCopyFailure(error: unknown): void {
-  recordClientErrorOnActiveSpan(ToClipboardError(error), {
+function reportClipboardCopyFailure(error: unknown): void {
+  recordClientErrorOnActiveSpan(toClipboardError(error), {
     action: "copyTextToClipboard",
     context: "clipboard",
     reason: "failed",
@@ -136,7 +136,7 @@ export async function copyToClipboardWithToast(
     case "failed":
       toast({ ...msgs.failed, variant: "destructive" });
       if (result.error) {
-        ReportClipboardCopyFailure(result.error);
+        reportClipboardCopyFailure(result.error);
       }
       break;
     default: {

--- a/src/lib/client/clipboard.ts
+++ b/src/lib/client/clipboard.ts
@@ -4,6 +4,8 @@
 
 "use client";
 
+import { recordClientErrorOnActiveSpan } from "@/lib/telemetry/client-errors";
+
 export type ClipboardCopyResult =
   | { ok: true; method: "clipboard" | "fallback" }
   | {
@@ -11,6 +13,18 @@ export type ClipboardCopyResult =
       reason: "permission-denied" | "insecure-context" | "unavailable" | "failed";
       error?: unknown;
     };
+
+function ToClipboardError(error: unknown): Error {
+  return error instanceof Error ? error : new Error("Clipboard copy failed");
+}
+
+function ReportClipboardCopyFailure(error: unknown): void {
+  recordClientErrorOnActiveSpan(ToClipboardError(error), {
+    action: "copyTextToClipboard",
+    context: "clipboard",
+    reason: "failed",
+  });
+}
 
 function copyTextWithExecCommand(text: string): boolean {
   if (typeof document === "undefined") return false;
@@ -121,8 +135,8 @@ export async function copyToClipboardWithToast(
       break;
     case "failed":
       toast({ ...msgs.failed, variant: "destructive" });
-      if (process.env.NODE_ENV === "development" && result.error) {
-        console.error("Clipboard copy failed:", result.error);
+      if (result.error) {
+        ReportClipboardCopyFailure(result.error);
       }
       break;
     default: {

--- a/src/lib/security/botid-client.ts
+++ b/src/lib/security/botid-client.ts
@@ -10,6 +10,18 @@ import { getBotIdProtectRules } from "@/config/botid-protect";
 declare global {
   var tripsageBotIdClientInitialized: boolean | undefined;
   var tripsageBotIdClientInitFailed: boolean | undefined;
+  var tripsageBotIdClientInitError: Error | undefined;
+}
+
+export function consumeBotIdClientInitFailure(): Error | null {
+  if (!globalThis.tripsageBotIdClientInitFailed) return null;
+
+  const error =
+    globalThis.tripsageBotIdClientInitError ??
+    new Error("BotID client initialization failed");
+  globalThis.tripsageBotIdClientInitFailed = undefined;
+  globalThis.tripsageBotIdClientInitError = undefined;
+  return error;
 }
 
 export function ensureBotIdClientInitialized(): void {
@@ -35,10 +47,10 @@ export function ensureBotIdClientInitialized(): void {
     }
   } catch (error) {
     // BotID client init failed; server-side verification remains enforced.
+    const exception =
+      error instanceof Error ? error : new Error("BotID client initialization failed");
     globalThis.tripsageBotIdClientInitFailed = true;
+    globalThis.tripsageBotIdClientInitError = exception;
     globalThis.tripsageBotIdClientInitialized = false;
-    if (process.env.NODE_ENV === "development") {
-      console.warn("[BotID] Client initialization failed:", error);
-    }
   }
 }

--- a/src/lib/security/botid-client.ts
+++ b/src/lib/security/botid-client.ts
@@ -13,6 +13,11 @@ declare global {
   var tripsageBotIdClientInitError: Error | undefined;
 }
 
+/**
+ * Consumes the most recent BotID client initialization failure.
+ *
+ * @returns The last initialization Error or null if no failure is pending.
+ */
 export function consumeBotIdClientInitFailure(): Error | null {
   if (!globalThis.tripsageBotIdClientInitFailed) return null;
 

--- a/src/lib/telemetry/__tests__/store-logger.test.ts
+++ b/src/lib/telemetry/__tests__/store-logger.test.ts
@@ -1,0 +1,57 @@
+/** @vitest-environment node */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const RECORD_CLIENT_ERROR_SPY = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/telemetry/client-errors", () => ({
+  recordClientErrorOnActiveSpan: RECORD_CLIENT_ERROR_SPY,
+}));
+
+import { createStoreLogger } from "../store-logger";
+
+interface ErrorWithDetails extends Error {
+  details?: Record<string, unknown>;
+}
+
+describe("createStoreLogger", () => {
+  beforeEach(() => {
+    RECORD_CLIENT_ERROR_SPY.mockReset();
+  });
+
+  it("records errors on the active client span with store metadata", () => {
+    const logger = createStoreLogger({
+      metadata: { slice: "filters" },
+      storeName: "search-store",
+    });
+
+    logger.error("Invalid filter state", { filterId: "price" });
+
+    expect(RECORD_CLIENT_ERROR_SPY).toHaveBeenCalledTimes(1);
+    const [captured] = RECORD_CLIENT_ERROR_SPY.mock.calls[0] ?? [];
+    const error = captured as ErrorWithDetails;
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe("[search-store] Invalid filter state");
+    expect(error.details).toEqual({
+      filterId: "price",
+      slice: "filters",
+      storeName: "search-store",
+    });
+  });
+
+  it("does not emit raw console diagnostics for non-error events", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const logger = createStoreLogger({ storeName: "ui-store" });
+
+    logger.info("Theme changed", { theme: "dark" });
+    logger.warn("Theme listener unavailable", { reason: "matchMedia" });
+
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(RECORD_CLIENT_ERROR_SPY).not.toHaveBeenCalled();
+
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+});

--- a/src/lib/telemetry/route-error-boundary.ts
+++ b/src/lib/telemetry/route-error-boundary.ts
@@ -9,7 +9,6 @@ import { getSessionId } from "@/lib/client/session";
 import { getUserIdFromUserStore } from "@/lib/client/user-store";
 import { errorService } from "@/lib/error-service";
 import { fireAndForget } from "@/lib/utils";
-import { recordClientErrorOnActiveSpan } from "./client-errors";
 
 interface RouteErrorBoundaryReportOptions {
   context: string;
@@ -31,9 +30,10 @@ export function reportRouteErrorBoundaryError(
   };
   const errorReport = errorService.createErrorReport(normalized, undefined, metadata);
 
-  fireAndForget(errorService.reportError(errorReport));
-  recordClientErrorOnActiveSpan(normalized, {
-    action: "render",
-    context,
-  });
+  fireAndForget(
+    errorService.reportError(errorReport, {
+      action: "render",
+      context,
+    })
+  );
 }

--- a/src/lib/telemetry/route-error-boundary.ts
+++ b/src/lib/telemetry/route-error-boundary.ts
@@ -18,6 +18,12 @@ interface RouteErrorBoundaryReportOptions {
 /**
  * Reports an App Router route-level boundary error to durable error reporting
  * and the currently active client span.
+ *
+ * @param error - Error value thrown by the route-level boundary.
+ * @param options - Route boundary reporting options.
+ * @param options.context - Telemetry context name for the boundary.
+ * @param options.includeUserId - Whether to include the current user ID.
+ * @returns Nothing.
  */
 export function reportRouteErrorBoundaryError(
   error: unknown,

--- a/src/lib/telemetry/route-error-boundary.ts
+++ b/src/lib/telemetry/route-error-boundary.ts
@@ -1,0 +1,39 @@
+/**
+ * @fileoverview Client telemetry helper for Next.js route error boundaries.
+ */
+
+"use client";
+
+import { normalizeThrownError } from "@/lib/client/normalize-thrown-error";
+import { getSessionId } from "@/lib/client/session";
+import { getUserIdFromUserStore } from "@/lib/client/user-store";
+import { errorService } from "@/lib/error-service";
+import { fireAndForget } from "@/lib/utils";
+import { recordClientErrorOnActiveSpan } from "./client-errors";
+
+interface RouteErrorBoundaryReportOptions {
+  context: string;
+  includeUserId?: boolean;
+}
+
+/**
+ * Reports an App Router route-level boundary error to durable error reporting
+ * and the currently active client span.
+ */
+export function reportRouteErrorBoundaryError(
+  error: unknown,
+  { context, includeUserId = true }: RouteErrorBoundaryReportOptions
+): void {
+  const normalized = normalizeThrownError(error);
+  const metadata = {
+    sessionId: getSessionId(),
+    ...(includeUserId ? { userId: getUserIdFromUserStore() } : {}),
+  };
+  const errorReport = errorService.createErrorReport(normalized, undefined, metadata);
+
+  fireAndForget(errorService.reportError(errorReport));
+  recordClientErrorOnActiveSpan(normalized, {
+    action: "render",
+    context,
+  });
+}

--- a/src/lib/telemetry/store-logger.ts
+++ b/src/lib/telemetry/store-logger.ts
@@ -21,7 +21,7 @@ interface StoreLogDetails {
  * Client-side logger for Zustand stores.
  *
  * Records errors to the active OTEL span when available.
- * Falls back to no-op in production for non-errors.
+ * Non-error store events are no-ops; use explicit telemetry for durable diagnostics.
  *
  * @param options - Configuration options including store name
  * @returns Logger object with error, warn, and info methods
@@ -47,47 +47,23 @@ export function createStoreLogger(options: StoreLogOptions) {
     },
 
     /**
-     * Log an info message. Development-only logging.
+     * Ignore non-error informational store events.
      *
      * @param message - Info message
      * @param details - Additional context
      */
-    info(message: string, details?: StoreLogDetails) {
-      if (process.env.NODE_ENV === "development") {
-        try {
-          if (details === undefined) {
-            console.log(`[${storeName}] ${message}`);
-          } else {
-            const safeDetails =
-              typeof details === "object" ? JSON.stringify(details) : String(details);
-            console.log(`[${storeName}] ${message}`, safeDetails);
-          }
-        } catch {
-          // Ignore stringification errors
-        }
-      }
+    info(_message: string, _details?: StoreLogDetails) {
+      // Non-error store events should not emit raw browser console diagnostics.
     },
 
     /**
-     * Log a warning. Development-only logging.
+     * Ignore non-error warning store events.
      *
      * @param message - Warning message
      * @param details - Additional context
      */
-    warn(message: string, details?: StoreLogDetails) {
-      if (process.env.NODE_ENV === "development") {
-        try {
-          if (details === undefined) {
-            console.warn(`[${storeName}] ${message}`);
-          } else {
-            const safeDetails =
-              typeof details === "object" ? JSON.stringify(details) : String(details);
-            console.warn(`[${storeName}] ${message}`, safeDetails);
-          }
-        } catch {
-          // Ignore stringification errors
-        }
-      }
+    warn(_message: string, _details?: StoreLogDetails) {
+      // Non-error store events should not emit raw browser console diagnostics.
     },
   };
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -138,24 +138,9 @@ export function fireAndForget<T>(
   promise: Promise<T>,
   onError?: (error: unknown) => void
 ): void {
-  const handleRejection = (_error: unknown) => {
+  const handleRejection = (error: unknown) => {
     if (onError) {
-      onError(_error);
-      return;
-    }
-
-    // Warn about missing error handler in development
-    const isClientDev =
-      typeof window !== "undefined" && process.env.NODE_ENV === "development";
-
-    if (isClientDev) {
-      console.warn(
-        "fireAndForget called without onError handler. Errors will be silently suppressed in production.",
-        {
-          error: _error,
-          stack: _error instanceof Error ? _error.stack : undefined,
-        }
-      );
+      onError(error);
     }
 
     // Swallow rejection silently when no handler provided


### PR DESCRIPTION
## Summary
- Centralize App Router route error-boundary reporting through `reportRouteErrorBoundaryError`.
- Replace development-only/raw client diagnostics with telemetry for component error boundaries, providers, reset-password parsing, clipboard copy failures, filter config validation, and store logging.
- Preserve resilient fallback behavior for error UI, filter null-render paths, clipboard failures, and BotID/Supabase Realtime initialization failures.
- Add focused coverage for the updated diagnostics paths and no-raw-console behavior.

## Why
- Client diagnostics should flow through the existing telemetry/error-reporting paths instead of ad hoc browser console logging.
- The remaining dirty tree had several related diagnostics hardening changes; grouping them into one PR keeps review velocity higher while preserving a single coherent intent.

## Scope
### Included
- Route-level error boundary reporting for root, global, auth, and dashboard boundaries.
- Component error boundary telemetry and fallback recovery handler typing.
- BotID and Supabase Realtime provider initialization/session failure telemetry.
- Reset password response-parse telemetry, clipboard failure telemetry, FilterRange invalid-config telemetry, amenity lookup no-console behavior, and store logger no-op behavior for non-errors.
- Focused tests for the included surfaces.

### Not included
- Workflow/dependency/lockfile changes.
- AI tool, search, trip, profile, budget/deals, calendar, chart deletion, and broader docs changes still present in the dirty tree.
- Hosted review-thread resolution comments or post-merge work.

## Release Please version impact
Versioning track:
- [ ] Pre-1.0 development track
- [x] Stable 1.0+ SemVer track
- [ ] Explicit repo override applies

Expected Release Please bump after merge to `main`:
- [ ] None
- [x] Patch
- [ ] Minor
- [ ] Major

Public API impact:
- [ ] No public API change
- [x] Public API changed, backward compatible
- [ ] Public API changed, breaking

Breaking changes:
- [x] None
- [ ] Yes

If breaking, describe the change, affected users/systems, and required migration steps:
- N/A

## Related issues / context
- Follow-up branch from the remaining dirty tree after PR #772.

## Implementation notes
- `reportRouteErrorBoundaryError` keeps durable `errorService` reporting and adds active-span telemetry from one helper.
- Fallback UI now accepts optional injected `onGoHome` and `onReload` handlers to make recovery actions testable without mutating browser globals.
- `FilterRange` reports invalid config from an effect rather than during render.
- BotID early initialization failures now preserve the original `Error` for later provider telemetry.

## Review guide
Recommended review order:
1. `src/lib/telemetry/route-error-boundary.ts` and route error boundary files.
2. `src/components/error/*` and associated tests.
3. Provider diagnostics in `src/components/providers/*` and `src/lib/security/botid-client.ts`.
4. Client helper/UI diagnostics in reset password, clipboard, filter range, amenities, store logger, and utils.

Areas needing extra attention:
- Ensure no telemetry calls introduce render-path side effects.
- Confirm fallback/error reporting behavior is preserved while raw console diagnostics are removed.

Specific feedback requested:
- [x] Correctness
- [x] Architecture
- [ ] API design
- [ ] Performance
- [ ] Security
- [x] Backward compatibility / migration
- [ ] UX / accessibility / copy

## Validation
### Automated
- [x] Tests added or updated
- [x] Type checks pass
- [x] Lint passes
- [ ] Build passes

Commands run in clean detached worktree:
- `pnpm install --frozen-lockfile`
- `pnpm biome:fix`
- `pnpm exec vitest run src/app/__tests__/error-boundaries-integration.test.tsx src/components/error/__tests__/error-boundary.test.tsx src/components/error/__tests__/error-fallback.test.tsx src/components/providers/__tests__/botid-client.test.tsx src/components/providers/__tests__/query-error-boundary.test.tsx src/__tests__/realtime-auth-provider.test.tsx src/components/auth/__tests__/reset-password-form.test.tsx src/features/search/components/cards/__tests__/amenities.test.tsx src/features/search/components/filters/__tests__/filter-range.test.tsx src/lib/client/__tests__/clipboard.dom.test.ts src/lib/telemetry/__tests__/store-logger.test.ts src/lib/__tests__/utils.test.ts`
- `pnpm type-check`
- `pnpm test:affected`
- `pnpm check:zod-v4`
- `pnpm check:api-route-errors`

### Manual
1. Verified the validation worktree stayed clean after formatting and checks.
2. Confirmed unrelated dirty-tree changes remained unstaged in the main checkout.

## Risk
- Medium.
- Error reporting and telemetry paths are broader than the previous small PRs, but behavior is covered by focused tests and existing durable reporting is preserved.
- Potential failure modes are duplicate telemetry or missed diagnostics; route/component/provider tests cover the expected calls.

## Rollout / rollback
- Roll out through the normal frontend deployment path.
- Roll back by reverting this PR; route boundaries and client helpers return to their previous local reporting/logging behavior.
