### PR TITLE
fix(cache): use Upstash SDK serialization

### DIFF
--- a/docs/architecture/decisions/adr-0054-upstash-testing-harness.md
+++ b/docs/architecture/decisions/adr-0054-upstash-testing-harness.md
@@ -17,7 +17,7 @@ Recent Vitest runs (`--pool=threads`) exposed brittle, duplicated Upstash mocks 
 We will adopt a three-tier Upstash testing strategy:
 
 1. **Unit-fast tier (default):** Shared in-memory stubs for `@upstash/redis` and `@upstash/ratelimit`, plus centralized MSW handlers for REST/QStash endpoints. Every suite will import the shared helper with a single `reset()` per test; use `vi.doMock` (not `vi.mock`) to stay thread-safe with hoisted evaluation under `--pool=threads`.
-2. **Local integration tier (optional):** Deterministic emulators (`upstash-redis-local` or equivalent REST-compatible server; QStash CLI dev server) started once per Vitest worker to validate HTTP contracts (auth headers, TTL, 429s) without external network. Prefer runtime Redis env names (`UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`) pointed at the emulator; `UPSTASH_EMULATOR_URL` is a legacy Redis alias.
+2. **Local integration tier (optional):** Deterministic emulators (`upstash-redis-local` or equivalent REST-compatible server; QStash CLI dev server) started once per Vitest worker to validate HTTP contracts (auth headers, TTL, 429s) without external network. Use runtime Redis env names (`UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`) pointed at the emulator.
 3. **Live contract smoke (gated):** A tiny serialized suite that hits real Upstash (Redis, Ratelimit, QStash publish) only when `UPSTASH_SMOKE=1` and secrets are present. Use runtime credential names (`UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `QSTASH_TOKEN`) plus `UPSTASH_QSTASH_SMOKE_TARGET_URL` for the disposable publish destination. Defaults to skipped in CI/PRs.
 
 Decision framework scoring (target ≥9/10 composite):

--- a/docs/development/testing/testing.md
+++ b/docs/development/testing/testing.md
@@ -127,7 +127,7 @@ Organize handlers by domain; compose with `composeHandlers`. Cover success + err
 
 - **Unit:** `setupUpstashMocks()` from `@/test/upstash/redis-mock`; call `redis.__reset()` and `ratelimit.__reset()` in `beforeEach`.
 - **HTTP:** `@/test/msw/handlers/upstash.ts` for pipeline/ratelimit/QStash.
-- **Emulator:** `UPSTASH_USE_EMULATOR=1` + `UPSTASH_REDIS_REST_URL` (Redis REST emulator; `UPSTASH_EMULATOR_URL` is a legacy alias) + `UPSTASH_QSTASH_DEV_URL`; helper in `@/test/upstash/emulator.ts`.
+- **Emulator:** `UPSTASH_USE_EMULATOR=1` + `UPSTASH_REDIS_REST_URL` (Redis REST emulator) + `UPSTASH_QSTASH_DEV_URL`; helper in `@/test/upstash/emulator.ts`.
 - **Smoke:** `pnpm test:upstash:smoke` with `UPSTASH_SMOKE=1`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `QSTASH_TOKEN`, and a disposable `UPSTASH_QSTASH_SMOKE_TARGET_URL`.
 
 ## AI SDK v6 Tests

--- a/src/lib/cache/__tests__/upstash.test.ts
+++ b/src/lib/cache/__tests__/upstash.test.ts
@@ -62,21 +62,21 @@ describe("getCachedJson", () => {
     expect(mockRedisGet).toHaveBeenCalledWith("missing-key");
   });
 
-  it("parses and returns valid JSON data", async () => {
+  it("returns SDK-deserialized cache data", async () => {
     const testData = { name: "test", value: 123 };
-    mockRedisGet.mockResolvedValue(JSON.stringify(testData));
+    mockRedisGet.mockResolvedValue(testData);
 
     const result = await getCachedJson<typeof testData>("valid-key");
 
     expect(result).toEqual(testData);
   });
 
-  it("returns null for invalid JSON", async () => {
-    mockRedisGet.mockResolvedValue("not valid json {");
+  it("returns string cache values from SDK deserialization", async () => {
+    mockRedisGet.mockResolvedValue("just a string");
 
-    const result = await getCachedJson("invalid-json-key");
+    const result = await getCachedJson<string>("string-key");
 
-    expect(result).toBeNull();
+    expect(result).toBe("just a string");
   });
 
   it("returns null when Redis throws", async () => {
@@ -93,7 +93,7 @@ describe("getCachedJson", () => {
       date: "2025-01-01T00:00:00Z",
       nested: { deep: { value: "test" } },
     };
-    mockRedisGet.mockResolvedValue(JSON.stringify(complexData));
+    mockRedisGet.mockResolvedValue(complexData);
 
     const result = await getCachedJson<typeof complexData>("complex-key");
 
@@ -125,22 +125,19 @@ describe("getCachedJsonSafe", () => {
 
   it("returns hit status with data for valid JSON", async () => {
     const testData = { id: 1, name: "test" };
-    mockRedisGet.mockResolvedValue(JSON.stringify(testData));
+    mockRedisGet.mockResolvedValue(testData);
 
     const result = await getCachedJsonSafe<typeof testData>("valid-key");
 
     expect(result).toEqual({ data: testData, status: "hit" });
   });
 
-  it("returns invalid status for malformed JSON", async () => {
+  it("returns hit status for string values when no schema is provided", async () => {
     mockRedisGet.mockResolvedValue("invalid json {{");
 
-    const result = await getCachedJsonSafe("bad-json-key");
+    const result = await getCachedJsonSafe<string>("string-key");
 
-    expect(result).toEqual({
-      raw: "invalid json {{",
-      status: "invalid",
-    });
+    expect(result).toEqual({ data: "invalid json {{", status: "hit" });
   });
 
   it("returns unavailable status when Redis throws", async () => {
@@ -157,7 +154,7 @@ describe("getCachedJsonSafe", () => {
       name: z.string(),
     });
     const validData = { id: 1, name: "test" };
-    mockRedisGet.mockResolvedValue(JSON.stringify(validData));
+    mockRedisGet.mockResolvedValue(validData);
 
     const result = await getCachedJsonSafe("schema-key", schema);
 
@@ -170,7 +167,7 @@ describe("getCachedJsonSafe", () => {
       name: z.string(),
     });
     const invalidData = { id: "not-a-number", name: 123 };
-    mockRedisGet.mockResolvedValue(JSON.stringify(invalidData));
+    mockRedisGet.mockResolvedValue(invalidData);
 
     const result = await getCachedJsonSafe("invalid-schema-key", schema);
 
@@ -202,12 +199,12 @@ describe("setCachedJson", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("sets JSON-stringified value without TTL", async () => {
+  it("sets values directly without TTL", async () => {
     const testData = { name: "test", value: 42 };
 
     await setCachedJson("no-ttl-key", testData);
 
-    expect(mockRedisSet).toHaveBeenCalledWith("no-ttl-key", JSON.stringify(testData));
+    expect(mockRedisSet).toHaveBeenCalledWith("no-ttl-key", testData);
   });
 
   it("sets value with TTL when ttlSeconds is positive", async () => {
@@ -215,7 +212,7 @@ describe("setCachedJson", () => {
 
     await setCachedJson("ttl-key", testData, 300);
 
-    expect(mockRedisSet).toHaveBeenCalledWith("ttl-key", JSON.stringify(testData), {
+    expect(mockRedisSet).toHaveBeenCalledWith("ttl-key", testData, {
       ex: 300,
     });
   });
@@ -225,7 +222,7 @@ describe("setCachedJson", () => {
 
     await setCachedJson("zero-ttl-key", testData, 0);
 
-    expect(mockRedisSet).toHaveBeenCalledWith("zero-ttl-key", JSON.stringify(testData));
+    expect(mockRedisSet).toHaveBeenCalledWith("zero-ttl-key", testData);
   });
 
   it("ignores TTL when ttlSeconds is negative", async () => {
@@ -233,10 +230,7 @@ describe("setCachedJson", () => {
 
     await setCachedJson("negative-ttl-key", testData, -100);
 
-    expect(mockRedisSet).toHaveBeenCalledWith(
-      "negative-ttl-key",
-      JSON.stringify(testData)
-    );
+    expect(mockRedisSet).toHaveBeenCalledWith("negative-ttl-key", testData);
   });
 
   it("handles arrays", async () => {
@@ -244,16 +238,13 @@ describe("setCachedJson", () => {
 
     await setCachedJson("array-key", arrayData);
 
-    expect(mockRedisSet).toHaveBeenCalledWith("array-key", JSON.stringify(arrayData));
+    expect(mockRedisSet).toHaveBeenCalledWith("array-key", arrayData);
   });
 
   it("handles primitive values", async () => {
     await setCachedJson("string-key", "just a string");
 
-    expect(mockRedisSet).toHaveBeenCalledWith(
-      "string-key",
-      JSON.stringify("just a string")
-    );
+    expect(mockRedisSet).toHaveBeenCalledWith("string-key", "just a string");
   });
 });
 

--- a/src/lib/cache/upstash.ts
+++ b/src/lib/cache/upstash.ts
@@ -59,9 +59,9 @@ export type CacheResult<T> =
 /**
  * Retrieves a cached JSON value from Upstash Redis.
  *
- * Deserializes the stored JSON string back to the specified type.
+ * Uses the Upstash Redis SDK's automatic deserialization for cached values.
  * Returns `null` if Redis is unavailable, key doesn't exist, or
- * deserialization fails.
+ * retrieval fails.
  *
  * @typeParam T - Expected type of the cached value.
  * @param key - Redis key to fetch.
@@ -93,29 +93,20 @@ export function getCachedJson<T>(
         return null;
       }
 
-      // We store JSON strings via JSON.stringify(), so we need to parse them manually.
-      // Upstash Redis only auto-deserializes when storing objects directly, not pre-stringified JSON.
-      let raw: string | null;
+      let cached: T | null;
       try {
-        raw = await redis.get<string>(key);
+        cached = await redis.get<T>(key);
       } catch (error) {
         captureCacheErrorOnSpan(span, error);
         return null;
       }
-      if (raw === null) {
+      if (cached === null) {
         span.setAttribute("cache.hit", false);
         return null;
       }
 
-      try {
-        span.setAttribute("cache.hit", true);
-        return JSON.parse(raw) as T;
-      } catch {
-        // Invalid JSON - return null to indicate cache miss/invalid data
-        span.setAttribute("cache.hit", false);
-        span.setAttribute("cache.parse_error", true);
-        return null;
-      }
+      span.setAttribute("cache.hit", true);
+      return cached;
     }
   );
 }
@@ -167,51 +158,50 @@ export function getCachedJsonSafe<T>(
         return { status: "unavailable" as const };
       }
 
-      // We store JSON strings via JSON.stringify(), so we need to parse them manually.
-      // Upstash Redis only auto-deserializes when storing objects directly, not pre-stringified JSON.
-      let raw: string | null;
+      let cached: unknown;
       try {
-        raw = await redis.get<string>(key);
+        cached = await redis.get<unknown>(key);
       } catch (error) {
         captureCacheErrorOnSpan(span, error);
         return { status: "unavailable" as const };
       }
-      if (raw === null) {
+      if (cached === null) {
         span.setAttribute("cache.status", "miss");
         return { status: "miss" as const };
       }
 
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(raw);
-      } catch {
-        // Invalid JSON - return invalid status with raw string
-        span.setAttribute("cache.status", "invalid");
-        return { raw, status: "invalid" as const };
-      }
-
       if (schema) {
-        const result = schema.safeParse(parsed);
+        const result = schema.safeParse(cached);
         if (!result.success) {
           span.setAttribute("cache.status", "invalid");
           span.setAttribute("cache.validation_failed", true);
-          return { raw: parsed, status: "invalid" as const };
+          return { raw: cached, status: "invalid" as const };
         }
         span.setAttribute("cache.status", "hit");
         return { data: result.data, status: "hit" as const };
       }
 
       span.setAttribute("cache.status", "hit");
-      return { data: parsed as T, status: "hit" as const };
+      return { data: cached as T, status: "hit" as const };
     }
   );
+}
+
+function estimateSerializedLength(value: unknown): number {
+  try {
+    const serialized =
+      typeof value === "string" ? value : (JSON.stringify(value) ?? "");
+    return serialized.length;
+  } catch {
+    return 0;
+  }
 }
 
 /**
  * Stores a JSON value in Upstash Redis with optional TTL.
  *
- * Serializes the value to JSON before storage. If `ttlSeconds` is
- * provided and positive, sets an expiration on the key.
+ * Relies on the Upstash Redis SDK to serialize JavaScript values. If
+ * `ttlSeconds` is provided and positive, sets an expiration on the key.
  *
  * @param key - Redis key to store the value under.
  * @param value - Value to serialize and cache (must be JSON-serializable).
@@ -250,14 +240,13 @@ export function setCachedJson(
         return;
       }
 
-      const payload = JSON.stringify(value);
-      span.setAttribute("cache.value_bytes", payload.length);
+      span.setAttribute("cache.value_bytes", estimateSerializedLength(value));
       try {
         if (ttlSeconds && ttlSeconds > 0) {
-          await redis.set(key, payload, { ex: ttlSeconds });
+          await redis.set(key, value, { ex: ttlSeconds });
           return;
         }
-        await redis.set(key, payload);
+        await redis.set(key, value);
       } catch (error) {
         captureCacheErrorOnSpan(span, error);
       }

--- a/src/test/upstash/emulator.ts
+++ b/src/test/upstash/emulator.ts
@@ -2,9 +2,9 @@
  * @fileoverview Optional Upstash emulator helpers.
  *
  * Reads and validates Upstash emulator config from env vars. No-op unless
- * UPSTASH_USE_EMULATOR=1. When enabled, prefer runtime Redis env
- * (UPSTASH_REDIS_REST_URL) pointed at the emulator; UPSTASH_EMULATOR_URL is
- * accepted as a legacy alias. QStash dev server still uses UPSTASH_QSTASH_DEV_URL
+ * UPSTASH_USE_EMULATOR=1. When enabled, point the runtime Redis env
+ * (UPSTASH_REDIS_REST_URL) at the emulator. QStash dev server still uses
+ * UPSTASH_QSTASH_DEV_URL
  * because production QStash publishes through the managed service endpoint.
  */
 
@@ -19,7 +19,7 @@ export function getEmulatorConfig(): EmulatorConfig {
   return {
     enabled,
     qstashUrl: process.env.UPSTASH_QSTASH_DEV_URL,
-    redisUrl: process.env.UPSTASH_REDIS_REST_URL ?? process.env.UPSTASH_EMULATOR_URL,
+    redisUrl: process.env.UPSTASH_REDIS_REST_URL,
   };
 }
 
@@ -29,7 +29,7 @@ export function startUpstashEmulators(): EmulatorConfig {
 
   if (!config.redisUrl) {
     throw new Error(
-      "UPSTASH_USE_EMULATOR=1 but UPSTASH_REDIS_REST_URL is not set; provide the Redis REST emulator URL (UPSTASH_EMULATOR_URL is accepted as a legacy alias)"
+      "UPSTASH_USE_EMULATOR=1 but UPSTASH_REDIS_REST_URL is not set; provide the Redis REST emulator URL"
     );
   }
 

--- a/src/test/upstash/index.ts
+++ b/src/test/upstash/index.ts
@@ -55,7 +55,7 @@ export type {
 export { createQStashMock } from "./qstash-mock";
 export type { RatelimitMockModule } from "./ratelimit-mock";
 // Re-export Ratelimit mock
-export { createRatelimitMock, RatelimitMock } from "./ratelimit-mock";
+export { createRatelimitMock } from "./ratelimit-mock";
 export type {
   RedisMockModule,
   UpstashMemoryStore,

--- a/src/test/upstash/ratelimit-mock.ts
+++ b/src/test/upstash/ratelimit-mock.ts
@@ -294,15 +294,3 @@ export function createRatelimitMock(): RatelimitMockModule {
     Ratelimit: RatelimitConstructor,
   };
 }
-
-// Legacy export for backwards compatibility
-// biome-ignore lint/complexity/noStaticOnlyClass: maintains backwards-compatible class API
-export class RatelimitMock {
-  static slidingWindow(limit: number, window: string): LimiterConfig {
-    return { intervalMs: parseWindow(window), limit, type: "sliding" };
-  }
-
-  static fixedWindow(limit: number, window: string): LimiterConfig {
-    return { intervalMs: parseWindow(window), limit, type: "fixed" };
-  }
-}

--- a/src/test/upstash/ratelimit.test.ts
+++ b/src/test/upstash/ratelimit.test.ts
@@ -6,7 +6,7 @@ import { withFakeTimers } from "@/test/utils/with-fake-timers";
 
 const ratelimit = createRatelimitMock();
 
-describe("RatelimitMock", () => {
+describe("Ratelimit mock module", () => {
   beforeEach(() => {
     ratelimit.__reset();
   });

--- a/src/test/upstash/redis-mock.ts
+++ b/src/test/upstash/redis-mock.ts
@@ -5,6 +5,8 @@
  * behavior with TTL tracking and pipeline support.
  */
 
+import { createRatelimitMock, type RatelimitMockModule } from "./ratelimit-mock";
+
 type StoredValue = {
   value: string;
   expiresAt?: number;
@@ -434,18 +436,9 @@ function objectFromTuples(args: string[]): Record<string, string> {
   return result;
 }
 
-// Re-export ratelimit mock for convenience
-export {
-  createRatelimitMock,
-  type RatelimitMockModule,
-} from "./ratelimit-mock";
-
-// Lazy import to avoid require() which doesn't work in vitest ESM context
-import { createRatelimitMock as createRl } from "./ratelimit-mock";
-
 export type UpstashMocks = {
   redis: RedisMockModule;
-  ratelimit: import("./ratelimit-mock").RatelimitMockModule;
+  ratelimit: RatelimitMockModule;
 };
 
 /**
@@ -469,6 +462,6 @@ export type UpstashMocks = {
  */
 export function setupUpstashMocks(): UpstashMocks {
   const redis = createRedisMock();
-  const ratelimit = createRl();
+  const ratelimit = createRatelimitMock();
   return { ratelimit, redis };
 }


### PR DESCRIPTION
## Summary
- Updates `getCachedJson*` and `setCachedJson` to rely on Upstash Redis SDK value serialization/deserialization instead of manual JSON string parsing.
- Keeps cache telemetry byte estimation without changing Redis write behavior to pre-stringified payloads.
- Removes stale Upstash test-harness compatibility aliases for `RatelimitMock` and `UPSTASH_EMULATOR_URL`.
- Aligns focused cache and Upstash test docs with the runtime env names and mock API.

## Why
- The Upstash SDK already serializes JavaScript values and deserializes reads. Manual `JSON.stringify`/`JSON.parse` creates drift between the helper contract and SDK behavior.
- Cache helpers should treat Redis string values as valid values unless a caller supplies a schema that rejects them.
- The legacy emulator alias and static ratelimit helper export were no longer used by the repo and made the test harness contract less clear.

## Scope
### Included
- `src/lib/cache/upstash.ts` cache read/write behavior update.
- Unit tests for SDK-deserialized objects, strings, TTL writes, arrays, and primitive values.
- Upstash test helper cleanup in `src/test/upstash/*`.
- ADR/testing doc updates for emulator env naming.

### Not included
- Package/dependency changes from the remaining dirty tree.
- Workflow or CI config changes from the remaining dirty tree.
- Live Upstash smoke-test execution.

## Release Please version impact
Versioning track:
- [ ] Pre-1.0 development track
- [x] Stable 1.0+ SemVer track
- [ ] Explicit repo override applies

Expected Release Please bump after merge to `main`:
- [ ] None
- [x] Patch
- [ ] Minor
- [ ] Major

Default interpretation for pre-1.0 repos unless explicitly overridden:
- `fix:` -> Patch
- `feat:` -> Patch
- `!` or `BREAKING CHANGE:` -> Minor

Public API impact:
- [x] No public API change
- [ ] Public API added
- [ ] Public API changed, backward compatible
- [ ] Public API changed, breaking

Breaking changes:
- [x] None
- [ ] Yes

If breaking, describe the change, affected users/systems, and required migration steps:
- N/A.

## Related issues / context
- Follow-up dirty-tree split after PR #774.
- No issue linked.

## Implementation notes
- `getCachedJson` now calls `redis.get<T>()` and returns the SDK-deserialized value directly.
- `getCachedJsonSafe` still returns `invalid` when a provided schema rejects the cached value.
- `setCachedJson` now writes the original value to Redis and uses a local serialized-length estimate only for telemetry.
- `UPSTASH_REDIS_REST_URL` is now the single Redis emulator env var for test helpers.

## Review guide
Recommended review order:
1. `src/lib/cache/upstash.ts`
2. `src/lib/cache/__tests__/upstash.test.ts`
3. `src/test/upstash/*`
4. Docs updates

Areas needing extra attention:
- Cache helper behavior for string values and schema validation failures.
- Test-harness export compatibility.
- Emulator env naming in docs and helper errors.

Specific feedback requested:
- [x] Correctness
- [ ] Architecture
- [x] API design
- [ ] Performance
- [ ] Security
- [x] Backward compatibility / migration
- [ ] UX / accessibility / copy

## Validation
### Automated
- [x] Tests added or updated
- [x] Type checks pass
- [x] Lint passes
- [ ] Build passes

Commands run in clean validation worktree `/home/bjorn/repos/agents/tripsage-ai-validate-upstash-cache`:
- `pnpm install --frozen-lockfile`
- `pnpm biome:fix`
- `pnpm exec vitest run src/lib/cache/__tests__/upstash.test.ts src/test/upstash/ratelimit.test.ts src/test/upstash/upstash.unit.test.ts`
- `pnpm type-check`
- `pnpm test:affected`
- `pnpm check:zod-v4`
- `pnpm check:api-route-errors`

### Manual
1. Confirmed `git diff --name-only main...HEAD` is limited to the Upstash/cache lane.
2. Confirmed no active source/test references remain for the removed `RatelimitMock` export.
3. Confirmed the clean validation worktree stayed clean after checks.

## Risk
Risk level:
- [ ] Low
- [x] Medium
- [ ] High

Main risks:
- Existing cached values written before this change may have been stored as JSON strings. Callers with schemas will reject incorrectly shaped values as invalid; callers without schemas can receive strings as valid cache hits.
- Any out-of-repo test code importing the removed `RatelimitMock` class or using `UPSTASH_EMULATOR_URL` will need to migrate.

## Rollout / rollback
- Feature flag: N/A.
- Deployment notes: Redis caches may naturally repopulate as TTLs expire.
- Monitoring to watch: cache hit/miss/invalid telemetry and Redis error rates.
- Rollback plan: Revert this PR to restore manual JSON serialization and legacy test aliases.

## Artifacts
- N/A.
