### PR TITLE
fix(calendar): harden client event UI

### DIFF
--- a/src/app/(app)/dashboard/calendar/__tests__/page.test.tsx
+++ b/src/app/(app)/dashboard/calendar/__tests__/page.test.tsx
@@ -1,0 +1,70 @@
+/** @vitest-environment jsdom */
+
+import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DateUtils } from "@/lib/dates/unified-date-utils";
+
+const calendarEventListSpy = vi.hoisted(() => vi.fn());
+const refreshSpy = vi.hoisted(() => vi.fn());
+const toastSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: refreshSpy,
+  }),
+}));
+
+vi.mock("@/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: toastSpy }),
+}));
+
+vi.mock("@/lib/security/random", () => ({
+  nowIso: vi.fn(() => "2026-01-15T12:34:56.000Z"),
+}));
+
+vi.mock("@/components/calendar/calendar-connection-card", () => ({
+  CalendarConnectionCard: () => <div data-testid="calendar-connection-card" />,
+}));
+
+vi.mock("@/components/calendar/calendar-event-form", () => ({
+  CalendarEventForm: () => <div data-testid="calendar-event-form" />,
+}));
+
+vi.mock("@/components/calendar/calendar-event-list", () => ({
+  CalendarEventList: (props: { timeMax?: Date; timeMin?: Date }) => {
+    calendarEventListSpy(props);
+    return <div data-testid="calendar-event-list" />;
+  },
+}));
+
+vi.mock("@/components/ui/tabs", () => ({
+  Tabs: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TabsContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+import CalendarPage from "../page";
+
+describe("CalendarPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes a centralized-clock event window to the event list", () => {
+    const expectedStart = DateUtils.startOf(
+      new Date("2026-01-15T12:34:56.000Z"),
+      "day"
+    );
+
+    render(<CalendarPage />);
+
+    expect(calendarEventListSpy).toHaveBeenCalledWith({
+      timeMax: DateUtils.add(expectedStart, 7, "days"),
+      timeMin: expectedStart,
+    });
+  });
+});

--- a/src/app/(app)/dashboard/calendar/page.tsx
+++ b/src/app/(app)/dashboard/calendar/page.tsx
@@ -12,6 +12,15 @@ import { CalendarEventList } from "@/components/calendar/calendar-event-list";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/components/ui/use-toast";
 import { DateUtils } from "@/lib/dates/unified-date-utils";
+import { nowIso } from "@/lib/security/random";
+
+function getCalendarEventWindow(): { nextWeek: Date; now: Date } {
+  const start = DateUtils.startOf(new Date(nowIso()), "day");
+  return {
+    nextWeek: DateUtils.add(start, 7, "days"),
+    now: start,
+  };
+}
 
 /**
  * Renders the calendar integration dashboard with connection status, events,
@@ -23,13 +32,7 @@ export default function CalendarPage() {
   const router = useRouter();
   const { toast } = useToast();
   const [activeTab, setActiveTab] = useState("status");
-  const timeWindow = useMemo(() => {
-    const start = DateUtils.startOf(new Date(), "day");
-    return {
-      nextWeek: DateUtils.add(start, 7, "days"),
-      now: start,
-    };
-  }, []);
+  const timeWindow = useMemo(getCalendarEventWindow, []);
 
   return (
     <div className="space-y-6">

--- a/src/components/calendar/__tests__/calendar-connection-card.test.tsx
+++ b/src/components/calendar/__tests__/calendar-connection-card.test.tsx
@@ -1,0 +1,77 @@
+/** @vitest-environment jsdom */
+
+import { HttpResponse, http } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CalendarConnectionCard } from "@/components/calendar/calendar-connection-card";
+import { server } from "@/test/msw/server";
+import { render, screen } from "@/test/test-utils";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+
+const { mockRecordClientErrorOnActiveSpan } = vi.hoisted(() => ({
+  mockRecordClientErrorOnActiveSpan: vi.fn(),
+}));
+
+vi.mock("@/lib/telemetry/client-errors", () => ({
+  recordClientErrorOnActiveSpan: mockRecordClientErrorOnActiveSpan,
+}));
+
+describe("CalendarConnectionCard", () => {
+  const useCalendarStatusHandlers = (handler: Parameters<typeof http.get>[1]) => {
+    server.use(
+      http.get(`${BASE_URL}/api/calendar/status`, handler),
+      http.get("/api/calendar/status", handler)
+    );
+  };
+
+  beforeEach(() => {
+    mockRecordClientErrorOnActiveSpan.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows load errors and records them through telemetry", async () => {
+    useCalendarStatusHandlers(() =>
+      HttpResponse.json({ error: "calendar status unavailable" }, { status: 503 })
+    );
+
+    render(<CalendarConnectionCard />);
+
+    expect(
+      await screen.findByText("Failed to load calendar status")
+    ).toBeInTheDocument();
+    expect(screen.getByText("calendar status unavailable")).toBeInTheDocument();
+    expect(mockRecordClientErrorOnActiveSpan).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "calendar status unavailable" }),
+      {
+        action: "loadCalendarStatus",
+        context: "CalendarConnectionCard",
+      }
+    );
+  });
+
+  it("keeps the error UI visible when telemetry recording fails", async () => {
+    useCalendarStatusHandlers(() =>
+      HttpResponse.json({ error: "calendar status unavailable" }, { status: 503 })
+    );
+    mockRecordClientErrorOnActiveSpan.mockImplementationOnce(() => {
+      throw new Error("telemetry unavailable");
+    });
+
+    render(<CalendarConnectionCard />);
+
+    expect(
+      await screen.findByText("Failed to load calendar status")
+    ).toBeInTheDocument();
+    expect(screen.getByText("calendar status unavailable")).toBeInTheDocument();
+    expect(mockRecordClientErrorOnActiveSpan).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "calendar status unavailable" }),
+      {
+        action: "loadCalendarStatus",
+        context: "CalendarConnectionCard",
+      }
+    );
+  });
+});

