### PR TITLE
fix(ai): harden rendered link safety

### DIFF
--- a/src/components/ai-elements/__tests__/cards.test.tsx
+++ b/src/components/ai-elements/__tests__/cards.test.tsx
@@ -2,7 +2,9 @@
 
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { DestinationCard } from "@/components/ai-elements/destination-card";
 import { FlightOfferCard } from "@/components/ai-elements/flight-card";
+import { ItineraryTimeline } from "@/components/ai-elements/itinerary-timeline";
 import { StayCard } from "@/components/ai-elements/stay-card";
 
 describe("AI Elements Cards", () => {
@@ -52,5 +54,104 @@ describe("AI Elements Cards", () => {
     );
     expect(screen.getByText(/Places to Stay/)).toBeInTheDocument();
     expect(screen.getByText(/Hotel A/)).toBeInTheDocument();
+  });
+
+  it("does not render unsafe flight booking links", () => {
+    render(
+      <FlightOfferCard
+        result={{
+          currency: "USD",
+          fromCache: false,
+          itineraries: [
+            {
+              bookingUrl: "javascript:alert(1)",
+              id: "it-unsafe",
+              price: 320.5,
+              segments: [
+                {
+                  arrival: "2025-12-15T16:00:00Z",
+                  departure: "2025-12-15T08:00:00Z",
+                  destination: "JFK",
+                  origin: "SFO",
+                },
+              ],
+            },
+          ],
+          offers: [],
+          provider: "duffel",
+          schemaVersion: "flight.v2",
+          sources: [],
+        }}
+      />
+    );
+
+    expect(screen.queryByRole("link", { name: "Book" })).toBeNull();
+  });
+
+  it("does not render unsafe stay links", () => {
+    render(
+      <StayCard
+        result={{
+          schemaVersion: "stay.v1",
+          sources: [],
+          stays: [
+            {
+              address: "123 Ave",
+              currency: "USD",
+              name: "Hotel A",
+              nightlyRate: 180,
+              url: "data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==",
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(screen.queryByRole("link", { name: "View" })).toBeNull();
+  });
+
+  it("does not render unsafe destination attraction links", () => {
+    render(
+      <DestinationCard
+        result={{
+          attractions: [
+            {
+              title: "Museum",
+              url: "javascript:alert(1)",
+            },
+          ],
+          destination: "Paris",
+          schemaVersion: "dest.v1",
+          sources: [],
+        }}
+      />
+    );
+
+    expect(screen.queryByRole("link", { name: "Learn more" })).toBeNull();
+  });
+
+  it("does not render unsafe itinerary activity links", () => {
+    render(
+      <ItineraryTimeline
+        result={{
+          days: [
+            {
+              activities: [
+                {
+                  name: "Walk",
+                  url: "//evil.example/path",
+                },
+              ],
+              day: 1,
+            },
+          ],
+          destination: "Paris",
+          schemaVersion: "itin.v1",
+          sources: [],
+        }}
+      />
+    );
+
+    expect(screen.queryByRole("link", { name: "Learn more" })).toBeNull();
   });
 });

--- a/src/components/ai-elements/__tests__/prompt-input.test.tsx
+++ b/src/components/ai-elements/__tests__/prompt-input.test.tsx
@@ -1,7 +1,8 @@
 /** @vitest-environment jsdom */
 
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   PromptInput,
   PromptInputBody,
@@ -10,17 +11,30 @@ import {
   PromptInputTextarea,
 } from "@/components/ai-elements/prompt-input";
 
+const { mockRecordClientErrorOnActiveSpan } = vi.hoisted(() => ({
+  mockRecordClientErrorOnActiveSpan: vi.fn(),
+}));
+
+vi.mock("@/lib/telemetry/client-errors", () => ({
+  recordClientErrorOnActiveSpan: mockRecordClientErrorOnActiveSpan,
+}));
+
 /** Test suite for PromptInput component */
 describe("ai-elements/prompt-input", () => {
   beforeEach(() => {
     vi.useRealTimers();
+    mockRecordClientErrorOnActiveSpan.mockReset();
   });
 
-  /** Test that onSubmit is called with typed text when submitted */
-  it("calls onSubmit with typed text when submitted", async () => {
-    const onSubmit = vi.fn().mockResolvedValue(undefined);
+  const renderPromptInput = ({
+    onError,
+    onSubmit,
+  }: {
+    onError?: (error: Error) => void;
+    onSubmit: ComponentProps<typeof PromptInput>["onSubmit"];
+  }) => {
     render(
-      <PromptInput onSubmit={onSubmit}>
+      <PromptInput onSubmit={onSubmit} onError={onError}>
         <PromptInputBody>
           <PromptInputTextarea placeholder="Type here" />
         </PromptInputBody>
@@ -29,11 +43,9 @@ describe("ai-elements/prompt-input", () => {
         </PromptInputFooter>
       </PromptInput>
     );
+  };
 
-    const textarea = screen.getByPlaceholderText("Type here") as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "Hello AI" } });
-
-    // Submit the form by clicking the submit button
+  const getPromptForm = () => {
     const submit = screen.getByText("Send");
     const form = submit.closest("form");
     expect(form).not.toBeNull();
@@ -42,12 +54,60 @@ describe("ai-elements/prompt-input", () => {
       throw new Error("Expected prompt form to be present");
     }
 
-    fireEvent.submit(form);
+    return form;
+  };
+
+  /** Test that onSubmit is called with typed text when submitted */
+  it("calls onSubmit with typed text when submitted", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    renderPromptInput({ onSubmit });
+
+    const textarea = screen.getByPlaceholderText("Type here") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "Hello AI" } });
+
+    // Submit the form by clicking the submit button
+    fireEvent.submit(getPromptForm());
 
     await Promise.resolve();
     expect(onSubmit).toHaveBeenCalledTimes(1);
 
     const payload = onSubmit.mock.calls[0]?.[0];
     expect(payload?.text).toBe("Hello AI");
+  });
+
+  it("reports empty prompt validation errors through telemetry", () => {
+    const onError = vi.fn();
+    const onSubmit = vi.fn();
+
+    renderPromptInput({ onError, onSubmit });
+
+    fireEvent.submit(getPromptForm());
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    expect(mockRecordClientErrorOnActiveSpan).toHaveBeenCalledWith(expect.any(Error), {
+      action: "validate",
+      context: "PromptInput",
+    });
+  });
+
+  it("reports async submission failures through telemetry", async () => {
+    const onError = vi.fn();
+    const error = new Error("stream unavailable");
+    const onSubmit = vi.fn().mockRejectedValue(error);
+
+    renderPromptInput({ onError, onSubmit });
+
+    const textarea = screen.getByPlaceholderText("Type here") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "Plan a trip" } });
+    fireEvent.submit(getPromptForm());
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(error);
+    });
+    expect(mockRecordClientErrorOnActiveSpan).toHaveBeenCalledWith(error, {
+      action: "submit",
+      context: "PromptInput",
+    });
   });
 });

