### PR TITLE
fix(activities): harden search client flow

### DIFF
--- a/docs/architecture/decisions/adr-0053-activity-search-google-places-integration.md
+++ b/docs/architecture/decisions/adr-0053-activity-search-google-places-integration.md
@@ -11,13 +11,14 @@
 
 ## Context
 
-TripSage AI currently has an incomplete activity search feature:
+At decision time, TripSage AI had an incomplete activity search feature. The current implementation now includes:
 
-- UI components exist (`/search/activities` page, `forms/activity-search-form`, `cards/activity-card`)
-- Zod schemas defined (`@schemas/search.ts`: `activitySchema`, `activitySearchParamsSchema`)
-- Database table exists (`search_activities` for durable search caching)
-- Hook placeholder exists (`useActivitySearch` with TODOs)
-- **Missing**: Backend API routes, AI SDK v6 tools, service layer, Google Places integration
+- UI components and page flow (`src/app/(app)/dashboard/search/activities`, `ActivitySearchForm`, `ActivityCard`)
+- Zod schemas defined in `@schemas/search` (`activitySchema`, `activitySearchParamsSchema`)
+- Supabase-backed search caching through the `search_activities` table
+- Backend API routes: `POST /api/activities/search` and `GET /api/activities/[id]`
+- AI SDK v6 tools: `searchActivities` and `getActivityDetails`
+- `ActivitiesService` plus Google Places helpers and guarded web-search fallback
 
 The accommodations feature (ADR-0050) uses Amadeus + Google Places for hotel search. Activities require a different approach:
 
@@ -43,7 +44,7 @@ We will implement activity search and (future) booking using a **hybrid provider
    - New tools in `src/ai/tools/server/activities.ts`:
      - `searchActivities` - wraps the activities service search (Places + cache + optional AI fallback).
      - `getActivityDetails` - wraps Place Details for a given Place ID.
-     - `bookActivity` - reserved for future integration; no partner/approval‑based APIs in scope.
+     - Activity booking remains out of scope for registered tools; no `bookActivity` tool is currently exported.
    - Tools are defined using `createAiTool` (`src/ai/lib/tool-factory.ts`) with Zod v4 input schemas from `@schemas/search.ts` and OTEL guardrails (caching, rate limiting, telemetry).
 
 4. **Service Layer** (`src/domain/activities/service.ts`)
@@ -65,7 +66,7 @@ We will implement activity search and (future) booking using a **hybrid provider
    - Upstash Redis is used **only for rate limiting and existing shared infra**, not as an additional cache layer for this feature to keep KISS/YAGNI.
 
 7. **Stripe integration** (deferred)
-   - Future `bookActivity` implementation may reuse the existing booking payment orchestrator (`src/lib/payments/booking-payment.ts`) but **no partner/approval‑based activity APIs** (Viator/GetYourGuide, etc.) are in scope for this ADR.
+   - A future partner booking implementation may reuse the existing booking payment orchestrator (`src/lib/payments/booking-payment.ts`) but **no partner/approval‑based activity APIs** (Viator/GetYourGuide, etc.) are in scope for this ADR.
 
 ## Options Considered
 
@@ -165,7 +166,7 @@ We adopt a **heuristically gated web search fallback** pattern for this ADR:
 
 ### Positive
 
-- Completes visible feature gap in UI
+- Completes visible feature gap in UI through the activity search page and route-backed results
 - Enables activity search in AI chat via tools
 - Follows established patterns (accommodations/flights) and reuses `createAiTool`, `withApiGuards`, and OTEL spans
 - Leverages existing Google Places integration and geocoding helpers while aligning with Places API (New) usage/billing recommendations (field masks, minimal data)
@@ -180,13 +181,12 @@ We adopt a **heuristically gated web search fallback** pattern for this ADR:
 - Limited real-time availability/pricing data from Places; activity pricing remains approximate
 - Additional Google Places API costs; must be managed via field masks, aggressive caching, and quotas
 - Hybrid fallback path increases complexity (routing logic, instrumentation, testing)
-- Requires implementing new activities service layer and tools from scratch
+- Adds activity-specific service/tool/cache logic that must be maintained alongside Places and web-search contracts
 
 ### Neutral
 
-- Database table already exists; just needs to be populated
-- Schemas already defined; minimal changes needed
-- UI components exist; backend integration needed
+- Database table and schemas are reused as the durable cache and contract boundaries
+- Direct partner booking remains deferred; activity results can still be saved to trips or linked externally
 
 ## References
 

--- a/docs/development/frontend/activities.md
+++ b/docs/development/frontend/activities.md
@@ -1,6 +1,6 @@
 # Activities Developer Guide
 
-Activity search and booking via Google Places API (New) with optional AI/web fallback. See SPEC-0030 and ADR-0053 for architecture details.
+Activity search and details via Google Places API (New) with optional AI/web fallback. Partner booking remains deferred; current UI flows support activity discovery, trip saving, and external links. See SPEC-0030 and ADR-0053 for architecture details.
 
 ## Overview
 
@@ -24,9 +24,9 @@ The activities feature provides:
 The `ActivitiesService` is a pure, DI-friendly orchestrator:
 
 ```typescript
-import { getActivitiesService } from "@domain/activities/container";
+import { createActivitiesService } from "@/lib/activities/service-factory";
 
-const service = getActivitiesService();
+const service = createActivitiesService({});
 
 // Search activities
 const result = await service.search(
@@ -115,7 +115,6 @@ const result = await searchActivities.execute({
 
 - `searchActivities` - Search with Google Places + optional AI fallback
 - `getActivityDetails` - Retrieve activity details by Place ID
-- `bookActivity` - Placeholder (deferred - no partner APIs)
 
 **Tool Features:**
 
@@ -175,7 +174,7 @@ const activity: Activity = {
 **Supabase `search_activities` Table:**
 
 - **Primary Results** (Google Places): 24-hour TTL
-- **Fallback Results** (AI/web): 6-hour TTL
+- **Fallback Results** (AI/web): persisted with source metadata under the same search-cache TTL
 - **Cache Key**: Normalized `query_hash` computed from search parameters
 - **Source Tracking**: `source` field distinguishes `googleplaces`, `ai_fallback`, `cached`
 
@@ -199,7 +198,7 @@ const activity: Activity = {
 1. Invoke `webSearch` tool with compact query (`"things to do in {destination}"`)
 2. Normalize web search results into `Activity[]` format
 3. Label as `source = 'ai_fallback'`
-4. Persist with shorter TTL (6 hours)
+4. Persist with fallback metadata and source labels
 5. Return combined results with metadata indicating sources
 
 **Important:** AI fallback results are clearly labeled and should not be used for booking or treated as authoritative.
@@ -224,39 +223,18 @@ const query = buildActivitySearchQuery("Paris", "museums");
 
 Photo names from Places API are returned as identifiers. Full URL resolution can be done via `GET /v1/{photoName}` if needed.
 
-## React Hook
+## Client Page Flow
 
-**File**: `src/hooks/use-activity-search.ts`
+**Files**: `src/app/(app)/dashboard/search/activities/activities-search-client.tsx` and `actions.ts`
 
 ```typescript