--- a/src/components/calendar/__tests__/calendar-event-form.test.tsx
+++ b/src/components/calendar/__tests__/calendar-event-form.test.tsx
@@ -1,0 +1,36 @@
+/** @vitest-environment jsdom */
+
+import { describe, expect, it, vi } from "vitest";
+import { CalendarEventForm } from "@/components/calendar/calendar-event-form";
+import { render, screen } from "@/test/test-utils";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
+
+describe("CalendarEventForm", () => {
+  it(
+    "renders default start and end datetime values",
+    withFakeTimers(() => {
+      vi.setSystemTime(new Date("2026-03-04T05:06:07.000Z"));
+
+      render(<CalendarEventForm />);
+
+      expect(screen.getByLabelText("Start")).toHaveValue("2026-03-04T05:06");
+      expect(screen.getByLabelText("End")).toHaveValue("2026-03-04T06:06");
+    })
+  );
+
+  it("preserves initial event datetime values", () => {
+    render(
+      <CalendarEventForm
+        initialData={{
+          end: { dateTime: new Date("2026-04-01T13:30:00.000Z") },
+          start: { dateTime: new Date("2026-04-01T12:30:00.000Z") },
+          summary: "Existing event",
+        }}
+      />
+    );
+
+    expect(screen.getByLabelText("Title")).toHaveValue("Existing event");
+    expect(screen.getByLabelText("Start")).toHaveValue("2026-04-01T12:30");
+    expect(screen.getByLabelText("End")).toHaveValue("2026-04-01T13:30");
+  });
+});

--- a/src/components/calendar/__tests__/calendar-event-list.test.tsx
+++ b/src/components/calendar/__tests__/calendar-event-list.test.tsx
@@ -1,15 +1,23 @@
 /** @vitest-environment jsdom */
 
 import { delay, HttpResponse, http } from "msw";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CalendarEventList } from "@/components/calendar/calendar-event-list";
 import { server } from "@/test/msw/server";
 import { render, screen, within } from "@/test/test-utils";
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
 