--- a/src/components/ai-elements/destination-card.tsx
+++ b/src/components/ai-elements/destination-card.tsx
@@ -13,6 +13,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { safeHref } from "@/lib/url/safe-href";
 import { Source, Sources, SourcesContent, SourcesTrigger } from "./sources";
 
 /**
@@ -60,27 +61,30 @@ export function DestinationCard({ result, ...props }: DestinationCardProps) {
           <div className="mb-4">
             <div className="mb-2 text-sm font-medium">Top Attractions</div>
             <div className="space-y-2">
-              {attractions.slice(0, 5).map((attraction: DestinationItem) => (
-                <div
-                  key={attraction.title ?? attraction.url ?? String(attraction)}
-                  className="text-xs"
-                >
-                  <div className="font-medium">{attraction.title}</div>
-                  {attraction.description ? (
-                    <div className="opacity-80">{attraction.description}</div>
-                  ) : null}
-                  {attraction.url ? (
-                    <a
-                      href={attraction.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="mt-1 block underline"
-                    >
-                      Learn more
-                    </a>
-                  ) : null}
-                </div>
-              ))}
+              {attractions.slice(0, 5).map((attraction: DestinationItem) => {
+                const href = safeHref(attraction.url);
+                return (
+                  <div
+                    key={attraction.title ?? attraction.url ?? String(attraction)}
+                    className="text-xs"
+                  >
+                    <div className="font-medium">{attraction.title}</div>
+                    {attraction.description ? (
+                      <div className="opacity-80">{attraction.description}</div>
+                    ) : null}
+                    {href ? (
+                      <a
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="mt-1 block underline"
+                      >
+                        Learn more
+                      </a>
+                    ) : null}
+                  </div>
+                );
+              })}
             </div>
           </div>
         ) : null}

--- a/src/components/ai-elements/flight-card.tsx
+++ b/src/components/ai-elements/flight-card.tsx
@@ -13,6 +13,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { safeHref } from "@/lib/url/safe-href";
 import { Source, Sources, SourcesContent, SourcesTrigger } from "./sources";
 
 /**
@@ -42,42 +43,45 @@ export function FlightOfferCard({ result, ...props }: FlightOfferCardProps) {
       </CardHeader>
       <CardContent>
         <div className="grid gap-3">
-          {top.map((itinerary: FlightItinerary) => (
-            <div key={itinerary.id} className="rounded border p-3">
-              <div className="flex items-center justify-between text-sm">
-                <div className="font-medium">
-                  {itinerary.segments[0]?.origin} →{" "}
-                  {itinerary.segments[itinerary.segments.length - 1]?.destination}
+          {top.map((itinerary: FlightItinerary) => {
+            const bookingHref = safeHref(itinerary.bookingUrl);
+            return (
+              <div key={itinerary.id} className="rounded border p-3">
+                <div className="flex items-center justify-between text-sm">
+                  <div className="font-medium">
+                    {itinerary.segments[0]?.origin} →{" "}
+                    {itinerary.segments[itinerary.segments.length - 1]?.destination}
+                  </div>
+                  <div className="font-semibold">
+                    {new Intl.NumberFormat(undefined, {
+                      currency: result.currency,
+                      style: "currency",
+                    }).format(itinerary.price)}
+                  </div>
                 </div>
-                <div className="font-semibold">
-                  {new Intl.NumberFormat(undefined, {
-                    currency: result.currency,
-                    style: "currency",
-                  }).format(itinerary.price)}
+                <div className="mt-1 text-xs opacity-80">
+                  {itinerary.segments
+                    .map(
+                      (segment: FlightSegment) =>
+                        `${segment.origin}→${segment.destination}`
+                    )
+                    .join(" · ")}
                 </div>
+                {bookingHref ? (
+                  <div className="mt-2 text-xs">
+                    <a
+                      href={bookingHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline"
+                    >
+                      Book
+                    </a>
+                  </div>
+                ) : null}
               </div>
-              <div className="mt-1 text-xs opacity-80">
-                {itinerary.segments
-                  .map(
-                    (segment: FlightSegment) =>
-                      `${segment.origin}→${segment.destination}`
-                  )
-                  .join(" · ")}
-              </div>
-              {itinerary.bookingUrl ? (
-                <div className="mt-2 text-xs">
-                  <a
-                    href={itinerary.bookingUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline"
-                  >
-                    Book
-                  </a>
-                </div>
-              ) : null}
-            </div>
-          ))}
+            );
+          })}
         </div>
         {Array.isArray(result.sources) && result.sources.length > 0 ? (
           <div className="mt-3">

--- a/src/components/ai-elements/itinerary-timeline.tsx
+++ b/src/components/ai-elements/itinerary-timeline.tsx
@@ -13,6 +13,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { safeHref } from "@/lib/url/safe-href";
 import { Source, Sources, SourcesContent, SourcesTrigger } from "./sources";
 
 /**
@@ -63,35 +64,38 @@ export function ItineraryTimeline({ result, ...props }: ItineraryTimelineProps) 
               </div>
               {Array.isArray(day.activities) && day.activities.length > 0 ? (
                 <div className="mt-2 space-y-2">
-                  {day.activities.map((activity: ItineraryActivity) => (
-                    <div
-                      key={activity.name ?? activity.url ?? String(activity)}
-                      className="rounded border p-2 text-xs"
-                    >
-                      <div className="font-medium">{activity.name}</div>
-                      {activity.time ? (
-                        <div className="mt-1 opacity-70">Time: {activity.time}</div>
-                      ) : null}
-                      {activity.location ? (
-                        <div className="mt-1 opacity-70">
-                          Location: {activity.location}
-                        </div>
-                      ) : null}
-                      {activity.description ? (
-                        <div className="mt-1 opacity-80">{activity.description}</div>
-                      ) : null}
-                      {activity.url ? (
-                        <a
-                          href={activity.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="mt-1 block underline"
-                        >
-                          Learn more
-                        </a>
-                      ) : null}
-                    </div>
-                  ))}
+                  {day.activities.map((activity: ItineraryActivity) => {
+                    const href = safeHref(activity.url);
+                    return (
+                      <div
+                        key={activity.name ?? activity.url ?? String(activity)}
+                        className="rounded border p-2 text-xs"
+                      >
+                        <div className="font-medium">{activity.name}</div>
+                        {activity.time ? (
+                          <div className="mt-1 opacity-70">Time: {activity.time}</div>
+                        ) : null}
+                        {activity.location ? (
+                          <div className="mt-1 opacity-70">
+                            Location: {activity.location}
+                          </div>
+                        ) : null}
+                        {activity.description ? (
+                          <div className="mt-1 opacity-80">{activity.description}</div>
+                        ) : null}
+                        {href ? (
+                          <a
+                            href={href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="mt-1 block underline"
+                          >
+                            Learn more
+                          </a>
+                        ) : null}
+                      </div>
+                    );
+                  })}
                 </div>
               ) : null}
             </div>

--- a/src/components/ai-elements/prompt-input.tsx
+++ b/src/components/ai-elements/prompt-input.tsx
@@ -20,6 +20,8 @@ import {
   InputGroupButton,
   InputGroupTextarea,
 } from "@/components/ui/input-group";
+import { getErrorMessage } from "@/lib/api/error-types";
+import { recordClientErrorOnActiveSpan } from "@/lib/telemetry/client-errors";
 import { cn } from "@/lib/utils";
 
 /**
@@ -35,7 +37,10 @@ export type PromptInputMessage = {
 /**
  * Props for the PromptInput form wrapper.
  */
