### PR TITLE
fix(memory): stabilize runtime timestamps

### DIFF
--- a/src/app/api/memory/[intent]/[userId]/__tests__/stats.route.test.ts
+++ b/src/app/api/memory/[intent]/[userId]/__tests__/stats.route.test.ts
@@ -1,0 +1,141 @@
+/** @vitest-environment node */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  setRateLimitFactoryForTests,
+  setSupabaseFactoryForTests,
+} from "@/lib/api/factory";
+import {
+  createMockNextRequest,
+  createRouteParamsContext,
+  getMockCookiesForTest,
+} from "@/test/helpers/route";
+import { setupUpstashTestEnvironment } from "@/test/upstash/setup";
+
+const { afterAllHook: upstashAfterAllHook, beforeEachHook: upstashBeforeEachHook } =
+  setupUpstashTestEnvironment();
+
+const mockHandleMemoryIntent = vi.hoisted(() => vi.fn());
+const mockNowIso = vi.hoisted(() => vi.fn(() => "2026-02-03T04:05:06.000Z"));
+
+vi.mock("@/lib/memory/orchestrator", () => ({
+  handleMemoryIntent: mockHandleMemoryIntent,
+}));
+
+vi.mock("@/lib/security/random", () => ({
+  nowIso: mockNowIso,
+  secureUuid: vi.fn(() => "00000000-0000-4000-8000-000000000000"),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(() =>
+    Promise.resolve(getMockCookiesForTest({ "sb-access-token": "test-token" }))
+  ),
+}));
+
+vi.mock("@/lib/redis", async () => {
+  const { RedisMockClient, sharedUpstashStore } = await import(
+    "@/test/upstash/redis-mock"
+  );
+  const client = new RedisMockClient(sharedUpstashStore);
+  return {
+    getRedis: () => client,
+  };
+});
+
+vi.mock("@/lib/env/server", () => ({
+  getServerEnvVarWithFallback: vi.fn((key: string, fallback?: string) => {
+    if (key === "UPSTASH_REDIS_REST_URL") return "http://upstash.test";
+    if (key === "UPSTASH_REDIS_REST_TOKEN") return "test-token";
+    return fallback ?? "";
+  }),
+}));
+
+const supabaseClient = {
+  auth: {
+    getUser: vi.fn(),
+  },
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerSupabase: vi.fn(async () => supabaseClient),
+}));
+
+async function importRoute() {
+  const mod = await import("../route");
+  return mod.GET;
+}
+
+describe("/api/memory/stats/[userId] route", () => {
+  const userId = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+  let Get: Awaited<ReturnType<typeof importRoute>> | null = null;
+
+  beforeAll(async () => {
+    Get = await importRoute();
+  }, 15_000);
+
+  beforeEach(() => {
+    upstashBeforeEachHook();
+    vi.clearAllMocks();
+    setRateLimitFactoryForTests(async () => ({
+      limit: 10,
+      remaining: 9,
+      reset: Date.now() + 60_000,
+      success: true,
+    }));
+    setSupabaseFactoryForTests(async () => supabaseClient as never);
+    supabaseClient.auth.getUser.mockResolvedValue({
+      data: { user: { id: userId } },
+      error: null,
+    });
+    mockHandleMemoryIntent.mockResolvedValue({
+      context: [
+        { context: "Paris", score: 0.9, source: "supabase" },
+        { context: "Budget stay", score: 0.7, source: "supabase" },
+      ],
+      intent: {
+        limit: 100,
+        sessionId: "",
+        type: "fetchContext",
+        userId,
+      },
+      results: [],
+      status: "ok",
+    });
+  });
+
+  afterAll(() => {
+    setSupabaseFactoryForTests(null);
+    setRateLimitFactoryForTests(null);
+    upstashAfterAllHook();
+  });
+
+  it("returns memory stats with a shared timestamp helper value", async () => {
+    const req = createMockNextRequest({
+      method: "GET",
+      url: `http://localhost/api/memory/stats/${userId}`,
+    });
+
+    if (!Get) throw new Error("route not loaded");
+    const res = await Get(req, createRouteParamsContext({ intent: "stats", userId }));
+    const body = (await res.json()) as {
+      lastUpdated: string;
+      memoryTypes: Record<string, number>;
+      storageSize: number;
+      totalMemories: number;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.lastUpdated).toBe("2026-02-03T04:05:06.000Z");
+    expect(body.memoryTypes.conversation_context).toBe(2);
+    expect(body.storageSize).toBe("Paris".length + "Budget stay".length);
+    expect(body.totalMemories).toBe(2);
+    expect(mockNowIso).toHaveBeenCalledOnce();
+    expect(mockHandleMemoryIntent).toHaveBeenCalledWith({
+      limit: 100,
+      sessionId: "",
+      type: "fetchContext",
+      userId,
+    });
+  });
+});