+const { mockRecordClientErrorOnActiveSpan } = vi.hoisted(() => ({
+  mockRecordClientErrorOnActiveSpan: vi.fn(),
+}));
+
 vi.mock("@/hooks/use-current-user-id", () => ({
   useCurrentUserId: () => "user-123",
+}));
+
+vi.mock("@/lib/telemetry/client-errors", () => ({
+  recordClientErrorOnActiveSpan: mockRecordClientErrorOnActiveSpan,
 }));
 
 describe("CalendarEventList", () => {
@@ -19,6 +27,10 @@ describe("CalendarEventList", () => {
       http.get("/api/calendar/events", handler)
     );
   };
+
+  beforeEach(() => {
+    mockRecordClientErrorOnActiveSpan.mockReset();
+  });
 
   it("renders events returned by API", async () => {
     const handler = () =>
@@ -59,6 +71,10 @@ describe("CalendarEventList", () => {
 
     expect(await screen.findByText(/failed to load events/i)).toBeInTheDocument();
     expect(screen.getByText(/invalid calendar events response/i)).toBeInTheDocument();
+    expect(mockRecordClientErrorOnActiveSpan).toHaveBeenCalledWith(expect.any(Error), {
+      action: "parseEvents",
+      context: "CalendarEventList",
+    });
   });
 
   it('shows "No events found in this time range" for empty items', async () => {
@@ -119,6 +135,29 @@ describe("CalendarEventList", () => {
     render(<CalendarEventList />);
 
     expect(await screen.findByText("Minimal Event")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /view in google calendar/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render unsafe calendar event links", async () => {
+    useEventsHandlers(() =>
+      HttpResponse.json({
+        items: [
+          {
+            end: { dateTime: "2025-12-12T11:00:00.000Z" },
+            htmlLink: "javascript:alert(1)",
+            id: "event-unsafe-link",
+            start: { dateTime: "2025-12-12T10:00:00.000Z" },
+            summary: "Unsafe Link Event",
+          },
+        ],
+      })
+    );
+
+    render(<CalendarEventList />);
+
+    expect(await screen.findByText("Unsafe Link Event")).toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: /view in google calendar/i })
     ).not.toBeInTheDocument();

--- a/src/components/calendar/calendar-connection-card.tsx
+++ b/src/components/calendar/calendar-connection-card.tsx
@@ -34,6 +34,17 @@ export interface CalendarConnectionCardProps {
   className?: string;
 }
 
+function ReportCalendarStatusLoadError(error: Error): void {
+  try {
+    recordClientErrorOnActiveSpan(error, {
+      action: "loadCalendarStatus",
+      context: "CalendarConnectionCard",
+    });
+  } catch {
+    // Keep calendar status UI resilient even if telemetry is unavailable.
+  }
+}
+
 /**
  * CalendarConnectionCard component.
  *
@@ -87,17 +98,7 @@ export function CalendarConnectionCard({ className }: CalendarConnectionCardProp
       }
       const message = err instanceof Error ? err.message : "Unknown error";
       setError(message);
-      try {
-        recordClientErrorOnActiveSpan(err instanceof Error ? err : new Error(message), {
-          action: "loadCalendarStatus",
-          context: "CalendarConnectionCard",
-        });
-      } catch (telemetryError) {
-        // Swallow telemetry errors to avoid breaking component
-        if (process.env.NODE_ENV === "development") {
-          console.error("Failed to record telemetry error:", telemetryError);
-        }
-      }
+      ReportCalendarStatusLoadError(err instanceof Error ? err : new Error(message));
     } finally {
       if (!abortController.signal.aborted) {
         setIsLoading(false);

--- a/src/components/calendar/calendar-event-form.tsx
+++ b/src/components/calendar/calendar-event-form.tsx
@@ -5,7 +5,7 @@
 "use client";
 
 import { createEventRequestSchema } from "@schemas/calendar";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -15,12 +15,28 @@ import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
 import { useZodForm } from "@/hooks/use-zod-form";
+import { nowIso } from "@/lib/security/random";
 
 const EVENT_FORM_SCHEMA = createEventRequestSchema.extend({
   calendarId: z.string().default("primary"),
 });
 
 type EventFormData = z.infer<typeof EVENT_FORM_SCHEMA>;
+const DEFAULT_EVENT_DURATION_MS = 60 * 60 * 1000;
+
+const BUILD_DEFAULT_EVENT_TIMES = (
+  currentIso: string = nowIso()
+): Pick<EventFormData, "end" | "start"> => {
+  const startDateTime = new Date(currentIso);
+  return {
+    end: {
+      dateTime: new Date(startDateTime.getTime() + DEFAULT_EVENT_DURATION_MS),
+    },
+    start: {
+      dateTime: startDateTime,
+    },
+  };
+};
 
 /**
  * Props for CalendarEventForm component.
@@ -49,6 +65,15 @@ export function CalendarEventForm({
 }: CalendarEventFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { toast } = useToast();
+  const defaultValues = useMemo(() => {
+    const defaultTimes = BUILD_DEFAULT_EVENT_TIMES();
+    return {
+      calendarId: "primary",
+      ...initialData,
+      end: initialData?.end ?? defaultTimes.end,
+      start: initialData?.start ?? defaultTimes.start,
+    };
+  }, [initialData]);
 
   const {
     register,
@@ -58,16 +83,7 @@ export function CalendarEventForm({
     setValue,
     reset,
   } = useZodForm({
-    defaultValues: {
-      calendarId: "primary",
-      ...initialData,
-      end: initialData?.end || {
-        dateTime: new Date(Date.now() + 60 * 60 * 1000), // Default 1 hour
-      },
-      start: initialData?.start || {
-        dateTime: new Date(),
-      },
-    },
+    defaultValues,
     mode: "onChange",
     schema: EVENT_FORM_SCHEMA,
   });
@@ -165,7 +181,7 @@ export function CalendarEventForm({
             )}
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div>
               <Label htmlFor="start">Start</Label>
               <Input

--- a/src/components/calendar/calendar-event-list.tsx
+++ b/src/components/calendar/calendar-event-list.tsx
@@ -18,6 +18,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useCurrentUserId } from "@/hooks/use-current-user-id";
 import { DateUtils } from "@/lib/dates/unified-date-utils";
 import { keys } from "@/lib/keys";
+import { recordClientErrorOnActiveSpan } from "@/lib/telemetry/client-errors";
+import { safeHref } from "@/lib/url/safe-href";
 
 const CalendarEventListItemSchema = z.looseObject({
   description: z.string().max(8192).optional(),
@@ -111,9 +113,10 @@ export function CalendarEventList({
       const json: unknown = await response.json();
       const parsed = CalendarEventsApiResponseSchema.safeParse(json);
       if (!parsed.success) {
-        if (process.env.NODE_ENV === "development") {
-          console.error("Calendar events validation error:", parsed.error);
-        }
+        recordClientErrorOnActiveSpan(parsed.error, {
+          action: "parseEvents",
+          context: "CalendarEventList",
+        });
         throw new Error("Invalid calendar events response");
       }
 
@@ -196,6 +199,7 @@ export function CalendarEventList({
                 : event.end?.date
                   ? DateUtils.parse(event.end.date)
                   : null;
+              const eventHref = safeHref(event.htmlLink);
 
               return (
                 <li
@@ -230,16 +234,16 @@ export function CalendarEventList({
                         </div>
                       )}
                     </div>
-                    {event.htmlLink && (
+                    {eventHref ? (
                       <a
-                        href={event.htmlLink}
+                        href={eventHref}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="text-sm text-primary hover:underline"
                       >
                         View in Google Calendar
                       </a>
-                    )}
+                    ) : null}
                   </div>
                 </li>
               );


### PR DESCRIPTION
## Summary
- Use the centralized clock helper for the dashboard calendar event window.
- Sanitize calendar event links before rendering Google Calendar anchors.
- Report calendar status and event response parsing failures through client telemetry.
- Make calendar event form defaults deterministic and adjust the datetime grid for small screens.
- Add focused component tests for calendar page, connection, form, and event list behavior.

## Why
- Calendar UI surfaces remote event data and should not render unsafe links from API payloads.
- Calendar error paths should be observable through telemetry without development console leakage.
- Date defaults should use the repo clock helper so tests and runtime behavior are deterministic.

## Scope
### Included
- Calendar dashboard event window calculation.
- Calendar connection error telemetry resilience.
- Calendar event list response parse telemetry and safe link rendering.
- Calendar event form default time construction and responsive field layout.
- Component test coverage for the above behavior.

### Not included
- Calendar API route behavior changes.
- Google Calendar service/client changes.
- Broader docs, workflow, or unrelated dirty-tree changes.

## Release Please version impact
Versioning track:
- [x] Pre-1.0 development track
- [ ] Stable 1.0+ SemVer track
- [ ] Explicit repo override applies

Expected Release Please bump after merge to `main`:
- [ ] None
- [x] Patch
- [ ] Minor
- [ ] Major

Public API impact:
- [x] No public API change
- [ ] Public API added
- [ ] Public API changed, backward compatible
- [ ] Public API changed, breaking

Breaking changes:
- [x] None
- [ ] Yes

If breaking, describe the change, affected users/systems, and required migration steps:
- N/A

## Related issues / context
- Follow-up slice from the remaining local dirty tree after PR #778.

## Implementation notes
- Reuses `nowIso` for calendar page/form default time behavior.
- Reuses `safeHref` for event `htmlLink` rendering.
- Telemetry recording in the connection card is isolated so telemetry failures do not hide the user-facing error state.

## Review guide
Recommended review order:
1. `src/components/calendar/calendar-event-list.tsx`
2. `src/components/calendar/calendar-connection-card.tsx`
3. `src/components/calendar/calendar-event-form.tsx`
4. `src/app/(app)/dashboard/calendar/page.tsx`
5. Added/updated tests

Areas needing extra attention:
- Unsafe event link behavior.
- Calendar time default behavior.
- Error telemetry paths.

Specific feedback requested:
- [x] Correctness
- [x] Security
- [x] UX / accessibility / copy

## Validation
### Automated
- [x] Tests added or updated
- [x] Type checks pass
- [x] Lint passes
- [ ] Build passes

Commands run:
- `pnpm exec vitest run 'src/app/(app)/dashboard/calendar/__tests__/page.test.tsx' 'src/components/calendar/__tests__/calendar-connection-card.test.tsx' 'src/components/calendar/__tests__/calendar-event-form.test.tsx' 'src/components/calendar/__tests__/calendar-event-list.test.tsx'`
- `pnpm biome:fix`
- `pnpm type-check`
- `pnpm test:affected`
- `pnpm check:zod-v4`
- `pnpm check:api-route-errors`

### Manual
1. Reviewed the staged diff to confirm only the calendar client hardening slice was committed.
2. Verified the primary dirty tree remains otherwise uncommitted for later branches.

## Risk
Risk level:
- [ ] Low
- [x] Medium
- [ ] High

Main risks:
- Unsafe calendar event links will no longer render as clickable anchors.
- Calendar form default timestamps now come from the centralized clock helper.

## Rollout / rollback
- Feature flag: N/A
- Deployment notes: Normal frontend deployment.
- Monitoring to watch: Client telemetry for `CalendarConnectionCard` and `CalendarEventList` error paths.
- Rollback plan: Revert this commit if calendar UI regressions appear.

## Artifacts
- N/A