-export type PromptInputProps = Omit<HTMLAttributes<HTMLFormElement>, "onSubmit"> & {
+export type PromptInputProps = Omit<
+  HTMLAttributes<HTMLFormElement>,
+  "onError" | "onSubmit"
+> & {
   /** Submit handler for the prompt input. */
   onSubmit: (
     message: PromptInputMessage,
@@ -44,6 +49,23 @@ export type PromptInputProps = Omit<HTMLAttributes<HTMLFormElement>, "onSubmit">
   /** Optional error handler for submission failures or validation errors. */
   onError?: (error: Error) => void;
 };
+
+function NormalizePromptInputError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(getErrorMessage(error));
+}
+
+function ReportPromptInputError(
+  error: unknown,
+  action: "submit" | "validate",
+  onError: PromptInputProps["onError"]
+) {
+  const normalized = NormalizePromptInputError(error);
+  recordClientErrorOnActiveSpan(normalized, {
+    action,
+    context: "PromptInput",
+  });
+  onError?.(normalized);
+}
 
 /**
  * Form wrapper that provides consistent layout via `InputGroup`.
@@ -66,11 +88,11 @@ export const PromptInput = ({
 
     // Validate non-empty message before submission
     if (trimmed.length === 0) {
-      const error = new Error("Cannot submit empty message");
-      if (process.env.NODE_ENV === "development") {
-        console.error("PromptInput validation error:", error);
-      }
-      onError?.(error);
+      ReportPromptInputError(
+        new Error("Cannot submit empty message"),
+        "validate",
+        onError
+      );
       return;
     }
 
@@ -83,20 +105,13 @@ export const PromptInput = ({
             form.reset();
           })
           .catch((error) => {
-            if (process.env.NODE_ENV === "development") {
-              console.error("PromptInput submission error:", error);
-            }
-            onError?.(error instanceof Error ? error : new Error(String(error)));
+            ReportPromptInputError(error, "submit", onError);
           });
       } else {
         form.reset();
       }
     } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
-      if (process.env.NODE_ENV === "development") {
-        console.error("PromptInput submission error:", err);
-      }
-      onError?.(err);
+      ReportPromptInputError(error, "submit", onError);
     }
   };
 

--- a/src/components/ai-elements/stay-card.tsx
+++ b/src/components/ai-elements/stay-card.tsx
@@ -13,6 +13,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { safeHref } from "@/lib/url/safe-href";
 import { Source, Sources, SourcesContent, SourcesTrigger } from "./sources";
 
 /**
@@ -39,40 +40,43 @@ export function StayCard({ result, ...props }: StayCardProps) {
       </CardHeader>
       <CardContent>
         <div className="grid gap-3">
-          {stays.map((stay: Stay) => (
-            <div
-              key={`${stay.name}-${stay.address ?? ""}-${stay.url ?? ""}`}
-              className="rounded border p-3"
-            >
-              <div className="flex items-center justify-between text-sm">
-                <div className="font-medium">{stay.name}</div>
-                {typeof stay.nightlyRate === "number" && stay.currency ? (
-                  <div className="font-semibold">
-                    {new Intl.NumberFormat(undefined, {
-                      currency: stay.currency,
-                      style: "currency",
-                    }).format(stay.nightlyRate)}
-                    <span className="ml-1 text-xs opacity-70">/night</span>
+          {stays.map((stay: Stay) => {
+            const href = safeHref(stay.url);
+            return (
+              <div
+                key={`${stay.name}-${stay.address ?? ""}-${stay.url ?? ""}`}
+                className="rounded border p-3"
+              >
+                <div className="flex items-center justify-between text-sm">
+                  <div className="font-medium">{stay.name}</div>
+                  {typeof stay.nightlyRate === "number" && stay.currency ? (
+                    <div className="font-semibold">
+                      {new Intl.NumberFormat(undefined, {
+                        currency: stay.currency,
+                        style: "currency",
+                      }).format(stay.nightlyRate)}
+                      <span className="ml-1 text-xs opacity-70">/night</span>
+                    </div>
+                  ) : null}
+                </div>
+                {stay.address ? (
+                  <div className="mt-1 text-xs opacity-80">{stay.address}</div>
+                ) : null}
+                {href ? (
+                  <div className="mt-2 text-xs">
+                    <a
+                      href={href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline"
+                    >
+                      View
+                    </a>
                   </div>
                 ) : null}
               </div>
-              {stay.address ? (
-                <div className="mt-1 text-xs opacity-80">{stay.address}</div>
-              ) : null}
-              {stay.url ? (
-                <div className="mt-2 text-xs">
-                  <a
-                    href={stay.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline"
-                  >
-                    View
-                  </a>
-                </div>
-              ) : null}
-            </div>
-          ))}
+            );
+          })}
         </div>
         {Array.isArray(result.sources) && result.sources.length > 0 ? (
           <div className="mt-3">

--- a/src/components/chat/__tests__/message-item.file-parts.test.tsx
+++ b/src/components/chat/__tests__/message-item.file-parts.test.tsx
@@ -47,4 +47,46 @@ describe("ChatMessageItem file parts", () => {
 
     expect(img).toHaveStyle({ display: "none" });
   });
+
+  it("does not render inline image for unsafe file URLs", () => {
+    const message = unsafeCast<UIMessage>({
+      id: "m3",
+      parts: [
+        {
+          mimeType: "image/png",
+          name: "Unsafe image",
+          type: "file",
+          url: "javascript:alert(1)",
+        },
+      ],
+      role: "assistant",
+    });
+
+    render(<ChatMessageItem message={message} />);
+
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(screen.getByText("Unsafe image")).toBeInTheDocument();
+    expect(screen.getByText("image/png")).toBeInTheDocument();
+  });
+
+  it("renders SVG file parts as attachments instead of inline images", () => {
+    const message = unsafeCast<UIMessage>({
+      id: "m4",
+      parts: [
+        {
+          data: "PHN2ZyBvbmxvYWQ9ImFsZXJ0KDEpIj48L3N2Zz4=",
+          mimeType: "image/svg+xml",
+          name: "vector.svg",
+          type: "file",
+        },
+      ],
+      role: "assistant",
+    });
+
+    render(<ChatMessageItem message={message} />);
+
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(screen.getByText("vector.svg")).toBeInTheDocument();
+    expect(screen.getByText("image/svg+xml")).toBeInTheDocument();
+  });
 });

--- a/src/components/chat/__tests__/message-item.metadata.test.tsx
+++ b/src/components/chat/__tests__/message-item.metadata.test.tsx
@@ -1,12 +1,24 @@
 /** @vitest-environment jsdom */
 
 import type { UIMessage } from "ai";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatMessageItem } from "@/components/chat/message-item";
 import { unsafeCast } from "@/test/helpers/unsafe-cast";
 import { render, screen } from "@/test/test-utils";
 
