### PR TITLE
fix(chat): harden error handling

### DIFF
--- a/src/app/(app)/chat/__tests__/chat-client.error.test.tsx
+++ b/src/app/(app)/chat/__tests__/chat-client.error.test.tsx
@@ -1,18 +1,26 @@
 /** @vitest-environment jsdom */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { server } from "@/test/msw/server";
 import { render, screen } from "@/test/test-utils";
 import { ChatClient } from "../chat-client";
 
-const mockChatState = {
-  error: new Error(
-    JSON.stringify({
-      error: "rate_limit_unavailable",
-      reason: "Rate limiting unavailable",
-    })
-  ),
-  status: "error" as const,
-};
+const { mockChatState, mockRecordClientErrorOnActiveSpan, mockSendMessage } =
+  vi.hoisted(() => ({
+    mockChatState: {
+      error: new Error(
+        JSON.stringify({
+          error: "rate_limit_unavailable",
+          reason: "Rate limiting unavailable",
+        })
+      ) as Error | null,
+      status: "error" as "error" | "ready",
+    },
+    mockRecordClientErrorOnActiveSpan: vi.fn(),
+    mockSendMessage: vi.fn(),
+  }));
 
 vi.mock("@ai-sdk/react", () => ({
   useChat: () => {
@@ -21,7 +29,7 @@ vi.mock("@ai-sdk/react", () => ({
       error: mockChatState.error,
       messages: [],
       regenerate: noop,
-      sendMessage: noop,
+      sendMessage: mockSendMessage,
       status: mockChatState.status,
       stop: noop,
     };
@@ -35,6 +43,10 @@ vi.mock("@/components/ai-elements/response", () => ({
   ),
 }));
 
+vi.mock("@/lib/telemetry/client-errors", () => ({
+  recordClientErrorOnActiveSpan: mockRecordClientErrorOnActiveSpan,
+}));
+
 describe("ChatClient error messaging", () => {
   beforeEach(() => {
     mockChatState.error = new Error(
@@ -44,6 +56,13 @@ describe("ChatClient error messaging", () => {
       })
     );
     mockChatState.status = "error";
+    mockRecordClientErrorOnActiveSpan.mockReset();
+    mockSendMessage.mockReset();
+    mockSendMessage.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("maps rate limit errors to a friendly message", () => {
@@ -71,5 +90,56 @@ describe("ChatClient error messaging", () => {
         "AI provider is not configured yet. Add an API key in settings to enable chat."
       )
     ).toBeInTheDocument();
+  });
+
+  it("reports session creation failures through telemetry and still sends the message", async () => {
+    server.use(http.post("/api/chat/sessions", () => HttpResponse.error()));
+    mockChatState.error = null;
+    mockChatState.status = "ready";
+
+    render(<ChatClient />);
+
+    fireEvent.change(screen.getByLabelText("Chat prompt"), {
+      target: { value: "Plan a trip" },
+    });
+    fireEvent.submit(
+      screen.getByLabelText("Chat prompt").closest("form") as HTMLFormElement
+    );
+
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalledWith({ text: "Plan a trip" }, undefined);
+    });
+    expect(mockRecordClientErrorOnActiveSpan).toHaveBeenCalledWith(expect.any(Error), {
+      action: "createSession",
+      context: "ChatClient",
+    });
+  });
+
+  it("reports message submission failures through telemetry", async () => {
+    const submitError = new Error("submit failed");
+    server.use(
+      http.post("/api/chat/sessions", () =>
+        HttpResponse.json({ id: "session-1" }, { status: 201 })
+      )
+    );
+    mockChatState.error = null;
+    mockChatState.status = "ready";
+    mockSendMessage.mockRejectedValueOnce(submitError);
+
+    render(<ChatClient />);
+
+    fireEvent.change(screen.getByLabelText("Chat prompt"), {
+      target: { value: "Find flights" },
+    });
+    fireEvent.submit(
+      screen.getByLabelText("Chat prompt").closest("form") as HTMLFormElement
+    );
+
+    await waitFor(() => {
+      expect(mockRecordClientErrorOnActiveSpan).toHaveBeenCalledWith(submitError, {
+        action: "submitMessage",
+        context: "ChatClient",
+      });
+    });
   });
 });

--- a/src/app/(app)/chat/chat-client.tsx
+++ b/src/app/(app)/chat/chat-client.tsx
@@ -36,6 +36,7 @@ import { ChatMessageItem } from "@/components/chat/message-item";
 import { Button } from "@/components/ui/button";
 import { secureId } from "@/lib/security/random";
 import { getBrowserClient } from "@/lib/supabase";
+import { recordClientErrorOnActiveSpan } from "@/lib/telemetry/client-errors";
 
 const STORAGE_BUCKET = "attachments";
 
@@ -86,6 +87,17 @@ function resolveChatErrorMessage(error?: Error): string {
   }
 
   return error.message || CHAT_ERROR_FALLBACK;
+}
+
+function normalizeChatClientError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function reportChatClientError(error: unknown, action: string): void {
+  recordClientErrorOnActiveSpan(normalizeChatClientError(error), {
+    action,
+    context: "ChatClient",
+  });
 }
 
 /**
@@ -211,9 +223,7 @@ export function ChatClient(): ReactElement {
         (err instanceof Error && err.name === "AbortError");
       if (isAbort) return null;
 
-      if (process.env.NODE_ENV === "development") {
-        console.error("Failed to create chat session:", err);
-      }
+      reportChatClientError(err, "createSession");
       return null;
     }
   };
@@ -356,9 +366,7 @@ export function ChatClient(): ReactElement {
         activeSessionId ? { body: { sessionId: activeSessionId } } : undefined
       );
     } catch (err) {
-      if (process.env.NODE_ENV === "development") {
-        console.error("Failed to submit chat message:", err);
-      }
+      reportChatClientError(err, "submitMessage");
     } finally {
       if (!controller.signal.aborted) {
         setInput("");

--- a/src/app/api/chat/__tests__/_handler.test.ts
+++ b/src/app/api/chat/__tests__/_handler.test.ts
@@ -127,6 +127,7 @@ describe("handleChat", () => {
     getMaybeSingleMock.mockResolvedValue({ data: { id: sessionId }, error: null });
     getManyMock.mockResolvedValue({ count: null, data: [], error: null });
     let messageInsertId = 100;
+    let clockNow = 1_000;
     insertSingleMock.mockImplementation((_client, table: string) => {
       if (table === "chat_messages") {
         messageInsertId += 1;
@@ -139,6 +140,7 @@ describe("handleChat", () => {
 
     await handleChat(
       {
+        clock: { now: () => clockNow },
         resolveProvider: async () => ({
           credentialSource: "user-provider",
           model: createMockModel(),
@@ -217,6 +219,7 @@ describe("handleChat", () => {
       totalUsage: usage,
     });
 
+    clockNow = 1_125;
     await streamOpts.onFinish?.({
       finishReason: undefined,
       isAborted: true,
@@ -238,7 +241,11 @@ describe("handleChat", () => {
     expect(typeof update.content).toBe("string");
     expect(update.content).toContain("partial answer");
     expect(update.metadata).toEqual(
-      expect.objectContaining({ isAborted: true, status: "aborted" })
+      expect.objectContaining({
+        durationMs: 125,
+        isAborted: true,
+        status: "aborted",
+      })
     );
   }, 10000);
 

--- a/src/app/api/chat/__tests__/route.test.ts
+++ b/src/app/api/chat/__tests__/route.test.ts
@@ -8,6 +8,7 @@ import {
   mockApiRouteAuthUser,
   resetApiRouteMocks,
 } from "@/test/helpers/api-route";
+import type { ChatDeps, ChatPayload } from "../_handler";
 
 vi.mock("server-only", () => ({}));
 
@@ -19,8 +20,9 @@ vi.mock("botid/server", async () => {
 });
 
 const getAdminSupabaseMock = vi.hoisted(() => vi.fn(() => ({})));
+type HandleChatMock = (deps: ChatDeps, payload: ChatPayload) => Promise<Response>;
 const handleChatMock = vi.hoisted(() =>
-  vi.fn(async () => new Response("ok", { status: 200 }))
+  vi.fn<HandleChatMock>(async () => new Response("ok", { status: 200 }))
 );
 
 vi.mock("@/lib/supabase/admin", () => ({
@@ -73,6 +75,15 @@ describe("/api/chat (AI SDK UI stream)", () => {
         userId,
       })
     );
+
+    const deps = handleChatMock.mock.calls[0]?.[0];
+    const performanceNowSpy = vi.spyOn(performance, "now").mockReturnValue(432.5);
+    try {
+      expect(deps.clock?.now()).toBe(432.5);
+      expect(performanceNowSpy).toHaveBeenCalledOnce();
+    } finally {
+      performanceNowSpy.mockRestore();
+    }
   });
 
   it("accepts single-message request shape (message field)", async () => {

--- a/src/app/api/chat/_handler.ts
+++ b/src/app/api/chat/_handler.ts
@@ -106,6 +106,10 @@ export interface ChatPayload {
   abortSignal?: AbortSignal;
 }
 
+function getClockNow(clock: ChatDeps["clock"]): number {
+  return clock?.now?.() ?? performance.now();
+}
+
 // Local schemas for AI SDK callback payloads; they differ from domain schemas
 // in @schemas/chat that represent persisted entities.
 const toolCallSchema = z.looseObject({
@@ -894,7 +898,7 @@ export async function handleChat(
   deps: ChatDeps,
   payload: ChatPayload
 ): Promise<Response> {
-  const startedAt = deps.clock?.now?.() ?? Date.now();
+  const startedAt = getClockNow(deps.clock);
   const requestId = secureUuid();
 
   const userId = payload.userId.trim();
@@ -1058,7 +1062,7 @@ export async function handleChat(
   const lastMessageId =
     latestUserMessage?.id ?? visibleHistory.at(-1)?.uiMessageId ?? "none";
   const memoryCacheKey = `${userId}:${sessionId}:${lastMessageId}`;
-  const cacheNow = deps.clock?.now?.() ?? Date.now();
+  const cacheNow = getClockNow(deps.clock);
   memorySummary = deps.memorySummaryCache?.get(memoryCacheKey, cacheNow);
   if (!memorySummary) {
     try {
@@ -1207,7 +1211,7 @@ export async function handleChat(
         messages: modelMessages,
         model: provider.model,
         onFinish: async ({ finishReason, text, totalUsage }) => {
-          const durationMs = (deps.clock?.now?.() ?? Date.now()) - startedAt;
+          const durationMs = getClockNow(deps.clock) - startedAt;
 
           deps.logger?.info?.("chat:finish", {
             durationMs,
@@ -1460,7 +1464,7 @@ export async function handleChat(
     onFinish: async ({ finishReason, isAborted, responseMessage }) => {
       if (!isAborted) return;
 
-      const durationMs = (deps.clock?.now?.() ?? Date.now()) - startedAt;
+      const durationMs = getClockNow(deps.clock) - startedAt;
       const text = getTextFromUiMessage(responseMessage);
       const metadataResult = chatMessageMetadataSchema.safeParse(
         responseMessage.metadata

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -151,7 +151,7 @@ export const POST = withApiGuards({
   const adminSupabase = getAdminSupabase();
   return handleChat(
     {
-      clock: { now: () => Date.now() },
+      clock: { now: () => performance.now() },
       config: {
         defaultMaxTokens,
         stepLimit,


### PR DESCRIPTION
## Summary
- Replaces chat client development-only console error logging with telemetry-backed client error reporting.
- Adds tests for session creation and message submission failure paths in the chat client.
- Injects a monotonic `performance.now()` clock through the chat API route and handler for deterministic duration metadata.
- Extends chat route and handler tests to cover the injected clock and aborted-stream duration metadata.

## Why
- Chat failures should be observable in telemetry instead of disappearing behind local-only console logging.
- Duration metadata should use a monotonic runtime clock so elapsed timing is deterministic and not affected by wall-clock changes.
- This is an independent dirty-tree slice that can be reviewed before PR #780 is merged because it branches directly from current `main`.

## Scope
### Included
- Chat client failure telemetry for session creation and message submission.
- Chat API route clock injection using `performance.now()`.
- Focused component and API tests for the changed chat behavior.

### Not included
- Broader search, profile, realtime, docs, CI, package, or dependency dirty-tree changes.
- Any change to memory runtime behavior from PR #780.

## Release Please version impact
Versioning track:
- [x] Pre-1.0 development track
- [ ] Stable 1.0+ SemVer track
- [ ] Explicit repo override applies

Expected Release Please bump after merge to `main`:
- [ ] None
- [x] Patch
- [ ] Minor
- [ ] Major

Default interpretation for pre-1.0 repos unless explicitly overridden:
- `fix:` -> Patch
- `feat:` -> Patch
- `!` or `BREAKING CHANGE:` -> Minor

Public API impact:
- [x] No public API change
- [ ] Public API added
- [ ] Public API changed, backward compatible
- [ ] Public API changed, breaking

Breaking changes:
- [x] None
- [ ] Yes

If breaking, describe the change, affected users/systems, and required migration steps:
- N/A

## Related issues / context
- Follow-up dirty-tree extraction after PR #780.
- No issue linked.

## Implementation notes
- `ChatClient` normalizes unknown thrown values to `Error` before calling `recordClientErrorOnActiveSpan`.
- `handleChat` now uses a small `getClockNow` helper so route-provided clocks and test clocks are applied consistently.
- `/api/chat` passes `performance.now()` rather than `Date.now()` so duration calculations use a monotonic source.

## Review guide
Recommended review order:
1. `src/app/(app)/chat/chat-client.tsx`
2. `src/app/api/chat/route.ts`
3. `src/app/api/chat/_handler.ts`
4. Updated tests under `src/app/(app)/chat/__tests__` and `src/app/api/chat/__tests__`

Areas needing extra attention:
- Client telemetry payload shape and whether action/context names match existing observability conventions.
- Monotonic clock usage for handler duration metadata.

Specific feedback requested:
- [x] Correctness
- [ ] Architecture
- [ ] API design
- [ ] Performance
- [ ] Security
- [ ] Backward compatibility / migration
- [ ] UX / accessibility / copy

## Validation
### Automated
- [x] Tests added or updated
- [x] Type checks pass
- [x] Lint passes
- [ ] Build passes

Commands run:
- `pnpm exec vitest run src/app/\(app\)/chat/__tests__/chat-client.error.test.tsx src/app/api/chat/__tests__/_handler.test.ts src/app/api/chat/__tests__/route.test.ts` - 3 files, 12 tests passed in the primary checkout before commit.
- `pnpm install --frozen-lockfile` - completed in clean validation worktree; prepare hook could not write hooks in linked worktree, but install exited 0.
- `rtk err pnpm biome:fix` - passed in clean validation worktree; no files changed.
- `rtk err pnpm type-check` - passed in clean validation worktree.
- `rtk test pnpm test:affected` - passed in clean validation worktree.
- `pnpm exec vitest run src/app/\(app\)/chat/__tests__/chat-client.error.test.tsx src/app/api/chat/__tests__/_handler.test.ts src/app/api/chat/__tests__/route.test.ts` - 3 files, 12 tests passed in clean validation worktree.
- `rtk err pnpm check:zod-v4` - passed in clean validation worktree.
- `rtk err pnpm check:api-route-errors` - passed in clean validation worktree.

### Manual
1. Confirmed the PR branch was created from current `main`, not stacked on PR #780.
2. Confirmed the primary checkout still preserves unrelated dirty-tree changes after commit.
3. Confirmed the clean validation worktree had no formatter or generated changes after gates.

## Risk
Risk level:
- [x] Low
- [ ] Medium
- [ ] High

Main risks:
- Chat client error telemetry could increase client-side observability volume for repeated submission failures.
- Handler duration values now use monotonic elapsed time instead of wall-clock time; this should improve duration semantics but reviewers should confirm no downstream code expects epoch timestamps for `durationMs`.

## Rollout / rollback
- Feature flag: N/A
- Deployment notes: Deploy with the normal web application release.
- Monitoring to watch: Client error telemetry for `ChatClient` actions `createSession` and `submitMessage`; chat API abort/finish logs.
- Rollback plan: Revert this commit to restore prior chat client error logging and route clock behavior.

## Artifacts
- N/A