-import { useActivitySearch } from "@/hooks/use-activity-search";
+import type { ActivitySearchParams } from "@schemas/search";
 
-function ActivitySearchComponent() {
-  const {
-    searchActivities,
-    isSearching,
-    searchError,
-    results,
-    searchMetadata,
-    resetSearch,
-  } = useActivitySearch();
+async function handleSearch(params: ActivitySearchParams) {
+  const normalizedParams = await onSubmitServer(params);
+  if (!normalizedParams.ok) return;
 
-  const handleSearch = async () => {
-    await searchActivities({
-      destination: "Paris",
-      category: "museums",
-    });
-  };
-
-  return (
-    <div>
-      {isSearching && <p>Searching...</p>}
-      {searchError && <p>Error: {searchError.message}</p>}
-      {results?.map((activity) => (
-        <ActivityCard key={activity.id} activity={activity} />
-      ))}
-    </div>
-  );
+  await executeSearch(normalizedParams.data);
 }
 ```
 
@@ -281,13 +259,13 @@ function ActivitySearchComponent() {
 - Schema validation
 - Error mapping
 
-**Hook Tests**: `src/hooks/__tests__/use-activity-search.test.tsx`
+**Client Tests**: `src/app/(app)/dashboard/search/activities/__tests__/activities-search-client.test.tsx`
 
-- Hook behavior
+- Page search behavior
 - API integration
 - State management
 
-**MSW Handlers**: `src/test/msw/handlers/google-places.ts`
+**MSW Handlers**: `src/test/msw/handlers/google.ts`
 
 - Mock Google Places API responses
 - Activity-specific search responses

--- a/docs/development/frontend/search-hooks.md
+++ b/docs/development/frontend/search-hooks.md
@@ -4,183 +4,93 @@ This document describes the intentional pattern differences in search hooks and 
 
 ## Overview
 
-The TripSage search domain uses three distinct hook patterns, each optimized for different use cases:
+The TripSage search domain uses three distinct client patterns, each optimized for different use cases:
 
-| Pattern | Hook | Best For |
-|---------|------|----------|
-| React Query Integration | `useAccommodationSearch` | Store-integrated searches with caching |
-| Self-Contained State | `useActivitySearch` | Searches with custom metadata |
-| External API Integration | `useDestinationSearch` | Third-party APIs via BFF routes (`/api/places/**`) |
+| Pattern | Surface | Best For |
+|---------|---------|----------|
+| Route-backed orchestration | `useSearchOrchestration` | Flight, hotel, and activity searches through API routes and Zustand stores |
+| Server action validation + client execution | `submitActivitySearch` + `ActivitiesSearchClient` | Page flows that need server-side validation before client fetch/store updates |
+| External API integration | `useDestinationSearch` | Third-party APIs via BFF routes (`/api/places/**`) |
 
-## Pattern 1: React Query Integration
+## Pattern 1: Route-Backed Orchestration
 
-**Example:** `useAccommodationSearch`
+**Example:** `useSearchOrchestration`
 
 **Characteristics:**
 
-- Uses `useMutation` for search operations
-- Uses `useQuery` for suggestions with stale time caching
-- Integrates with `search-params-store` and `search-results-store`
-- Tracks search lifecycle in Zustand stores
+- Initializes the active search type across params and filters stores.
+- Executes route-backed searches through `SEARCH_ENDPOINTS`.
+- Maps route responses into `SearchResults`.
+- Tracks search lifecycle, metrics, errors, history, and retry state in Zustand stores.
 
 **Dependencies:**
 
-- `@tanstack/react-query`
 - `search-params-store`
+- `search-filters-store`
 - `search-results-store`
+- `search-history-store`
 
 **Use when:**
 
-- Search results should be cached
-- Need integration with centralized store state
-- Want automatic retry and error handling from React Query
-- Building a primary search flow
+- Building route-backed flight, hotel, or activity pages.
+- Results need to participate in global search state, filters, history, retry, or saved-search flows.
+- The route response needs mapping into the shared `SearchResults` shape.
 
 **Code pattern:**
 
 ```typescript
-// Example simplified for clarity; imports (React, React Query, apiClient) omitted.
-// AccommodationSearchResponse below is a sample response contract—replace with your real type.
-type AccommodationSearchResponse = { results: Accommodation[] };
-type AccommodationSuggestion = { id: string; name: string };
-export function useAccommodationSearch() {
-  const { updateAccommodationParams } = useSearchParamsStore();
-  const { startSearch, setSearchResults, setSearchError, completeSearch } =
-    useSearchResultsStore();
-  const currentSearchIdRef = useRef<string | null>(null);
-  const getSuggestions = useQuery({
-    queryKey: ["accommodation-suggestions"],
-    // Replace with your suggestions endpoint/client
-    queryFn: () => apiClient.get<AccommodationSuggestion[]>("/accommodations/suggestions"),
-    staleTime: 5 * 60 * 1000,
-  });
+const { initializeSearch, executeSearch, isSearching } = useSearchOrchestration();
 
-  const searchMutation = useMutation({
-    mutationFn: async (params: SearchAccommodationParams) => {
-      const response = await apiClient.post<AccommodationSearchResponse>(
-        "/accommodations/search",
-        params
-      );
-      return response;
-    },
-    onMutate: (params) => {
-      // Track in store
-      currentSearchIdRef.current = startSearch("accommodation", { ...params });
-    },
-  });
+useEffect(() => {
+  initializeSearch("activity");
+}, [initializeSearch]);
 
-  // Handle success/error in useEffect to update stores
-  useEffect(() => {
-    if (searchMutation.data && currentSearchIdRef.current) {
-      setSearchResults(currentSearchIdRef.current, {
-        accommodations: searchMutation.data.results,
-      });
-      completeSearch(currentSearchIdRef.current);
-    } else if (searchMutation.error && currentSearchIdRef.current) {
-      setSearchError(currentSearchIdRef.current, searchMutation.error);
-      completeSearch(currentSearchIdRef.current);
-    }
-  }, [
-    searchMutation.data,
-    searchMutation.error,
-    setSearchResults,
-    setSearchError,
-    completeSearch,
-  ]);
-
-  return {
-    isSearching: searchMutation.isPending,
-    search: searchMutation.mutate,
-    searchAsync: searchMutation.mutateAsync,
-    searchError: searchMutation.error,
-    suggestions: getSuggestions.data,
-    updateParams: updateAccommodationParams,
-  };
+async function handleSearch(params: ActivitySearchParams, signal?: AbortSignal) {
+  await executeSearch(params, signal);
 }
 ```
 
-## Pattern 2: Self-Contained State
+## Pattern 2: Server Action Validation + Client Execution
 
-**Example:** `useActivitySearch`
+**Example:** activity search page flow
 
 **Characteristics:**
 
-- Uses local `useState` for all state management
-- Provides custom metadata beyond results (source, cached flag)
-- Direct fetch calls without React Query
-- More control over state transitions
+- Uses a Server Action for validation and telemetry.
+- Executes the route-backed search on the client through `useSearchOrchestration`.
+- Uses an `AbortController` to cancel stale requests.
+- Keeps page-local UI state, such as selected activity and trip-selection modal state, inside the page client component.
 
 **Dependencies:**
 
-- React `useState`, `useCallback`
-- No external state library required
+- `src/app/(app)/dashboard/search/activities/actions.ts`
+- `src/app/(app)/dashboard/search/activities/activities-search-client.tsx`
+- `useSearchOrchestration`
+- `useAbortableSearchTask`
 
 **Use when:**
 
-- Need custom metadata tracking (e.g., data source, cache status)
-- Search is self-contained and doesn't need global coordination
-- Want simpler state management without query library
-- Building secondary or specialized search flows
+- Search params need server-side validation or telemetry before execution.
+- The page needs route-backed results plus page-specific UI state.
+- The flow must prevent stale in-flight searches from updating the UI.
 
 **Code pattern:**
 
 ```typescript
-export function useActivitySearch(): UseActivitySearchResult {
-  const [isSearching, setIsSearching] = useState(false);
-  const [searchError, setSearchError] = useState<Error | null>(null);
-  const [results, setResults] = useState<Activity[] | null>(null);
-  const [searchMetadata, setSearchMetadata] = useState<Metadata | null>(null);
+const { executeSearch } = useSearchOrchestration();
+const { clearSearchController, startSearchController } = useAbortableSearchTask();
 
-  const searchActivities = useCallback(async (params: ActivitySearchParams) => {
-    setIsSearching(true);
-    setSearchError(null);
+const handleSearch = useCallback(async (params: ActivitySearchParams) => {
+  const controller = startSearchController();
+  try {
+    const normalizedParams = await onSubmitServer(params);
+    if (controller.signal.aborted || !normalizedParams.ok) return;
 
-    try {
-      const response = await fetch("/api/activities/search", {
-        body: JSON.stringify(params),
-        method: "POST",
-      });
-
-      const data = await response.json();
-      setResults(data.activities);
-      setSearchMetadata(data.metadata);
-    } catch (error) {
-      setSearchError(error as Error);
-      setResults(null);
-    } finally {
-      setIsSearching(false);
-    }
-  }, []);
-
-  const resetSearch = useCallback(() => {
-    setIsSearching(false);
-    setSearchError(null);
-    setResults(null);
-    setSearchMetadata(null);
-    // Optional: abort any in-flight request here.
-  }, []);
-
-  const saveSearch = useCallback((params: ActivitySearchParams) => {
-    // Persist locally; replace with API call if needed.
-    localStorage.setItem("latest-activity-search", JSON.stringify(params));
-    setSearchMetadata((prev) => ({
-      ...(prev ?? {}),
-      savedAt: new Date().toISOString(),
-      source: "local",
-    }));
-  }, []);
-
-  return {
-    isSearching,
-    searchError,
-    results,
-    searchMetadata,
-    searchActivities,
-    resetSearch,
-    saveSearch,
-    // Add more helpers as needed (e.g., debounce, cache hydration)
-  };
-}
+    await executeSearch(normalizedParams.data, controller.signal);
+  } finally {
+    clearSearchController(controller);
+  }
+}, [clearSearchController, executeSearch, onSubmitServer, startSearchController]);
 ```
 
 ## Pattern 3: External API Integration
@@ -265,21 +175,20 @@ If the same normalization logic is needed in other hooks, extract
 
 ## Decision Guide
 
-### Default to Pattern 1 (React Query)
+### Default to Pattern 1 (Route-Backed Orchestration)
 
 Use for new search types when:
 
 - Building primary search flows
-- Need caching and automatic background refetching
+- Need route-backed execution and shared result mapping
 - Want integration with search history and saved searches
-- Need consistent error handling and retry logic
+- Need consistent error handling, metrics, and retry state
 
-### Use Pattern 2 (Self-Contained) when
+### Use Pattern 2 (Server Action Validation + Client Execution) when
 
-- Metadata tracking is important (source, cache status, timing)
-- Search is specialized and standalone
-- Want full control over state transitions
-- Avoiding React Query dependency for simplicity
+- Server-side validation, auth-aware lookups, or telemetry should happen before client execution.
+- Page-local UI state is larger than the shared search result state.
+- Stale in-flight requests must be explicitly cancelled.
 
 ### Use Pattern 3 (External API) when
 
@@ -298,11 +207,9 @@ Use `SearchFormShell` component for consistent form handling:
 import { SearchFormShell } from "@/features/search/components/common/search-form-shell";
 
 <SearchFormShell
-  schema={flightSearchSchema}
-  defaultValues={{ origin: "", destination: "" }}
+  form={form}
   onSubmit={handleSearch}
   telemetrySpanName="flight.search"
-  popularItems={popularDestinations}
 >
   {(form) => (
     <>
@@ -318,16 +225,23 @@ import { SearchFormShell } from "@/features/search/components/common/search-form
 Use cross-store selectors for unified state access:
 
 ```typescript
+import { useSearchOrchestration } from "@/features/search/hooks/search/use-search-orchestration";
 import {
-  useSearchSummary,
-  useActiveFiltersSummary,
-  useSearchValidation,
-} from "@/stores/selectors/search-selectors";
+  useActiveFilterCount,
+  useHasActiveFilters,
+} from "@/features/search/store/search-filters-store";
+import {
+  useSearchParamsValidation,
+  useSearchType,
+} from "@/features/search/store/search-params-store";
 
 function SearchDashboard() {
-  const { searchType, resultCount, isSearching } = useSearchSummary();
-  const { count: filterCount, hasFilters } = useActiveFiltersSummary();
-  const { isValid, paramsErrors } = useSearchValidation();
+  const { getSearchSummary, isSearching } = useSearchOrchestration();
+  const searchType = useSearchType();
+  const filterCount = useActiveFilterCount();
+  const hasFilters = useHasActiveFilters();
+  const { hasValidParams, validationErrors } = useSearchParamsValidation();
+  const summary = getSearchSummary();
 
   // Unified view of search state from multiple stores
 }

--- a/e2e/activities-search.spec.ts
+++ b/e2e/activities-search.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/test";
+import { authenticateAsTestUser, resetTestAuth } from "./helpers/auth";
+
+test.describe("Activities Search", () => {
+  test.beforeEach(async ({ page }) => {
+    await resetTestAuth(page);
+  });
+
+  test("renders the authenticated activities search page", async ({ page }) => {
+    await authenticateAsTestUser(page);
+    await page.goto("/dashboard/search/activities", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { level: 1, name: "Search" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Search Activities" })
+    ).toBeVisible();
+    await expect(page.getByText("Discover Amazing Activities")).toBeVisible();
+  });
+});

--- a/src/app/(app)/dashboard/search/activities/__tests__/activities-search-client.test.tsx
+++ b/src/app/(app)/dashboard/search/activities/__tests__/activities-search-client.test.tsx
@@ -1,0 +1,182 @@
+/** @vitest-environment jsdom */
+
+import type { Activity, ActivitySearchParams } from "@schemas/search";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sampleActivity: Activity = {
+  date: "2099-06-01",
+  description: "Guided museum visit",
+  duration: 2,
+  id: "activity-1",
+  location: "Paris",
+  name: "Museum Tour",
+  price: 25,
+  rating: 4.5,
+  type: "Museum",
+};
+
+const {
+  mockExecuteSearch,
+  mockGetPlanningTrips,
+  mockInitializeSearch,
+  mockRecordClientErrorOnActiveSpan,
+  mockToast,
+} = vi.hoisted(() => ({
+  mockExecuteSearch: vi.fn(),
+  mockGetPlanningTrips: vi.fn(),
+  mockInitializeSearch: vi.fn(),
+  mockRecordClientErrorOnActiveSpan: vi.fn(),
+  mockToast: vi.fn(),
+}));
+
+const { mockSearchResultsState } = vi.hoisted(() => ({
+  mockSearchResultsState: {
+    error: null as Error | null,
+    metrics: { provider: "TestProvider" },
+    results: { activities: [] as Activity[] },
+  },
+}));
+
+const { mockComparisonState, mockUseComparisonStore } = vi.hoisted(() => {
+  const comparisonState = {
+    addItem: vi.fn(),
+    clearByType: vi.fn(),
+    getItemsByType: vi.fn(() => []),
+    hasItem: vi.fn(() => false),
+    removeItem: vi.fn(),
+  };
+  const useStore = <T,>(selector: (state: typeof comparisonState) => T): T =>
+    selector(comparisonState);
+  return {
+    mockComparisonState: comparisonState,
+    mockUseComparisonStore: Object.assign(useStore, {
+      getState: () => comparisonState,
+    }),
+  };
+});
+
+vi.mock("@/components/layouts/search-layout", () => ({
+  SearchLayout: ({ children }: { children: React.ReactNode }) => (
+    <main>{children}</main>
+  ),
+}));
+
+vi.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock("@/features/search/components/cards/activity-card", () => ({
+  ActivityCard: ({
+    activity,
+    onSelect,
+  }: {
+    activity: Activity;
+    onSelect?: (activity: Activity) => void;
+  }) => (
+    <button type="button" onClick={() => onSelect?.(activity)}>
+      Select {activity.name}
+    </button>
+  ),
+}));
+
+vi.mock("@/features/search/components/forms/activity-search-form", () => ({
+  ActivitySearchForm: () => <div data-testid="activity-search-form" />,
+}));
+
+vi.mock("@/features/search/components/modals/activity-comparison-modal", () => ({
+  ActivityComparisonModal: () => null,
+}));
+
+vi.mock("@/features/search/components/modals/trip-selection-modal", () => ({
+  TripSelectionModal: () => null,
+}));
+
+vi.mock("@/features/search/hooks/search/use-search-orchestration", () => ({
+  useSearchOrchestration: () => ({
+    executeSearch: mockExecuteSearch,
+    initializeSearch: mockInitializeSearch,
+    isSearching: false,
+  }),
+}));
+
+vi.mock("@/features/search/store/comparison-store", () => ({
+  useComparisonStore: mockUseComparisonStore,
+}));
+
+vi.mock("@/features/search/store/search-results-store", () => ({
+  useSearchResultsStore: <T,>(
+    selector: (state: typeof mockSearchResultsState) => T
+  ): T => selector(mockSearchResultsState),
+}));
+
+vi.mock("@/lib/telemetry/client-errors", () => ({
+  recordClientErrorOnActiveSpan: mockRecordClientErrorOnActiveSpan,
+}));
+
+vi.mock("../actions", () => ({
+  addActivityToTrip: vi.fn(),
+  getPlanningTrips: mockGetPlanningTrips,
+}));
+
+vi.mock("../activities-selection-dialog", () => ({
+  ActivitiesSelectionDialog: ({
+    isOpen,
+    onAddToTrip,
+    selectedActivity,
+  }: {
+    isOpen: boolean;
+    onAddToTrip: () => void;
+    selectedActivity: Activity | null;
+  }) =>
+    isOpen && selectedActivity ? (
+      <button type="button" onClick={onAddToTrip}>
+        Add {selectedActivity.name} to trip
+      </button>
+    ) : null,
+}));
+
+import ActivitiesSearchClient from "../activities-search-client";
+
+describe("ActivitiesSearchClient", () => {
+  beforeEach(() => {
+    mockComparisonState.addItem.mockReset();
+    mockComparisonState.clearByType.mockReset();
+    mockComparisonState.getItemsByType.mockReset();
+    mockComparisonState.getItemsByType.mockReturnValue([]);
+    mockComparisonState.hasItem.mockReset();
+    mockComparisonState.hasItem.mockReturnValue(false);
+    mockComparisonState.removeItem.mockReset();
+    mockExecuteSearch.mockReset();
+    mockGetPlanningTrips.mockReset();
+    mockInitializeSearch.mockReset();
+    mockRecordClientErrorOnActiveSpan.mockReset();
+    mockToast.mockReset();
+    mockSearchResultsState.error = null;
+    mockSearchResultsState.metrics = { provider: "TestProvider" };
+    mockSearchResultsState.results = { activities: [sampleActivity] };
+  });
+
+  it("reports trip-loading failures through telemetry", async () => {
+    const loadError = new Error("trip fetch failed");
+    mockGetPlanningTrips.mockRejectedValueOnce(loadError);
+    const onSubmitServer = vi.fn<(params: ActivitySearchParams) => Promise<never>>();
+
+    render(<ActivitiesSearchClient onSubmitServer={onSubmitServer} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Select Museum Tour" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add Museum Tour to trip" }));
+
+    await waitFor(() => {
+      expect(mockRecordClientErrorOnActiveSpan).toHaveBeenCalledWith(loadError, {
+        action: "loadTrips",
+        context: "ActivitiesSearchClient",
+      });
+    });
+    expect(mockToast).toHaveBeenCalledWith({
+      description: "trip fetch failed",
+      title: "Error",
+      variant: "destructive",
+    });
+  });
+});