--- a/src/app/api/memory/[intent]/[userId]/__tests__/stats.route.test.ts
+++ b/src/app/api/memory/[intent]/[userId]/__tests__/stats.route.test.ts
@@ -10,6 +10,7 @@ import {
   createRouteParamsContext,
   getMockCookiesForTest,
 } from "@/test/helpers/route";
+import { unsafeCast } from "@/test/helpers/unsafe-cast";
 import { setupUpstashTestEnvironment } from "@/test/upstash/setup";
 
 const { afterAllHook: upstashAfterAllHook, beforeEachHook: upstashBeforeEachHook } =
@@ -83,7 +84,7 @@ describe("/api/memory/stats/[userId] route", () => {
       reset: Date.now() + 60_000,
       success: true,
     }));
-    setSupabaseFactoryForTests(async () => supabaseClient as never);
+    setSupabaseFactoryForTests(async () => unsafeCast(supabaseClient));
     supabaseClient.auth.getUser.mockResolvedValue({
       data: { user: { id: userId } },
       error: null,

--- a/src/app/api/memory/[intent]/[userId]/route.ts
+++ b/src/app/api/memory/[intent]/[userId]/route.ts
@@ -123,7 +123,7 @@ const getStats = withApiGuards({
     const contextItems = memoryResult.context ?? [];
 
     return NextResponse.json({
-      lastUpdated: new Date().toISOString(),
+      lastUpdated: nowIso(),
       memoryTypes: {
         conversation_context: contextItems.length,
         other: 0,

--- a/src/app/api/memory/[intent]/__tests__/search.route.test.ts
+++ b/src/app/api/memory/[intent]/__tests__/search.route.test.ts
@@ -80,6 +80,14 @@ async function importRoute() {
   return mod.POST;
 }
 
+function mockPerformanceNowSequence(values: number[]) {
+  const nowSpy = vi.spyOn(performance, "now");
+  for (const value of values) {
+    nowSpy.mockReturnValueOnce(value);
+  }
+  return nowSpy;
+}
+
 describe("/api/memory/search route", () => {
   const userId = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
 
@@ -106,6 +114,7 @@ describe("/api/memory/search route", () => {
   });
 
   it("returns schema-compliant search results", async () => {
+    const nowSpy = mockPerformanceNowSequence([20.25, 33.75]);
     const post = await importRoute();
 
     const context: MemoryContextResponse[] = [
@@ -141,25 +150,30 @@ describe("/api/memory/search route", () => {
       url: "http://localhost/api/memory/search",
     });
 
-    const res = await post(req, createRouteParamsContext({ intent: "search" }));
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as SearchMemoriesResponse;
+    try {
+      const res = await post(req, createRouteParamsContext({ intent: "search" }));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SearchMemoriesResponse;
 
-    expect(body.success).toBe(true);
-    expect(body.totalFound).toBe(1);
-    expect(body.searchMetadata.queryProcessed).toBe("paris");
-    expect(body.memories[0]?.similarityScore).toBeGreaterThanOrEqual(0);
-    expect(body.memories[0]?.relevanceReason).toContain("Matched");
-    expect(body.memories[0]?.memory.userId).toBe(userId);
-    expect(body.memories[0]?.memory.content).toContain("Paris");
+      expect(body.success).toBe(true);
+      expect(body.totalFound).toBe(1);
+      expect(body.searchMetadata.queryProcessed).toBe("paris");
+      expect(body.searchMetadata.searchTimeMs).toBe(13.5);
+      expect(body.memories[0]?.similarityScore).toBeGreaterThanOrEqual(0);
+      expect(body.memories[0]?.relevanceReason).toContain("Matched");
+      expect(body.memories[0]?.memory.userId).toBe(userId);
+      expect(body.memories[0]?.memory.content).toContain("Paris");
 
-    expect(mockHandleMemoryIntent).toHaveBeenCalledWith({
-      limit: 10,
-      query: "paris",
-      sessionId: "",
-      type: "fetchContext",
-      userId,
-    });
+      expect(mockHandleMemoryIntent).toHaveBeenCalledWith({
+        limit: 10,
+        query: "paris",
+        sessionId: "",
+        type: "fetchContext",
+        userId,
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
   }, 15_000);
 
   it("filters by similarityThreshold when provided", async () => {

--- a/src/app/api/memory/[intent]/route.ts
+++ b/src/app/api/memory/[intent]/route.ts
@@ -57,7 +57,7 @@ const postSearch = withApiGuards({
       });
     }
 
-    const startMs = Date.now();
+    const startMs = performance.now();
     const logger = createServerLogger("memory.search", {
       redactKeys: ["error", "userId"],
     });
@@ -169,7 +169,7 @@ const postSearch = withApiGuards({
           memories,
           searchMetadata: {
             queryProcessed: processedQuery,
-            searchTimeMs: Date.now() - startMs,
+            searchTimeMs: performance.now() - startMs,
             similarityThresholdUsed,
           },
           success: true,

--- a/src/hooks/use-memory.ts
+++ b/src/hooks/use-memory.ts
@@ -17,7 +17,7 @@ import type {
 } from "@schemas/memory";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useAuthenticatedApi } from "@/hooks/use-authenticated-api";
-import { type AppError, handleApiError } from "@/lib/api/error-types";
+import { type ApiError, handleApiError } from "@/lib/api/error-types";
 import { keys } from "@/lib/keys";
 import { cacheTimes, staleTimes } from "@/lib/query/config";
 
@@ -30,7 +30,7 @@ import { cacheTimes, staleTimes } from "@/lib/query/config";
 export function useMemoryContext(userId: string, enabled = true) {
   const { makeAuthenticatedRequest } = useAuthenticatedApi();
 
-  return useQuery<MemoryContextResponse, AppError>({
+  return useQuery<MemoryContextResponse, ApiError>({
     enabled: enabled && !!userId,
     gcTime: cacheTimes.medium,
     queryFn: async () => {
@@ -54,7 +54,7 @@ export function useMemoryContext(userId: string, enabled = true) {
 export function useSearchMemories() {
   const { makeAuthenticatedRequest } = useAuthenticatedApi();
 
-  return useMutation<SearchMemoriesResponse, AppError, SearchMemoriesRequest>({
+  return useMutation<SearchMemoriesResponse, ApiError, SearchMemoriesRequest>({
     mutationFn: async (variables) => {
       try {
         return await makeAuthenticatedRequest<SearchMemoriesResponse>(
@@ -81,7 +81,7 @@ export function useSearchMemories() {
 export function useUpdatePreferences(userId: string) {
   const { makeAuthenticatedRequest } = useAuthenticatedApi();
 
-  return useMutation<UpdatePreferencesResponse, AppError, UpdatePreferencesRequest>({
+  return useMutation<UpdatePreferencesResponse, ApiError, UpdatePreferencesRequest>({
     mutationFn: async (variables) => {
       try {
         return await makeAuthenticatedRequest<UpdatePreferencesResponse>(
@@ -109,7 +109,7 @@ export function useUpdatePreferences(userId: string) {
 export function useMemoryInsights(userId: string, enabled = true) {
   const { makeAuthenticatedRequest } = useAuthenticatedApi();
 
-  return useQuery<MemoryInsightsResponse, AppError>({
+  return useQuery<MemoryInsightsResponse, ApiError>({
     enabled: enabled && !!userId,
     gcTime: cacheTimes.extended,
     queryFn: async () => {
@@ -135,7 +135,7 @@ export function useAddConversationMemory() {
 
   return useMutation<
     AddConversationMemoryResponse,
-    AppError,
+    ApiError,
     AddConversationMemoryRequest
   >({
     mutationFn: async (variables) => {
@@ -164,7 +164,7 @@ export function useAddConversationMemory() {
 export function useDeleteUserMemories(userId: string) {
   const { makeAuthenticatedRequest } = useAuthenticatedApi();
 
-  return useMutation<DeleteUserMemoriesResponse, AppError, void>({
+  return useMutation<DeleteUserMemoriesResponse, ApiError, void>({
     mutationFn: async () => {
       try {
         return await makeAuthenticatedRequest<DeleteUserMemoriesResponse>(
@@ -197,7 +197,7 @@ export function useMemoryStats(userId: string, enabled = true) {
       storageSize: number;
       totalMemories: number;
     },
-    AppError
+    ApiError
   >({
     enabled: enabled && !!userId,
     gcTime: cacheTimes.extended,

--- a/src/lib/memory/__tests__/orchestrator.test.ts
+++ b/src/lib/memory/__tests__/orchestrator.test.ts
@@ -7,7 +7,7 @@ import type {
   MemoryAdapterExecutionResult,
   MemoryIntent,
   MemoryOrchestratorOptions,
-} from "../orchestrator";
+} from "../types";
 
 // Mock server-only and telemetry before imports
 vi.mock("server-only", () => ({}));

--- a/src/lib/memory/__tests__/supabase-adapter.test.ts
+++ b/src/lib/memory/__tests__/supabase-adapter.test.ts
@@ -1,0 +1,106 @@
+/** @vitest-environment node */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const adminClient = vi.hoisted(() => ({}));
+const getMaybeSingleMock = vi.hoisted(() => vi.fn());
+const insertSingleMock = vi.hoisted(() => vi.fn());
+const updateSingleMock = vi.hoisted(() => vi.fn());
+const nowIsoMock = vi.hoisted(() => vi.fn(() => "2026-02-03T04:05:06.000Z"));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminSupabase: vi.fn(() => adminClient),
+}));
+
+vi.mock("@/lib/supabase/typed-helpers", () => ({
+  getMany: vi.fn(),
+  getMaybeSingle: getMaybeSingleMock,
+  insertSingle: insertSingleMock,
+  updateSingle: updateSingleMock,
+}));
+
+vi.mock("@/lib/security/random", () => ({
+  nowIso: nowIsoMock,
+}));
+
+vi.mock("@/lib/telemetry/logger", () => ({
+  createServerLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+  })),
+}));
+
+import { createSupabaseMemoryAdapter } from "../supabase-adapter";
+
+describe("createSupabaseMemoryAdapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getMaybeSingleMock.mockResolvedValue({ data: { id: "session-1" }, error: null });
+    insertSingleMock.mockResolvedValue({ data: { id: "turn-1" }, error: null });
+    updateSingleMock.mockResolvedValue({ data: { id: "session-1" }, error: null });
+  });
+
+  it("uses the shared timestamp helper when syncing sessions", async () => {
+    const adapter = createSupabaseMemoryAdapter();
+
+    const result = await adapter.handle(
+      {
+        sessionId: "session-1",
+        type: "syncSession",
+        userId: "user-1",
+      },
+      { now: () => 123 }
+    );
+
+    expect(result.status).toBe("ok");
+    expect(updateSingleMock).toHaveBeenCalledWith(
+      adminClient,
+      "sessions",
+      { last_synced_at: "2026-02-03T04:05:06.000Z" },
+      expect.any(Function),
+      { schema: "memories", select: "id", validate: false }
+    );
+    expect(nowIsoMock).toHaveBeenCalledOnce();
+  });
+
+  it("uses the shared timestamp helper after committing a turn", async () => {
+    const adapter = createSupabaseMemoryAdapter();
+
+    const result = await adapter.handle(
+      {
+        sessionId: "session-1",
+        turn: {
+          content: "Trip memory",
+          id: "turn-1",
+          role: "user",
+          timestamp: "2026-02-03T04:00:00.000Z",
+        },
+        type: "onTurnCommitted",
+        userId: "user-1",
+      },
+      { now: () => 123 }
+    );
+
+    expect(result.status).toBe("ok");
+    expect(insertSingleMock).toHaveBeenCalledWith(
+      adminClient,
+      "turns",
+      expect.objectContaining({
+        content: { text: "Trip memory" },
+        session_id: "session-1",
+        user_id: "user-1",
+      }),
+      { schema: "memories", select: "id", validate: false }
+    );
+    expect(updateSingleMock).toHaveBeenCalledWith(
+      adminClient,
+      "sessions",
+      { last_synced_at: "2026-02-03T04:05:06.000Z" },
+      expect.any(Function),
+      { schema: "memories", select: "id", validate: false }
+    );
+    expect(nowIsoMock).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/memory/__tests__/upstash-adapter.test.ts
+++ b/src/lib/memory/__tests__/upstash-adapter.test.ts
@@ -40,7 +40,9 @@ describe("createUpstashMemoryAdapter", () => {
 
   it("uses stable idempotency keys for onTurnCommitted sync", async () => {
     const adapter = createUpstashMemoryAdapter();
-    const ctx = { now: () => Date.now() };
+    const bucketNowMs = Date.parse("2026-02-03T04:05:06.000Z");
+    const expectedBucket = Math.floor(bucketNowMs / (5 * 60 * 1000));
+    const ctx = { now: () => bucketNowMs };
 
     const intent = {
       sessionId: "session-123",
@@ -64,7 +66,9 @@ describe("createUpstashMemoryAdapter", () => {
     for (const message of messages) {
       const body = message.body as { idempotencyKey: string; payload: unknown };
       expect(message.url).toBe("https://example.test/api/jobs/memory-sync");
-      expect(body.idempotencyKey).toMatch(/^conv-sync:session-123:turn-1:\d+$/);
+      expect(body.idempotencyKey).toBe(
+        `conv-sync:session-123:turn-1:${expectedBucket}`
+      );
       expect(body.payload).toEqual(
         expect.objectContaining({
           sessionId: "session-123",

--- a/src/lib/memory/orchestrator.ts
+++ b/src/lib/memory/orchestrator.ts
@@ -18,19 +18,6 @@ import type {
 } from "./types";
 import { createUpstashMemoryAdapter } from "./upstash-adapter";
 
-// Re-export types for backwards compatibility
-export type {
-  MemoryAdapter,
-  MemoryAdapterContext,
-  MemoryAdapterExecutionResult,
-  MemoryAdapterExecutionStatus,
-  MemoryAdapterResult,
-  MemoryIntent,
-  MemoryIntentType,
-  MemoryOrchestratorOptions,
-  MemoryOrchestratorResult,
-} from "./types";
-
 /** Simple PII redaction result. */
 type PiiRedactionResult = {
   hadPii: boolean;

--- a/src/lib/memory/supabase-adapter.ts
+++ b/src/lib/memory/supabase-adapter.ts
@@ -13,6 +13,7 @@ import {
   TEXT_EMBEDDING_DIMENSIONS,
 } from "@/lib/ai/embeddings/text-embedding-model";
 import { toPgvector } from "@/lib/rag/pgvector";
+import { nowIso } from "@/lib/security/random";
 import { createAdminSupabase } from "@/lib/supabase/admin";
 import type { Database } from "@/lib/supabase/database.types";
 import {
@@ -315,7 +316,7 @@ async function handleOnTurnCommitted(
       supabase,
       "sessions",
       // biome-ignore lint/style/useNamingConvention: database column uses snake_case
-      { last_synced_at: new Date().toISOString() },
+      { last_synced_at: nowIso() },
       (qb) => qb.eq("id", intent.sessionId).eq("user_id", intent.userId),
       { schema: "memories", select: "id", validate: false }
     );
@@ -345,7 +346,7 @@ async function handleSyncSession(
       supabase,
       "sessions",
       // biome-ignore lint/style/useNamingConvention: database column uses snake_case
-      { last_synced_at: new Date().toISOString() },
+      { last_synced_at: nowIso() },
       (qb) => qb.eq("id", intent.sessionId).eq("user_id", intent.userId),
       { schema: "memories", select: "id", validate: false }
     );

--- a/src/lib/memory/upstash-adapter.ts
+++ b/src/lib/memory/upstash-adapter.ts
@@ -14,8 +14,15 @@ import type {
   MemoryIntent,
 } from "./types";
 
+const MEMORY_SYNC_TIME_BUCKET_MS = 5 * 60 * 1000;
+
+function getMemorySyncTimeBucket(ctx: MemoryAdapterContext): number {
+  return Math.floor(ctx.now() / MEMORY_SYNC_TIME_BUCKET_MS);
+}
+
 async function handleOnTurnCommitted(
-  intent: Extract<MemoryIntent, { type: "onTurnCommitted" }>
+  intent: Extract<MemoryIntent, { type: "onTurnCommitted" }>,
+  ctx: MemoryAdapterContext
 ): Promise<MemoryAdapterExecutionResult> {
   const messages = [
     {
@@ -32,7 +39,7 @@ async function handleOnTurnCommitted(
 
   try {
     // Use a time-bucketed component so the same turn can be re-processed after a short window.
-    const timeBucket = Math.floor(Date.now() / (5 * 60 * 1000)); // 5-minute buckets
+    const timeBucket = getMemorySyncTimeBucket(ctx);
     const idempotencyKey = `conv-sync:${intent.sessionId}:${intent.turn.id}:${timeBucket}`;
     const result = await tryEnqueueJob(
       "memory-sync",
@@ -146,7 +153,7 @@ export function createUpstashMemoryAdapter(): MemoryAdapter {
       let result: MemoryAdapterExecutionResult = { status: "skipped" };
 
       if (intent.type === "onTurnCommitted") {
-        result = await handleOnTurnCommitted(intent);
+        result = await handleOnTurnCommitted(intent, ctx);
       } else if (intent.type === "syncSession" || intent.type === "backfillSession") {
         result = await handleSyncSession(intent);
       }


### PR DESCRIPTION
## Summary
- Use shared clock helpers for memory stats and Supabase sync timestamps.
- Use `performance.now()` for memory search elapsed-time metadata.
- Drive Upstash memory-sync idempotency buckets from the injected adapter context clock.
- Move memory adapter type imports to the canonical `types` module after removing re-exports.
- Add focused tests for stats timestamps, search timing, Supabase timestamp writes, and Upstash bucket stability.

## Why
- Memory runtime behavior should be deterministic and testable instead of depending on direct wall-clock reads.
- Adapter code already receives runtime context; idempotency behavior should use that context consistently.
- Type ownership should live in `src/lib/memory/types` instead of being re-exported from the orchestrator module.

## Scope
### Included
- Memory API stats/search timing behavior.
- Memory hook error type alignment from `AppError` to `ApiError`.
- Memory orchestrator type ownership cleanup.
- Supabase and Upstash adapter timestamp/idempotency behavior.
- API and adapter tests for the changed behavior.

### Not included
- Memory schema changes.
- New memory storage behavior or migrations.
- Broader API route hardening outside memory routes.
- Unrelated dirty-tree changes from other subsystems.

## Release Please version impact
Versioning track:
- [x] Pre-1.0 development track
- [ ] Stable 1.0+ SemVer track
- [ ] Explicit repo override applies

Expected Release Please bump after merge to `main`:
- [ ] None
- [x] Patch
- [ ] Minor
- [ ] Major

Public API impact:
- [x] No public API change
- [ ] Public API added
- [ ] Public API changed, backward compatible
- [ ] Public API changed, breaking

Breaking changes:
- [x] None
- [ ] Yes

If breaking, describe the change, affected users/systems, and required migration steps:
- N/A

## Related issues / context
- Follow-up slice from the remaining local dirty tree after PR #779.

## Implementation notes
- `nowIso()` is used for API stats and Supabase `last_synced_at` writes.
- Memory search timing uses monotonic `performance.now()` rather than wall-clock time.
- Upstash sync idempotency keys now use `ctx.now()` for deterministic bucket calculation.
- Orchestrator type re-exports were removed, so tests import from `src/lib/memory/types`.

## Review guide
Recommended review order:
1. `src/app/api/memory/[intent]/route.ts`
2. `src/app/api/memory/[intent]/[userId]/route.ts`
3. `src/lib/memory/upstash-adapter.ts`
4. `src/lib/memory/supabase-adapter.ts`
5. Added/updated tests

Areas needing extra attention:
- Timestamp source consistency.
- Upstash idempotency key behavior.
- Public import compatibility around removed orchestrator type re-exports.

Specific feedback requested:
- [x] Correctness
- [x] Architecture
- [x] Backward compatibility / migration

## Validation
### Automated
- [x] Tests added or updated
- [x] Type checks pass
- [x] Lint passes
- [ ] Build passes

Commands run:
- `pnpm exec vitest run 'src/app/api/memory/[intent]/[userId]/__tests__/stats.route.test.ts' 'src/app/api/memory/[intent]/__tests__/search.route.test.ts' 'src/lib/memory/__tests__/orchestrator.test.ts' 'src/lib/memory/__tests__/upstash-adapter.test.ts' 'src/lib/memory/__tests__/supabase-adapter.test.ts'`
- `pnpm biome:fix`
- `pnpm type-check`
- `pnpm test:affected`
- `pnpm check:zod-v4`
- `pnpm check:api-route-errors`

### Manual
1. Reviewed the staged diff to confirm only the memory runtime determinism slice was committed.
2. Verified the primary dirty tree remains otherwise uncommitted for later branches.

## Risk
Risk level:
- [ ] Low
- [x] Medium
- [ ] High

Main risks:
- Removing orchestrator type re-exports may affect any internal imports not covered by type-check.
- Upstash idempotency buckets now follow the adapter context clock, so callers must provide a sane `ctx.now()` value.

## Rollout / rollback
- Feature flag: N/A
- Deployment notes: Normal API/frontend deployment.
- Monitoring to watch: Memory search latency metadata, memory-sync enqueue/idempotency behavior, Supabase `last_synced_at` updates.
- Rollback plan: Revert this commit if memory sync idempotency or timestamp behavior regresses.

## Artifacts
- N/A