+const { mockRecordClientErrorOnActiveSpan } = vi.hoisted(() => ({
+  mockRecordClientErrorOnActiveSpan: vi.fn(),
+}));
+
+vi.mock("@/lib/telemetry/client-errors", () => ({
+  recordClientErrorOnActiveSpan: mockRecordClientErrorOnActiveSpan,
+}));
+
 describe("ChatMessageItem metadata", () => {
+  beforeEach(() => {
+    mockRecordClientErrorOnActiveSpan.mockReset();
+  });
+
   it("renders finish reason and token usage metadata", () => {
     const message = unsafeCast<UIMessage>({
       id: "m-meta",
@@ -98,5 +110,26 @@ describe("ChatMessageItem metadata", () => {
     expect(screen.queryByText(/Abort:/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Finish:/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Tokens:/)).not.toBeInTheDocument();
+  });
+
+  it("reports invalid step-start parts through telemetry and skips rendering them", () => {
+    const message = unsafeCast<UIMessage>({
+      id: "m-invalid-step",
+      parts: [
+        { step: 0, type: "step-start" },
+        { text: "Message body still renders", type: "text" },
+      ],
+      role: "assistant",
+    });
+
+    render(<ChatMessageItem message={message} />);
+
+    expect(screen.getByText("Message body still renders")).toBeInTheDocument();
+    expect(screen.queryByText("Step 0")).not.toBeInTheDocument();
+    expect(mockRecordClientErrorOnActiveSpan).toHaveBeenCalledWith(expect.any(Error), {
+      action: "parseStepStartPart",
+      context: "ChatMessageItem",
+      step: 0,
+    });
   });
 });

--- a/src/components/chat/message-item.tsx
+++ b/src/components/chat/message-item.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/ai-elements/sources";
 import { StayCard } from "@/components/ai-elements/stay-card";
 import { Tool } from "@/components/ai-elements/tool";
+import { recordClientErrorOnActiveSpan } from "@/lib/telemetry/client-errors";
 import { parseSchemaCard } from "@/lib/ui/parse-schema-card";
 import { safeHref } from "@/lib/url/safe-href";
 
@@ -66,6 +67,22 @@ function AsRecord(value: unknown): Record<string, unknown> | null {
   return value as Record<string, unknown>;
 }
 
+function ReportInvalidStepStartPart(step: unknown): void {
+  recordClientErrorOnActiveSpan(
+    new Error("Invalid step-start part: expected step to be a positive integer."),
+    {
+      action: "parseStepStartPart",
+      context: "ChatMessageItem",
+      step:
+        typeof step === "number" ||
+        typeof step === "string" ||
+        typeof step === "boolean"
+          ? step
+          : undefined,
+    }
+  );
+}
+
 // biome-ignore lint/style/useNamingConvention: Type guard helper for discriminated parts
 function isSourceUrlPart(value: unknown): value is SourceUrlPart {
   if (typeof value !== "object" || value === null) return false;
@@ -84,10 +101,8 @@ function isStepStartPart(value: unknown): value is StepStartPart {
     step === undefined ||
     (typeof step === "number" && Number.isInteger(step) && step > 0);
 
-  if (!valid && process.env.NODE_ENV === "development") {
-    console.warn("Invalid step-start part: expected step to be a positive integer.", {
-      step,
-    });
+  if (!valid) {
+    ReportInvalidStepStartPart(step);
   }
 
   return valid;
@@ -98,8 +113,8 @@ const REDACT_KEYS = new Set(["apikey", "token", "secret", "password", "id"]);
 const MAX_STRING_LENGTH = 200;
 const MAX_DEPTH = 2;
 
-/** Allowlist of safe MIME types for data URLs */
-const SAFE_MIME_TYPES = new Set([
+/** Allowlist of MIME types safe to display as attachment metadata. */
+const DISPLAY_MIME_TYPES = new Set([
   "image/png",
   "image/jpeg",
   "image/jpg",
@@ -112,6 +127,14 @@ const SAFE_MIME_TYPES = new Set([
   "audio/wav",
   "application/pdf",
 ]);
+const INLINE_IMAGE_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/jpg",
+  "image/gif",
+  "image/webp",
+]);
+const ALLOWED_IMAGE_URL_PROTOCOLS = new Set(["http:", "https:"]);
 
 const BASE64_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
 
@@ -130,7 +153,7 @@ function isValidBase64(value: string): boolean {
 /**
  * Validates and normalizes a MIME type string.
  * Returns the MIME type if it's in the allowlist, otherwise returns a safe default.
- * Only explicit MIME types in SAFE_MIME_TYPES are allowed to prevent XSS vectors.
+ * Only explicit MIME types in DISPLAY_MIME_TYPES are allowed to prevent XSS vectors.
  */
 // biome-ignore lint/style/useNamingConvention: Internal utility function, not a React component
 function validateMimeType(mimeType?: string): string {
@@ -139,12 +162,27 @@ function validateMimeType(mimeType?: string): string {
   }
 
   const normalized = mimeType.toLowerCase().trim();
-  if (SAFE_MIME_TYPES.has(normalized)) {
+  if (DISPLAY_MIME_TYPES.has(normalized)) {
     return normalized;
   }
 
   // Default to safe fallback for unknown types
   return "application/octet-stream";
+}
+
+// biome-ignore lint/style/useNamingConvention: Internal utility function, not a React component
+function safeInlineImageSrc(raw?: string): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.startsWith("//")) return null;
+  if (trimmed.startsWith("/")) return trimmed;
+
+  try {
+    const url = new URL(trimmed);
+    return ALLOWED_IMAGE_URL_PROTOCOLS.has(url.protocol) ? trimmed : null;
+  } catch {
+    return null;
+  }
 }
 
 // biome-ignore lint/style/useNamingConvention: Internal utility function, not a React component
@@ -581,14 +619,14 @@ export function ChatMessageItem({
               const data =
                 typeof filePart.data === "string" ? filePart.data : undefined;
               const url = typeof filePart.url === "string" ? filePart.url : undefined;
+              const canRenderInlineImage = INLINE_IMAGE_MIME_TYPES.has(mimeType);
               const fileUrl =
-                url ??
-                (data && isValidBase64(data)
+                canRenderInlineImage && data && isValidBase64(data)
                   ? `data:${mimeType};base64,${data}`
-                  : null);
+                  : safeInlineImageSrc(url);
 
               // Render images inline
-              if (mimeType.startsWith("image/") && fileUrl) {
+              if (canRenderInlineImage && fileUrl) {
                 const width =
                   typeof filePart.width === "number" && filePart.width > 0
                     ? filePart.width

--- a/src/components/markdown/Markdown.test.tsx
+++ b/src/components/markdown/Markdown.test.tsx
@@ -1,6 +1,7 @@
 /** @vitest-environment jsdom */
 
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import type { ComponentProps, ComponentType } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Markdown } from "./Markdown";
@@ -100,5 +101,18 @@ describe("markdown/Markdown", () => {
     const props = getLastProps();
     expect(props.linkSafety).toEqual({ enabled: false });
     expect(typeof (props.components as AnyRecord | undefined)?.a).toBe("function");
+  });
+
+  it("sanitizes hrefs in the final anchor component", () => {
+    render(<Markdown content={"[ok](https://example.com)"} mode="static" />);
+
+    const props = getLastProps();
+    const Anchor = (props.components as { a: ComponentType<ComponentProps<"a">> }).a;
+    render(<Anchor href="javascript:alert(1)">Blocked</Anchor>);
+
+    const anchor = screen.getByText("Blocked");
+    expect(anchor).not.toHaveAttribute("href");
+    expect(anchor).not.toHaveAttribute("target");
+    expect(anchor).not.toHaveAttribute("rel");
   });
 });

--- a/src/components/markdown/Markdown.tsx
+++ b/src/components/markdown/Markdown.tsx
@@ -18,6 +18,7 @@ import {
 import type { Pluggable, PluggableList, Plugin } from "unified";
 import { z } from "zod";
 import { getClientOrigin } from "@/lib/url/client-origin";
+import { safeHref } from "@/lib/url/safe-href";
 import { cn } from "@/lib/utils";
 
 /** Security profile controlling allowed content sources and sanitization strictness. */
@@ -267,18 +268,23 @@ function TripSageMarkdownLink({
   className,
   href,
   node: _node,
+  rel: _rel,
+  target: _target,
   ...rest
 }: MarkdownLinkProps) {
   const isIncomplete = href === "streamdown:incomplete-link";
+  const safe = isIncomplete ? undefined : safeHref(href);
+  const safeLinkProps = safe
+    ? { href: safe, rel: "noopener noreferrer", target: "_blank" }
+    : {};
+
   return (
     <a
       {...rest}
+      {...safeLinkProps}
       className={cn("wrap-anywhere font-medium text-primary underline", className)}
       data-incomplete={isIncomplete}
       data-streamdown="link"
-      href={href}
-      rel="noopener noreferrer"
-      target="_blank"
     >
       {children}
     </a>


### PR DESCRIPTION
## Summary
- Sanitize AI card links before rendering booking, stay, destination, and itinerary anchors.
- Harden chat file-part rendering so unsafe URLs and SVG attachments are not rendered inline as images.
- Sanitize Markdown anchor hrefs at the final rendered component boundary.
- Route prompt input and invalid chat step parsing errors through client telemetry instead of development console output.
- Add component tests for unsafe link blocking and telemetry reporting.

## Why
- AI/tool-derived content can include untrusted URLs or file metadata. The UI should not render unsafe protocols or inline unsafe image payloads.
- Client error paths should use the telemetry helper consistently so failures are observable without production console usage.

## Scope
### Included
- AI element card link sanitization using the existing `safeHref` helper.
- Markdown link sanitization in the canonical renderer.
- Chat file-part inline image restrictions for safe image MIME types and safe URL protocols.
- Prompt input and invalid step-start telemetry coverage.

### Not included
- Changes to the shared `safeHref` implementation.
- Broader chat transport, schema, or server-side validation changes.
- Any unrelated dirty-tree changes from the remaining local work.

## Release Please version impact
Versioning track:
- [x] Pre-1.0 development track
- [ ] Stable 1.0+ SemVer track
- [ ] Explicit repo override applies

Expected Release Please bump after merge to `main`:
- [ ] None
- [x] Patch
- [ ] Minor
- [ ] Major

Public API impact:
- [x] No public API change
- [ ] Public API added
- [ ] Public API changed, backward compatible
- [ ] Public API changed, breaking

Breaking changes:
- [x] None
- [ ] Yes

If breaking, describe the change, affected users/systems, and required migration steps:
- N/A

## Related issues / context
- Follow-up slice from the remaining local dirty tree after PR #776.

## Implementation notes
- Existing `safeHref` behavior is reused for AI card and Markdown anchors.
- Chat inline rendering is limited to raster image MIME types; SVG and unsafe URLs fall back to attachment metadata.
- Prompt submission errors are normalized with `getErrorMessage` before telemetry reporting.

## Review guide
Recommended review order:
1. `src/components/chat/message-item.tsx`
2. `src/components/markdown/Markdown.tsx`
3. `src/components/ai-elements/*-card.tsx` and `prompt-input.tsx`
4. Updated component tests

Areas needing extra attention:
- Link rendering behavior for untrusted model/tool output.
- Inline file rendering compatibility for safe raster images.

Specific feedback requested:
- [x] Correctness
- [x] Security
- [x] UX / accessibility / copy

## Validation
### Automated
- [x] Tests added or updated
- [x] Type checks pass
- [x] Lint passes
- [ ] Build passes

Commands run:
- `pnpm exec vitest run 'src/components/ai-elements/__tests__/cards.test.tsx' 'src/components/ai-elements/__tests__/prompt-input.test.tsx' 'src/components/chat/__tests__/message-item.file-parts.test.tsx' 'src/components/chat/__tests__/message-item.metadata.test.tsx' 'src/components/markdown/Markdown.test.tsx'`
- `pnpm biome:fix`
- `pnpm type-check`
- `pnpm test:affected`
- `pnpm check:zod-v4`
- `pnpm check:api-route-errors`

### Manual
1. Reviewed the staged diff to confirm only the selected AI/chat/Markdown lane was committed.
2. Verified the primary dirty tree remains otherwise uncommitted for later branches.

## Risk
Risk level:
- [ ] Low
- [x] Medium
- [ ] High

Main risks:
- Some previously clickable unsafe or non-http links will now render as plain content.
- SVG image file parts now render as attachments instead of inline images.

## Rollout / rollback
- Feature flag: N/A
- Deployment notes: Normal frontend deployment.
- Monitoring to watch: Client telemetry for `PromptInput` and `ChatMessageItem` parsing/reporting events.
- Rollback plan: Revert this commit if link/file rendering regressions appear.

## Artifacts
- N/A