--- a/src/app/(app)/dashboard/search/activities/activities-search-client.tsx
+++ b/src/app/(app)/dashboard/search/activities/activities-search-client.tsx
@@ -42,6 +42,7 @@ import { useSearchResultsStore } from "@/features/search/store/search-results-st
 import { openActivityBooking } from "@/lib/activities/booking";
 import { getErrorMessage } from "@/lib/api/error-types";
 import type { Result, ResultError } from "@/lib/result";
+import { recordClientErrorOnActiveSpan } from "@/lib/telemetry/client-errors";
 import { addActivityToTrip, getPlanningTrips } from "./actions";
 import { ActivitiesSelectionDialog } from "./activities-selection-dialog";
 import { isActivity, partitionActivitiesByFallback } from "./activity-results";
@@ -59,6 +60,16 @@ const ACTIVITY_COLORS = {
   aiSuggestionIcon: "text-highlight",
   successIcon: "text-success",
 } as const;
+
+function normalizeActivitiesClientError(
+  error: unknown,
+  fallbackMessage: string
+): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  return new Error(error ? String(error) : fallbackMessage);
+}
 
 /** Activity search client component props. */
 interface ActivitiesSearchClientProps {
@@ -216,17 +227,16 @@ export default function ActivitiesSearchClient({
       setTrips(fetchedTrips.data);
       setIsTripModalOpen(true);
     } catch (error) {
-      const message =
-        error instanceof Error
-          ? error.message
-          : error
-            ? String(error)
-            : "Failed to load trips.";
-      if (process.env.NODE_ENV === "development") {
-        console.error("Failed to load trips:", error);
-      }
+      const normalizedError = normalizeActivitiesClientError(
+        error,
+        "Failed to load trips."
+      );
+      recordClientErrorOnActiveSpan(normalizedError, {
+        action: "loadTrips",
+        context: "ActivitiesSearchClient",
+      });
       toast({
-        description: message || "Failed to load trips.",
+        description: normalizedError.message || "Failed to load trips.",
         title: "Error",
         variant: "destructive",
       });

--- a/src/app/(app)/dashboard/search/activities/activities-search-client.tsx
+++ b/src/app/(app)/dashboard/search/activities/activities-search-client.tsx
@@ -76,7 +76,7 @@ function normalizeActivitiesClientError(
   if (error instanceof Error) {
     return error;
   }
-  return new Error(error ? String(error) : fallbackMessage);
+  return new Error(getErrorMessage(error) || fallbackMessage);
 }
 
 /** Activity search client component props. */

--- a/src/app/(app)/dashboard/search/activities/activities-search-client.tsx
+++ b/src/app/(app)/dashboard/search/activities/activities-search-client.tsx
@@ -63,6 +63,12 @@ const ACTIVITY_COLORS = {
 
 const EMPTY_ACTIVITIES: Activity[] = [];
 
+/**
+ * Converts thrown values from client activity flows into displayable Error objects.
+ *
+ * @param error - The value caught by the caller.
+ * @param fallbackMessage - Message used when the thrown value is empty.
+ */
 function normalizeActivitiesClientError(
   error: unknown,
   fallbackMessage: string
@@ -108,12 +114,10 @@ export default function ActivitiesSearchClient({
   const [pendingAddFromComparison, setPendingAddFromComparison] = useState(false);
   const [hasSearched, setHasSearched] = useState(false);
   const didInitFromUrlParams = useRef(false);
-  const { addItem, removeItem, clearByType, hasItem } = useComparisonStore((state) => ({
-    addItem: state.addItem,
-    clearByType: state.clearByType,
-    hasItem: state.hasItem,
-    removeItem: state.removeItem,
-  }));
+  const addItem = useComparisonStore((state) => state.addItem);
+  const clearByType = useComparisonStore((state) => state.clearByType);
+  const hasItem = useComparisonStore((state) => state.hasItem);
+  const removeItem = useComparisonStore((state) => state.removeItem);
   const activityComparisonItems = useComparisonStore((state) =>
     state.getItemsByType("activity")
   );

--- a/src/app/(app)/dashboard/search/activities/activities-search-client.tsx
+++ b/src/app/(app)/dashboard/search/activities/activities-search-client.tsx
@@ -61,6 +61,8 @@ const ACTIVITY_COLORS = {
   successIcon: "text-success",
 } as const;
 
+const EMPTY_ACTIVITIES: Activity[] = [];
+
 function normalizeActivitiesClientError(
   error: unknown,
   fallbackMessage: string
@@ -96,7 +98,9 @@ export default function ActivitiesSearchClient({
   const [selectedActivity, setSelectedActivity] = useState<Activity | null>(null);
   const { initializeSearch, executeSearch, isSearching } = useSearchOrchestration();
   const searchError = useSearchResultsStore((state) => state.error);
-  const activities = useSearchResultsStore((state) => state.results.activities ?? []);
+  const activities = useSearchResultsStore(
+    (state) => state.results.activities ?? EMPTY_ACTIVITIES
+  );
   const searchMetadata = useSearchResultsStore((state) => state.metrics);
   const primaryActionRef = useRef<HTMLButtonElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);

--- a/src/features/search/components/modals/__tests__/activity-comparison-modal.test.tsx
+++ b/src/features/search/components/modals/__tests__/activity-comparison-modal.test.tsx
@@ -3,17 +3,6 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ActivityComparisonModal } from "../activity-comparison-modal";
 
-// Mock Lucide icons
-vi.mock("lucide-react", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("lucide-react")>();
-  return {
-    ...actual,
-    MapPin: () => <div data-testid="map-pin-icon" />,
-    Star: () => <div data-testid="star-icon" />,
-    X: () => <div data-testid="x-icon" />,
-  };
-});
-
 // Mock Next.js Image
 vi.mock("next/image", () => ({
   default: (props: { alt: string }) => (

--- a/src/features/search/components/modals/__tests__/trip-selection-modal.test.tsx
+++ b/src/features/search/components/modals/__tests__/trip-selection-modal.test.tsx
@@ -45,6 +45,13 @@ const MOCK_TRIPS: UiTrip[] = [
   },
 ];
 
+const EXPECTED_TRIP_START_DATE = new Intl.DateTimeFormat(undefined, {
+  day: "numeric",
+  month: "short",
+  timeZone: "UTC",
+  year: "numeric",
+}).format(new Date(Date.UTC(2026, 5, 1)));
+
 /** Renders the modal with default props and user-event helpers. */
 function RenderTripSelectionModal(
   overrides: Partial<Parameters<typeof TripSelectionModal>[0]> = {}
@@ -80,7 +87,7 @@ describe("TripSelectionModal", () => {
     const { props, user } = RenderTripSelectionModal();
     const addButton = screen.getByRole("button", { name: "Add to Trip" });
 
-    expect(screen.getByText("Jun 1, 2026")).toBeInTheDocument();
+    expect(screen.getByText(EXPECTED_TRIP_START_DATE)).toBeInTheDocument();
     expect(addButton).toBeDisabled();
 
     await user.click(GetTripLabel("Paris Spring"));

--- a/src/features/search/components/modals/__tests__/trip-selection-modal.test.tsx
+++ b/src/features/search/components/modals/__tests__/trip-selection-modal.test.tsx
@@ -1,3 +1,5 @@
+/** @vitest-environment jsdom */
+
 import type { Activity } from "@schemas/search";
 import type { UiTrip } from "@schemas/trips";
 import { render, screen } from "@testing-library/react";
@@ -76,6 +78,7 @@ describe("TripSelectionModal", () => {
     const { props, user } = RenderTripSelectionModal();
     const addButton = screen.getByRole("button", { name: "Add to Trip" });
 
+    expect(screen.getByText("Jun 1, 2026")).toBeInTheDocument();
     expect(addButton).toBeDisabled();
 
     await user.click(GetTripLabel("Paris Spring"));

--- a/src/features/search/components/modals/__tests__/trip-selection-modal.test.tsx
+++ b/src/features/search/components/modals/__tests__/trip-selection-modal.test.tsx
@@ -45,6 +45,7 @@ const MOCK_TRIPS: UiTrip[] = [
   },
 ];
 
+/** Renders the modal with default props and user-event helpers. */
 function RenderTripSelectionModal(
   overrides: Partial<Parameters<typeof TripSelectionModal>[0]> = {}
 ) {
@@ -65,6 +66,7 @@ function RenderTripSelectionModal(
   };
 }
 
+/** Finds the clickable label for a trip name in the modal list. */
 function GetTripLabel(name: string): HTMLLabelElement {
   const label = screen.getByText(name).closest("label");
   if (!(label instanceof HTMLLabelElement)) {

--- a/src/features/search/components/modals/__tests__/trip-selection-modal.test.tsx
+++ b/src/features/search/components/modals/__tests__/trip-selection-modal.test.tsx
@@ -1,0 +1,112 @@
+import type { Activity } from "@schemas/search";
+import type { UiTrip } from "@schemas/trips";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { TripSelectionModal } from "../trip-selection-modal";
+
+const MOCK_ACTIVITY: Activity = {
+  coordinates: { lat: 48.8566, lng: 2.3522 },
+  date: "2026-06-01T00:00:00Z",
+  description: "Guided museum tour",
+  duration: 120,
+  id: "activity-1",
+  images: [],
+  location: "Paris",
+  name: "Louvre Highlights",
+  price: 75,
+  rating: 4.7,
+  type: "tour",
+};
+
+const NEXT_ACTIVITY: Activity = {
+  ...MOCK_ACTIVITY,
+  id: "activity-2",
+  name: "Seine Evening Cruise",
+};
+
+const MOCK_TRIPS: UiTrip[] = [
+  {
+    currency: "USD",
+    destination: "Paris",
+    destinations: [],
+    id: "trip-1",
+    startDate: "2026-06-01",
+    title: "Paris Spring",
+  },
+  {
+    currency: "USD",
+    destination: "Rome",
+    destinations: [],
+    id: "trip-2",
+    title: "Rome Weekend",
+  },
+];
+
+function RenderTripSelectionModal(
+  overrides: Partial<Parameters<typeof TripSelectionModal>[0]> = {}
+) {
+  const props: Parameters<typeof TripSelectionModal>[0] = {
+    activity: MOCK_ACTIVITY,
+    isAdding: false,
+    isOpen: true,
+    onAddToTrip: vi.fn().mockResolvedValue(undefined),
+    onClose: vi.fn(),
+    trips: MOCK_TRIPS,
+    ...overrides,
+  };
+
+  return {
+    props,
+    user: userEvent.setup(),
+    ...render(<TripSelectionModal {...props} />),
+  };
+}
+
+function GetTripLabel(name: string): HTMLLabelElement {
+  const label = screen.getByText(name).closest("label");
+  if (!(label instanceof HTMLLabelElement)) {
+    throw new Error(`Missing label for trip: ${name}`);
+  }
+  return label;
+}
+
+describe("TripSelectionModal", () => {
+  it("adds the selected trip", async () => {
+    const { props, user } = RenderTripSelectionModal();
+    const addButton = screen.getByRole("button", { name: "Add to Trip" });
+
+    expect(addButton).toBeDisabled();
+
+    await user.click(GetTripLabel("Paris Spring"));
+
+    expect(addButton).toBeEnabled();
+
+    await user.click(addButton);
+
+    expect(props.onAddToTrip).toHaveBeenCalledWith("trip-1");
+  });
+
+  it("resets the selected trip when the activity changes", async () => {
+    const { props, rerender, user } = RenderTripSelectionModal();
+
+    await user.click(GetTripLabel("Paris Spring"));
+    expect(screen.getByRole("button", { name: "Add to Trip" })).toBeEnabled();
+
+    rerender(<TripSelectionModal {...props} activity={NEXT_ACTIVITY} />);
+
+    expect(screen.getByRole("button", { name: "Add to Trip" })).toBeDisabled();
+  });
+
+  it("resets the selected trip when reopened", async () => {
+    const { props, rerender, user } = RenderTripSelectionModal();
+
+    await user.click(GetTripLabel("Paris Spring"));
+    expect(screen.getByRole("button", { name: "Add to Trip" })).toBeEnabled();
+
+    rerender(<TripSelectionModal {...props} isOpen={false} />);
+    rerender(<TripSelectionModal {...props} isOpen />);
+
+    expect(screen.getByRole("button", { name: "Add to Trip" })).toBeDisabled();
+  });
+});

--- a/src/features/search/components/modals/trip-selection-modal.tsx
+++ b/src/features/search/components/modals/trip-selection-modal.tsx
@@ -8,7 +8,7 @@ import type { Activity } from "@schemas/search";
 import type { UiTrip } from "@schemas/trips";
 import { CalendarIcon, MapPinIcon } from "lucide-react";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -53,6 +53,31 @@ export function TripSelectionModal({
   onAddToTrip,
   isAdding,
 }: TripSelectionModalProps) {
+  const resetKey = `${isOpen ? "open" : "closed"}:${activity.id}`;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <TripSelectionModalContent
+        key={resetKey}
+        activity={activity}
+        trips={trips}
+        onAddToTrip={onAddToTrip}
+        onClose={onClose}
+        isAdding={isAdding}
+      />
+    </Dialog>
+  );
+}
+
+type TripSelectionModalContentProps = Omit<TripSelectionModalProps, "isOpen">;
+
+function TripSelectionModalContent({
+  onClose,
+  activity,
+  trips,
+  onAddToTrip,
+  isAdding,
+}: TripSelectionModalContentProps) {
   const [selectedTripId, setSelectedTripId] = useState<string | null>(null);
 
   const handleClose = () => {
@@ -66,85 +91,76 @@ export function TripSelectionModal({
     }
   };
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: reset selection when modal or activity changes
-  useEffect(() => {
-    setSelectedTripId(null);
-  }, [activity.id, isOpen]);
-
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-      <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle>Add to Trip</DialogTitle>
-          <DialogDescription>
-            Choose a trip to add "{activity.name}" to.
-          </DialogDescription>
-        </DialogHeader>
-        <div className="grid gap-4 py-4">
-          {trips.length === 0 ? (
-            <div className="text-center py-4 text-muted-foreground">
-              No active or planning trips found.
-              <br />
-              <Button variant="link" className="mt-2" asChild>
-                <Link href="/trips" onClick={onClose}>
-                  Create a new trip
-                </Link>
-              </Button>
-            </div>
-          ) : (
-            <ScrollArea className="h-[300px] pr-4">
-              <RadioGroup
-                value={selectedTripId ?? ""}
-                onValueChange={(value) =>
-                  setSelectedTripId(value === "" ? null : value)
-                }
-                className="space-y-4"
-              >
-                {trips.map((trip) => (
-                  <div
-                    key={trip.id}
-                    className={`flex items-start space-x-3 space-y-0 rounded-md border p-4 transition-colors ${
-                      selectedTripId === trip.id
-                        ? "border-primary bg-accent"
-                        : "hover:bg-accent/50"
-                    }`}
+    <DialogContent className="sm:max-w-[425px]">
+      <DialogHeader>
+        <DialogTitle>Add to Trip</DialogTitle>
+        <DialogDescription>
+          Choose a trip to add "{activity.name}" to.
+        </DialogDescription>
+      </DialogHeader>
+      <div className="grid gap-4 py-4">
+        {trips.length === 0 ? (
+          <div className="text-center py-4 text-muted-foreground">
+            No active or planning trips found.
+            <br />
+            <Button variant="link" className="mt-2" asChild>
+              <Link href="/trips" onClick={onClose}>
+                Create a new trip
+              </Link>
+            </Button>
+          </div>
+        ) : (
+          <ScrollArea className="h-[300px] pr-4">
+            <RadioGroup
+              value={selectedTripId ?? ""}
+              onValueChange={(value) => setSelectedTripId(value === "" ? null : value)}
+              className="space-y-4"
+            >
+              {trips.map((trip) => (
+                <div
+                  key={trip.id}
+                  className={`flex items-start space-x-3 space-y-0 rounded-md border p-4 transition-colors ${
+                    selectedTripId === trip.id
+                      ? "border-primary bg-accent"
+                      : "hover:bg-accent/50"
+                  }`}
+                >
+                  <RadioGroupItem
+                    value={trip.id}
+                    id={`trip-${trip.id}`}
+                    className="mt-1 cursor-pointer"
+                  />
+                  <Label
+                    htmlFor={`trip-${trip.id}`}
+                    className="flex-1 cursor-pointer grid gap-1.5"
                   >
-                    <RadioGroupItem
-                      value={trip.id}
-                      id={`trip-${trip.id}`}
-                      className="mt-1 cursor-pointer"
-                    />
-                    <Label
-                      htmlFor={`trip-${trip.id}`}
-                      className="flex-1 cursor-pointer grid gap-1.5"
-                    >
-                      <span className="font-semibold text-base">{trip.title}</span>
+                    <span className="font-semibold text-base">{trip.title}</span>
+                    <div className="flex items-center text-sm text-muted-foreground gap-2">
+                      <MapPinIcon aria-hidden="true" className="h-3 w-3" />
+                      <span>{trip.destination}</span>
+                    </div>
+                    {trip.startDate && (
                       <div className="flex items-center text-sm text-muted-foreground gap-2">
-                        <MapPinIcon aria-hidden="true" className="h-3 w-3" />
-                        <span>{trip.destination}</span>
+                        <CalendarIcon aria-hidden="true" className="h-3 w-3" />
+                        <span>{new Date(trip.startDate).toLocaleDateString()}</span>
                       </div>
-                      {trip.startDate && (
-                        <div className="flex items-center text-sm text-muted-foreground gap-2">
-                          <CalendarIcon aria-hidden="true" className="h-3 w-3" />
-                          <span>{new Date(trip.startDate).toLocaleDateString()}</span>
-                        </div>
-                      )}
-                    </Label>
-                  </div>
-                ))}
-              </RadioGroup>
-            </ScrollArea>
-          )}
-        </div>
-        <DialogFooter>
-          <Button variant="outline" onClick={handleClose} disabled={isAdding}>
-            Cancel
-          </Button>
-          <Button onClick={handleConfirm} disabled={!selectedTripId || isAdding}>
-            {isAdding ? "Adding…" : "Add to Trip"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+                    )}
+                  </Label>
+                </div>
+              ))}
+            </RadioGroup>
+          </ScrollArea>
+        )}
+      </div>
+      <DialogFooter>
+        <Button variant="outline" onClick={handleClose} disabled={isAdding}>
+          Cancel
+        </Button>
+        <Button onClick={handleConfirm} disabled={!selectedTripId || isAdding}>
+          {isAdding ? "Adding…" : "Add to Trip"}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
   );
 }

--- a/src/features/search/components/modals/trip-selection-modal.tsx
+++ b/src/features/search/components/modals/trip-selection-modal.tsx
@@ -29,6 +29,11 @@ const TRIP_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
 });
 
+/**
+ * Formats date-only trip starts without shifting the displayed day by local timezone.
+ *
+ * @param value - ISO date or datetime string from the trip summary.
+ */
 const FORMAT_TRIP_START_DATE = (value: string): string => {
   const dateParts = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
   const date = dateParts
@@ -93,6 +98,11 @@ export function TripSelectionModal({
 
 type TripSelectionModalContentProps = Omit<TripSelectionModalProps, "isOpen">;
 
+/**
+ * Stateful dialog body that resets selection when React remounts it for a new trip flow.
+ *
+ * @param props - Component props without the open state owned by the parent dialog.
+ */
 function TripSelectionModalContent({
   onClose,
   activity,

--- a/src/features/search/components/modals/trip-selection-modal.tsx
+++ b/src/features/search/components/modals/trip-selection-modal.tsx
@@ -22,6 +22,28 @@ import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
+const TRIP_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  day: "numeric",
+  month: "short",
+  timeZone: "UTC",
+  year: "numeric",
+});
+
+const FORMAT_TRIP_START_DATE = (value: string): string => {
+  const dateParts = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
+  const date = dateParts
+    ? new Date(
+        Date.UTC(Number(dateParts[1]), Number(dateParts[2]) - 1, Number(dateParts[3]))
+      )
+    : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return TRIP_DATE_FORMATTER.format(date);
+};
+
 interface TripSelectionModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -143,7 +165,7 @@ function TripSelectionModalContent({
                     {trip.startDate && (
                       <div className="flex items-center text-sm text-muted-foreground gap-2">
                         <CalendarIcon aria-hidden="true" className="h-3 w-3" />
-                        <span>{new Date(trip.startDate).toLocaleDateString()}</span>
+                        <span>{FORMAT_TRIP_START_DATE(trip.startDate)}</span>
                       </div>
                     )}
                   </Label>

--- a/src/features/search/components/modals/trip-selection-modal.tsx
+++ b/src/features/search/components/modals/trip-selection-modal.tsx
@@ -22,7 +22,7 @@ import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
-const TRIP_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
+const TRIP_DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
   day: "numeric",
   month: "short",
   timeZone: "UTC",

--- a/src/features/search/hooks/search/use-search-orchestration.ts
+++ b/src/features/search/hooks/search/use-search-orchestration.ts
@@ -562,6 +562,3 @@ export function useSearchOrchestration(): UseSearchOrchestrationResult {
     ]
   );
 }
-
-// Re-export the hook as useSearchStore for backward compatibility
-export { useSearchOrchestration as useSearchStore };

--- a/src/lib/activities/booking.ts
+++ b/src/lib/activities/booking.ts
@@ -4,6 +4,7 @@
 
 import type { Activity } from "@schemas/search";
 import { getClientOrigin } from "@/lib/url/client-origin";
+import { safeHref } from "@/lib/url/safe-href";
 
 /** Structured attributes carried with booking telemetry events. */
 type TelemetryAttributes = Record<string, string | number | boolean>;
@@ -331,10 +332,11 @@ export function openActivityBooking(activity: ActivityWithMetadata): boolean {
     return false;
   }
 
-  if (!url.startsWith("http://") && !url.startsWith("https://")) {
+  const href = safeHref(url);
+  if (!href || (!href.startsWith("http://") && !href.startsWith("https://"))) {
     return false;
   }
 
-  window.open(url, "_blank", "noopener,noreferrer");
+  window.open(href, "_blank", "noopener,noreferrer");
   return true;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -190,6 +190,7 @@ export default defineConfig({
           include: [
             "src/components/**/*.{test,spec}.?(c|m)[jt]s?(x)",
             "src/app/**/*.{test,spec}.?(c|m)[jt]s?(x)",
+            "src/features/**/*.{test,spec}.?(c|m)[jt]sx",
             "src/hooks/**/*.{test,spec}.?(c|m)[jt]s?(x)",
             "src/stores/**/*.{test,spec}.?(c|m)[jt]s?(x)",
             "src/__tests__/**/*.{test,spec}.?(c|m)[jt]s?(x)",


### PR DESCRIPTION
## Summary
- Reports activity trip-loading failures through client telemetry instead of dev-only console logging.
- Stabilizes empty activity results so the activities page does not trigger a Zustand/React update loop before results exist.
- Resets trip selection by remounting modal content when the modal or activity changes.
- Sanitizes activity booking URLs with the shared `safeHref` helper.
- Adds activity search page/component coverage, a Chromium e2e smoke, and updates activity/search docs.

## Why
- The activities page could crash before results loaded because `state.results.activities ?? []` created a new fallback array for each store snapshot.
- Trip-loading failures should be captured through telemetry consistently with the rest of the client diagnostics work.
- The trip-selection modal had effect-based state reset logic that was brittle and required lint suppression.
- Activity booking URLs are user/provider-derived and should use the same URL safety helper as other UI surfaces.

## Scope
### Included
- Activity search client error normalization and telemetry reporting.
- Stable empty activity result fallback for Zustand selectors.
- Trip-selection modal state-reset refactor.
- Safe URL handling in activity booking helper.
- Component tests for activity search and trip selection.
- New authenticated Chromium smoke for `/dashboard/search/activities`.
- Vitest component project include for `src/features/**` specs.
- Activity/search documentation updates for route-backed orchestration.

### Not included
- Broader search UI changes still present in the dirty tree.
- Package, workflow, and release config changes still present in the dirty tree.
- Full Playwright browser matrix.

## Release Please version impact
Versioning track:
- [ ] Pre-1.0 development track
- [x] Stable 1.0+ SemVer track
- [ ] Explicit repo override applies

Expected Release Please bump after merge to `main`:
- [ ] None
- [x] Patch
- [ ] Minor
- [ ] Major

Default interpretation for pre-1.0 repos unless explicitly overridden:
- `fix:` -> Patch
- `feat:` -> Patch
- `!` or `BREAKING CHANGE:` -> Minor

Public API impact:
- [x] No public API change
- [ ] Public API added
- [ ] Public API changed, backward compatible
- [ ] Public API changed, breaking

Breaking changes:
- [x] None
- [ ] Yes

If breaking, describe the change, affected users/systems, and required migration steps:
- N/A.

## Related issues / context
- Follow-up dirty-tree split after PR #775.
- No issue linked.

## Implementation notes
- The first e2e run exposed a real page crash: `state.results.activities ?? []` returned a new empty array on each snapshot, producing a maximum update depth error. This PR fixes that with a module-level stable empty activity array.
- `TripSelectionModal` now keys inner content by open/closed state plus activity id, so local selected-trip state resets without a synchronization effect.
- `openActivityBooking` still only opens absolute HTTP(S) URLs, but now validates through `safeHref` before opening.
- Adding feature component specs required adding `src/features/**/*.{test,spec}.?(c|m)[jt]sx` to the Vitest component project.

## Review guide
Recommended review order:
1. `src/app/(app)/dashboard/search/activities/activities-search-client.tsx`
2. `src/features/search/components/modals/trip-selection-modal.tsx`
3. `src/lib/activities/booking.ts`
4. Tests and `vitest.config.ts`
5. Docs updates

Areas needing extra attention:
- Zustand selector stability on the activities page.
- Modal reset behavior when switching activities or reopening.
- URL safety behavior for activity booking links.
- Vitest include glob for feature component tests.

Specific feedback requested:
- [x] Correctness
- [ ] Architecture
- [ ] API design
- [ ] Performance
- [x] Security
- [ ] Backward compatibility / migration
- [x] UX / accessibility / copy

## Validation
### Automated
- [x] Tests added or updated
- [x] Type checks pass
- [x] Lint passes
- [ ] Build passes

Commands run in clean validation worktree `/home/bjorn/repos/agents/tripsage-ai-validate-activity-search-flow`:
- `pnpm install --frozen-lockfile`
- `pnpm biome:fix`
- `pnpm exec vitest run 'src/app/(app)/dashboard/search/activities/__tests__/activities-search-client.test.tsx' 'src/features/search/components/modals/__tests__/trip-selection-modal.test.tsx' 'src/features/search/components/modals/__tests__/activity-comparison-modal.test.tsx' 'src/lib/activities/__tests__/booking.dom.test.ts'`
- `pnpm exec playwright test e2e/activities-search.spec.ts --project=chromium`
- `pnpm type-check`
- `pnpm test:affected`
- `pnpm check:zod-v4`
- `pnpm check:api-route-errors`

### Manual
1. Confirmed `git diff --name-only main...HEAD` is limited to activity/search flow, focused tests, docs, and Vitest discovery config.
2. Confirmed the first e2e crash was fixed by the stable empty result fallback and the rerun passed.
3. Confirmed the clean validation worktree stayed clean after checks.

## Risk
Risk level:
- [ ] Low
- [x] Medium
- [ ] High

Main risks:
- `src/features` test discovery can increase component test coverage and surface existing failures in future unrelated PRs.
- Activity booking link behavior is stricter for malformed/provider-derived URLs.
- The e2e smoke depends on authenticated test-user setup and route rendering stability.

## Rollout / rollback
- Feature flag: N/A.
- Deployment notes: Normal app deploy; no migration required.
- Monitoring to watch: client error telemetry for `ActivitiesSearchClient`, activity booking click failures, and e2e/Frontend quick CI checks.
- Rollback plan: Revert this PR to restore previous selector/modal behavior and remove the new e2e smoke.

## Artifacts
- N/A.
