### PR TITLE
refactor(auth): standardize auth route errors and CI guardrails

### DIFF
--- a/.github/ci-config.yml
+++ b/.github/ci-config.yml
@@ -3,6 +3,7 @@
 versions:
   node: "24"
   node-full: "24.x"
+  corepack: "0.35.0"
   pnpm: "11.3.0"
   biome: "2.4.15"
   playwright: "1.60.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ permissions:
   contents: read
   pull-requests: read
 
+env:
+  COREPACK_VERSION: "0.35.0"
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -84,7 +87,7 @@ jobs:
 
       - name: Install deps
         run: |
-          npm install -g corepack@latest
+          npm install -g "corepack@${COREPACK_VERSION}"
           corepack enable pnpm
           corepack install
           pnpm ci
@@ -129,6 +132,12 @@ jobs:
       - name: Reject secrets (full scan)
         if: github.event_name != 'pull_request'
         run: pnpm check:no-secrets:full
+
+      - name: Dependency usage audit
+        run: pnpm deps:audit
+
+      - name: High-severity dependency audit
+        run: pnpm audit --audit-level high
 
       - name: Architecture boundary checks
         run: pnpm boundary:check
@@ -292,7 +301,7 @@ jobs:
 
       - name: Install deps
         run: |
-          npm install -g corepack@latest
+          npm install -g "corepack@${COREPACK_VERSION}"
           corepack enable pnpm
           corepack install
           pnpm ci
@@ -305,7 +314,7 @@ jobs:
           CI: '1'
           VITEST_COVERAGE_SKIP_THRESHOLDS: '1'
         run: >-
-          pnpm vitest run --coverage
+          pnpm exec vitest run --coverage
           --pool=threads --reporter=blob
           --shard=${{ matrix.shard }}/${{ matrix.total }}
 
@@ -332,7 +341,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm install -g corepack@latest
+          npm install -g "corepack@${COREPACK_VERSION}"
           corepack enable pnpm
           corepack install
           pnpm ci
@@ -346,7 +355,7 @@ jobs:
 
       - name: Merge reports
         run: |
-          pnpm vitest run --merge-reports .vitest-reports --coverage
+          pnpm exec vitest run --merge-reports .vitest-reports --coverage
           node scripts/check-coverage-critical.mjs
 
       - name: Upload coverage report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,4 +60,4 @@ jobs:
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || github.token }}
-        run: npx semantic-release --extends ./release.config.mjs
+        run: pnpm exec semantic-release --extends ./release.config.mjs

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Zero-trust architecture with defense-in-depth security:
 - **Server-Only Secrets**: BYOK routes import `"server-only"` and run with `dynamic = "force-dynamic"` to ensure secrets processed per-request
 - **PII Redaction**: OpenTelemetry spans automatically redact sensitive data; structured logging with correlation IDs
 - **Tool Approval Gates**: Critical operations (bookings, payments) pause streaming and require explicit user consent
-- **Dependency Security**: Dependabot provides automated vulnerability scanning in CI; `pnpm audit` is available for local/manual checks (not run in CI)
+- **Dependency Security**: Dependabot provides automated vulnerability scanning; CI runs `pnpm deps:audit` and `pnpm audit --audit-level high`, with `pnpm audit` available for local/manual checks
 
 ### Security Testing
 

--- a/docs/development/backend/release-automation.md
+++ b/docs/development/backend/release-automation.md
@@ -6,7 +6,7 @@ This repository uses semantic-release to automate versioning, changelog updates,
 
 - Trigger: push to `main`.
 - Action: `.github/workflows/release.yml`.
-- Steps: checkout (full history) → set up Node from `.nvmrc` → install pnpm and dependencies → run `npx semantic-release --extends release.config.mjs`.
+- Steps: checkout (full history) → set up Node from `.nvmrc` → install pnpm and dependencies → run `pnpm exec semantic-release --extends release.config.mjs`.
 - Env: `GITHUB_TOKEN`.
 - Permissions: `contents`, `issues`, and `pull-requests` (write) to create tags and release notes.
 

--- a/scripts/check-api-route-errors.mjs
+++ b/scripts/check-api-route-errors.mjs
@@ -1,15 +1,17 @@
 /**
- * @fileoverview Enforces route-handler error response helpers in `src/app/api/**`.
+ * @fileoverview Enforces route-handler error response helpers in app API/auth routes.
  *
  * Repo contract forbids inline JSON error responses like:
  * - `NextResponse.json({ error: "..." }, { status: 4xx/5xx })`
+ * - `NextResponse.json({ code: "..." }, { status: 4xx/5xx })`
  * - `new Response(JSON.stringify({ error: "..." }), { status: 4xx/5xx })`
+ * - `new Response(JSON.stringify({ code: "..." }), { status: 4xx/5xx })`
  *
  * Use `errorResponse()` (and other helpers) from `@/lib/api/route-helpers` instead.
  *
  * Notes:
  * - Only checks files changed in the current diff (BASE_REF...HEAD, defaulting to origin/main...HEAD or main...HEAD).
- * - Use `--full` to scan all tracked `src/app/api/**` files.
+ * - Use `--full` to scan all tracked `src/app/api/**` and `src/app/auth/**` files.
  * - Excludes tests/mocks.
  * - Allow an exception by adding `api-route-error-ok:` on the violating line with a short justification.
  */
@@ -24,23 +26,31 @@ const ARGS = new Set(process.argv.slice(2));
 const MODE = ARGS.has("--full") ? "full" : "diff";
 
 const CHECKED_FILE_RE = /\.(c|m)?[tj]sx?$/;
+const CHECKED_ROUTE_PATHS = ["src/app/api", "src/app/auth"];
+const CHECKED_ROUTE_PREFIXES = CHECKED_ROUTE_PATHS.map((path) => `${path}/`);
 
 function isExcludedPath(filePath) {
-  if (!filePath.startsWith("src/app/api/")) return true;
+  if (!CHECKED_ROUTE_PREFIXES.some((prefix) => filePath.startsWith(prefix))) {
+    return true;
+  }
   if (!CHECKED_FILE_RE.test(filePath)) return true;
   if (EXCLUDED_PATH_PARTS.some((part) => filePath.includes(part))) return true;
   return filePath.includes(".test.") || filePath.includes(".spec.");
 }
 
 function runGitDiffNameOnly(range) {
-  return execFileSync("git", ["diff", "--name-only", range, "--", "src/app/api"], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+  return execFileSync(
+    "git",
+    ["diff", "--name-only", range, "--", ...CHECKED_ROUTE_PATHS],
+    {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }
+  );
 }
 
 function getTrackedFiles() {
-  const out = execFileSync("git", ["ls-files", "--", "src/app/api"], {
+  const out = execFileSync("git", ["ls-files", "--", ...CHECKED_ROUTE_PATHS], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -345,9 +355,9 @@ function findObjectLiteralAfter(text, startIndex) {
 }
 
 function isErrorObjectLiteral(objectLiteralText) {
-  // We only care about top-level payload objects that include an `error:` property.
+  // We only care about payload objects that include `error:` or legacy `code:`.
   // If a route uses an error helper, this won't match.
-  return /\berror\b\s*:/.test(objectLiteralText);
+  return /\b(error|code)\b\s*:/.test(objectLiteralText);
 }
 
 function scanForbiddenNextResponseJson(text) {
@@ -464,7 +474,7 @@ if (violations.length > 0) {
     `Found forbidden inline error JSON responses in ${
       MODE === "full" ? "tracked" : "changed"
     } route code.\n\n` +
-      "Use `errorResponse()` (or `unauthorizedResponse()`, `forbiddenResponse()`, etc.) from `@/lib/api/route-helpers`.\n\n" +
+      "Use `errorResponse()` (or `unauthorizedResponse()`, `forbiddenResponse()`, etc.) from `@/lib/api/route-helpers`; auth routes may use `authRouteErrorResponse()` from `@/lib/auth/route-error-response`.\n\n" +
       `If absolutely necessary, add '${ALLOWLIST_MARKER}' on the violating line with a short justification.\n\n` +
       formatted +
       "\n"

--- a/scripts/check-no-unknown-casts.mjs
+++ b/scripts/check-no-unknown-casts.mjs
@@ -3,7 +3,7 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
 const CHECKED_FILE_RE = /\.(c|m)?[tj]sx?$/;
 
@@ -24,6 +24,7 @@ function listTrackedSrcFiles() {
     .split("\n")
     .map((line) => line.trim())
     .filter(Boolean)
+    .filter((filePath) => existsSync(filePath))
     .filter((filePath) => !isExcludedPath(filePath));
 }
 

--- a/src/app/auth/delete/__tests__/route.test.ts
+++ b/src/app/auth/delete/__tests__/route.test.ts
@@ -54,7 +54,9 @@ describe("/auth/delete route", () => {
     expect(res.status).toBe(400);
     await expect(res.json()).resolves.toEqual({
       code: "DELETE_FAILED",
+      error: "delete_failed",
       message: "Delete failed",
+      reason: "Delete failed",
     });
   });
 
@@ -63,6 +65,10 @@ describe("/auth/delete route", () => {
 
     const res = await DELETE();
     expect(res.status).toBe(500);
-    await expect(res.json()).resolves.toMatchObject({ code: "DELETE_FAILED" });
+    await expect(res.json()).resolves.toMatchObject({
+      code: "DELETE_FAILED",
+      error: "delete_failed",
+      reason: "not authenticated",
+    });
   });
 });

--- a/src/app/auth/delete/route.ts
+++ b/src/app/auth/delete/route.ts
@@ -5,6 +5,7 @@
 import "server-only";
 
 import { NextResponse } from "next/server";
+import { authRouteErrorResponse } from "@/lib/auth/route-error-response";
 import { requireUser } from "@/lib/auth/server";
 import { createAdminSupabase } from "@/lib/supabase/admin";
 
@@ -20,16 +21,21 @@ export async function DELETE(): Promise<NextResponse> {
 
     const { error } = await admin.auth.admin.deleteUser(user.id);
     if (error) {
-      return NextResponse.json(
-        { code: "DELETE_FAILED", message: error.message },
-        { status: 400 }
-      );
+      return authRouteErrorResponse({
+        code: "DELETE_FAILED",
+        reason: error.message,
+        status: 400,
+      });
     }
 
     return NextResponse.json({ ok: true });
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Failed to delete account.";
-    return NextResponse.json({ code: "DELETE_FAILED", message }, { status: 500 });
+    return authRouteErrorResponse({
+      code: "DELETE_FAILED",
+      reason: message,
+      status: 500,
+    });
   }
 }

--- a/src/app/auth/email/resend/__tests__/route.test.ts
+++ b/src/app/auth/email/resend/__tests__/route.test.ts
@@ -40,7 +40,11 @@ describe("/auth/email/resend route", () => {
 
     const res = await POST(new NextRequest("http://localhost/auth/email/resend"));
     expect(res.status).toBe(400);
-    await expect(res.json()).resolves.toMatchObject({ code: "EMAIL_REQUIRED" });
+    await expect(res.json()).resolves.toMatchObject({
+      code: "EMAIL_REQUIRED",
+      error: "email_required",
+      reason: "User email is required to resend verification",
+    });
     expect(resend).not.toHaveBeenCalled();
   });
 
@@ -57,7 +61,9 @@ describe("/auth/email/resend route", () => {
     expect(res.status).toBe(400);
     await expect(res.json()).resolves.toEqual({
       code: "RESEND_FAILED",
+      error: "resend_failed",
       message: "Resend failed",
+      reason: "Resend failed",
     });
     expect(resend).toHaveBeenCalledTimes(1);
     expect(resend).toHaveBeenCalledWith({ email: "user@example.com", type: "signup" });

--- a/src/app/auth/email/resend/route.ts
+++ b/src/app/auth/email/resend/route.ts
@@ -6,6 +6,7 @@ import "server-only";
 
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { authRouteErrorResponse } from "@/lib/auth/route-error-response";
 import { requireUser } from "@/lib/auth/server";
 import { ROUTES } from "@/lib/routes";
 
@@ -15,13 +16,11 @@ export async function POST(_request: NextRequest): Promise<NextResponse> {
   });
 
   if (!user.email) {
-    return NextResponse.json(
-      {
-        code: "EMAIL_REQUIRED",
-        message: "User email is required to resend verification",
-      },
-      { status: 400 }
-    );
+    return authRouteErrorResponse({
+      code: "EMAIL_REQUIRED",
+      reason: "User email is required to resend verification",
+      status: 400,
+    });
   }
 
   const { error } = await supabase.auth.resend({
@@ -30,10 +29,11 @@ export async function POST(_request: NextRequest): Promise<NextResponse> {
   });
 
   if (error) {
-    return NextResponse.json(
-      { code: "RESEND_FAILED", message: error.message },
-      { status: 400 }
-    );
+    return authRouteErrorResponse({
+      code: "RESEND_FAILED",
+      reason: error.message,
+      status: 400,
+    });
   }
 
   return NextResponse.json({ ok: true });

--- a/src/app/auth/email/verify/__tests__/route.test.ts
+++ b/src/app/auth/email/verify/__tests__/route.test.ts
@@ -45,7 +45,9 @@ describe("POST /auth/email/verify", () => {
     expect(res.status).toBe(413);
     expect(await res.json()).toEqual({
       code: "PAYLOAD_TOO_LARGE",
+      error: "payload_too_large",
       message: "Request body exceeds limit",
+      reason: "Request body exceeds limit",
     });
     expect(cancelled).toBe(true);
     expect(pulls).toBeLessThan(20);

--- a/src/app/auth/email/verify/route.ts
+++ b/src/app/auth/email/verify/route.ts
@@ -8,6 +8,7 @@ import type { EmailOtpType } from "@supabase/supabase-js";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { parseJsonBody } from "@/lib/api/route-helpers";
+import { authRouteErrorResponse } from "@/lib/auth/route-error-response";
 import { createServerSupabase } from "@/lib/supabase/server";
 import { emitOperationalAlertOncePerWindow } from "@/lib/telemetry/degraded-mode";
 import { createServerLogger } from "@/lib/telemetry/logger";
@@ -24,25 +25,28 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const parsed = await parseJsonBody(request, { maxBytes: MAX_BODY_BYTES });
   if (!parsed.ok) {
     if (parsed.error.status === 413) {
-      return NextResponse.json(
-        { code: "PAYLOAD_TOO_LARGE", message: "Request body exceeds limit" },
-        { status: 413 }
-      );
+      return authRouteErrorResponse({
+        code: "PAYLOAD_TOO_LARGE",
+        reason: "Request body exceeds limit",
+        status: 413,
+      });
     }
-    return NextResponse.json(
-      { code: "BAD_REQUEST", message: "Malformed JSON" },
-      { status: 400 }
-    );
+    return authRouteErrorResponse({
+      code: "BAD_REQUEST",
+      reason: "Malformed JSON",
+      status: 400,
+    });
   }
 
   const payload: VerifyPayload = isPlainObject(parsed.data) ? parsed.data : {};
 
   const token = typeof payload.token === "string" ? payload.token : "";
   if (!token) {
-    return NextResponse.json(
-      { code: "VALIDATION_ERROR", message: "Verification token is required" },
-      { status: 400 }
-    );
+    return authRouteErrorResponse({
+      code: "VALIDATION_ERROR",
+      reason: "Verification token is required",
+      status: 400,
+    });
   }
 
   const supabase = await createServerSupabase();
@@ -66,10 +70,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       errorCode: error.code,
       status: error.status,
     });
-    return NextResponse.json(
-      { code: "VERIFICATION_FAILED", message: "Verification failed" },
-      { status: 400 }
-    );
+    return authRouteErrorResponse({
+      code: "VERIFICATION_FAILED",
+      reason: "Verification failed",
+      status: 400,
+    });
   }
 
   return NextResponse.json({ ok: true });

--- a/src/app/auth/logout/__tests__/route.test.ts
+++ b/src/app/auth/logout/__tests__/route.test.ts
@@ -61,6 +61,7 @@ describe("auth/logout route", () => {
     expect(body).toEqual({
       error: "logout_failed",
       message: "signout failed",
+      reason: "signout failed",
     });
   });
 

--- a/src/app/auth/logout/__tests__/route.test.ts
+++ b/src/app/auth/logout/__tests__/route.test.ts
@@ -60,8 +60,8 @@ describe("auth/logout route", () => {
     const body = await res.json();
     expect(body).toEqual({
       error: "logout_failed",
-      message: "signout failed",
-      reason: "signout failed",
+      message: "Logout failed",
+      reason: "Logout failed",
     });
   });
 

--- a/src/app/auth/logout/route.ts
+++ b/src/app/auth/logout/route.ts
@@ -8,6 +8,9 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { authRouteErrorResponse } from "@/lib/auth/route-error-response";
 import { createServerSupabase } from "@/lib/supabase/server";
+import { createServerLogger } from "@/lib/telemetry/logger";
+
+const logger = createServerLogger("auth.logout");
 
 /**
  * Handles POST /auth/logout requests from client-side consumers.
@@ -20,9 +23,10 @@ export async function POST(_request: NextRequest): Promise<NextResponse> {
   const { error } = await supabase.auth.signOut();
 
   if (error) {
+    logger.error("auth.logout.sign_out_failed", { message: error.message });
     return authRouteErrorResponse({
       error: "logout_failed",
-      reason: error.message,
+      reason: "Logout failed",
       status: 500,
     });
   }

--- a/src/app/auth/logout/route.ts
+++ b/src/app/auth/logout/route.ts
@@ -6,6 +6,7 @@ import "server-only";
 
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { authRouteErrorResponse } from "@/lib/auth/route-error-response";
 import { createServerSupabase } from "@/lib/supabase/server";
 
 /**
@@ -19,10 +20,11 @@ export async function POST(_request: NextRequest): Promise<NextResponse> {
   const { error } = await supabase.auth.signOut();
 
   if (error) {
-    return NextResponse.json(
-      { error: "logout_failed", message: error.message },
-      { status: 500 }
-    );
+    return authRouteErrorResponse({
+      error: "logout_failed",
+      reason: error.message,
+      status: 500,
+    });
   }
 
   return NextResponse.json({ success: true });

--- a/src/app/auth/password/change/route.ts
+++ b/src/app/auth/password/change/route.ts
@@ -8,7 +8,8 @@ import { changePasswordPayloadSchema } from "@schemas/auth";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { type RouteContext, withApiGuards } from "@/lib/api/factory";
-import { errorResponse, parseJsonBody } from "@/lib/api/route-helpers";
+import { parseJsonBody } from "@/lib/api/route-helpers";
+import { authRouteErrorResponse } from "@/lib/auth/route-error-response";
 import {
   getAuthErrorCode,
   getAuthErrorStatus,
@@ -23,29 +24,10 @@ interface ChangePasswordPayload {
   newPassword?: unknown;
 }
 
-interface PasswordChangeErrorOptions {
-  code: string;
-  message: string;
-  status: number;
-}
-
 // Password change payloads are tiny; keep a tight limit to reduce DoS surface.
 const MAX_BODY_BYTES = 4 * 1024;
 
 const logger = createServerLogger("auth.password.change");
-
-function passwordChangeErrorResponse({
-  code,
-  message,
-  status,
-}: PasswordChangeErrorOptions): NextResponse {
-  return errorResponse({
-    error: code.toLowerCase(),
-    extras: { code, message },
-    reason: message,
-    status,
-  });
-}
 
 async function handlePasswordChange(
   request: NextRequest,
@@ -54,15 +36,15 @@ async function handlePasswordChange(
   const parsedBody = await parseJsonBody(request, { maxBytes: MAX_BODY_BYTES });
   if (!parsedBody.ok) {
     if (parsedBody.error.status === 413) {
-      return passwordChangeErrorResponse({
+      return authRouteErrorResponse({
         code: "PAYLOAD_TOO_LARGE",
-        message: "Request body exceeds limit",
+        reason: "Request body exceeds limit",
         status: 413,
       });
     }
-    return passwordChangeErrorResponse({
+    return authRouteErrorResponse({
       code: "BAD_REQUEST",
-      message: "Malformed JSON",
+      reason: "Malformed JSON",
       status: 400,
     });
   }
@@ -78,9 +60,9 @@ async function handlePasswordChange(
 
   if (!parsed.success) {
     const issue = parsed.error.issues[0];
-    return passwordChangeErrorResponse({
+    return authRouteErrorResponse({
       code: "VALIDATION_ERROR",
-      message: issue?.message ?? "Invalid input",
+      reason: issue?.message ?? "Invalid input",
       status: 400,
     });
   }
@@ -88,9 +70,9 @@ async function handlePasswordChange(
   const email = user?.email;
 
   if (!email) {
-    return passwordChangeErrorResponse({
+    return authRouteErrorResponse({
       code: "EMAIL_REQUIRED",
-      message: "User email is required to change password",
+      reason: "User email is required to change password",
       status: 400,
     });
   }
@@ -102,9 +84,9 @@ async function handlePasswordChange(
   });
 
   if (isMfaRequiredError(signInError)) {
-    return passwordChangeErrorResponse({
+    return authRouteErrorResponse({
       code: signInError.code ?? "mfa_required",
-      message: "Multi-factor authentication required",
+      reason: "Multi-factor authentication required",
       status: 403,
     });
   }
@@ -128,16 +110,16 @@ async function handlePasswordChange(
         errorCode,
         status,
       });
-      return passwordChangeErrorResponse({
+      return authRouteErrorResponse({
         code: "AUTH_UPSTREAM_ERROR",
-        message: "Password verification temporarily unavailable",
+        reason: "Password verification temporarily unavailable",
         status: 503,
       });
     }
 
-    return passwordChangeErrorResponse({
+    return authRouteErrorResponse({
       code: "INVALID_CREDENTIALS",
-      message: "Current password is incorrect",
+      reason: "Current password is incorrect",
       status: 400,
     });
   }
@@ -167,16 +149,16 @@ async function handlePasswordChange(
 
     // Distinguish upstream service errors from validation failures
     if (upstreamStatus >= 500 || upstreamStatus === 429) {
-      return passwordChangeErrorResponse({
+      return authRouteErrorResponse({
         code: "AUTH_UPSTREAM_ERROR",
-        message: "Password update temporarily unavailable",
+        reason: "Password update temporarily unavailable",
         status: 503,
       });
     }
 
-    return passwordChangeErrorResponse({
+    return authRouteErrorResponse({
       code: "UPDATE_FAILED",
-      message: "Password update failed",
+      reason: "Password update failed",
       status: 400,
     });
   }

--- a/src/app/auth/password/reset-request/__tests__/route.test.ts
+++ b/src/app/auth/password/reset-request/__tests__/route.test.ts
@@ -154,7 +154,9 @@ describe("POST /auth/password/reset-request", () => {
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({
       code: "INVALID_HOST",
+      error: "invalid_host",
       message: "Invalid request host",
+      reason: "Invalid request host",
     });
     expect(ResetPassword).not.toHaveBeenCalled();
   });
@@ -222,7 +224,9 @@ describe("POST /auth/password/reset-request", () => {
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({
       code: "BAD_REQUEST",
+      error: "bad_request",
       message: "Malformed JSON",
+      reason: "Malformed JSON",
     });
     expect(ResetPassword).not.toHaveBeenCalled();
   });

--- a/src/app/auth/password/reset-request/route.ts
+++ b/src/app/auth/password/reset-request/route.ts
@@ -9,6 +9,7 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { type RouteParamsContext, withApiGuards } from "@/lib/api/factory";
 import { parseJsonBody } from "@/lib/api/route-helpers";
+import { authRouteErrorResponse } from "@/lib/auth/route-error-response";
 import { getServerEnvVarWithFallback } from "@/lib/env/server";
 import { getClientIpFromHeaders } from "@/lib/http/ip";
 import { emitOperationalAlertOncePerWindow } from "@/lib/telemetry/degraded-mode";
@@ -82,15 +83,17 @@ const guardedPOST = withApiGuards({
   const parsedBody = await parseJsonBody(request, { maxBytes: MAX_BODY_BYTES });
   if (!parsedBody.ok) {
     if (parsedBody.error.status === 413) {
-      return NextResponse.json(
-        { code: "PAYLOAD_TOO_LARGE", message: "Request body exceeds limit" },
-        { status: 413 }
-      );
+      return authRouteErrorResponse({
+        code: "PAYLOAD_TOO_LARGE",
+        reason: "Request body exceeds limit",
+        status: 413,
+      });
     }
-    return NextResponse.json(
-      { code: "BAD_REQUEST", message: "Malformed JSON" },
-      { status: 400 }
-    );
+    return authRouteErrorResponse({
+      code: "BAD_REQUEST",
+      reason: "Malformed JSON",
+      status: 400,
+    });
   }
 
   const payload: ResetRequestPayload = isPlainObject(parsedBody.data)
@@ -104,7 +107,11 @@ const guardedPOST = withApiGuards({
   if (!parsed.success) {
     const issue = parsed.error.issues[0];
     const message = issue?.message ?? "Email is required";
-    return NextResponse.json({ code: "VALIDATION_ERROR", message }, { status: 400 });
+    return authRouteErrorResponse({
+      code: "VALIDATION_ERROR",
+      reason: message,
+      status: 400,
+    });
   }
 
   const { email } = parsed.data;
@@ -128,10 +135,11 @@ const guardedPOST = withApiGuards({
       ...telemetryMeta,
       originHash,
     });
-    return NextResponse.json(
-      { code: "INVALID_HOST", message: "Invalid request host" },
-      { status: 400 }
-    );
+    return authRouteErrorResponse({
+      code: "INVALID_HOST",
+      reason: "Invalid request host",
+      status: 400,
+    });
   }
 
   const basePath = normalizeBasePath(

--- a/src/app/auth/password/reset/__tests__/route.test.ts
+++ b/src/app/auth/password/reset/__tests__/route.test.ts
@@ -65,7 +65,9 @@ describe("/auth/password/reset route", () => {
     expect(res.status).toBe(413);
     await expect(res.json()).resolves.toEqual({
       code: "PAYLOAD_TOO_LARGE",
+      error: "payload_too_large",
       message: "Request body exceeds limit",
+      reason: "Request body exceeds limit",
     });
   });
 
@@ -78,8 +80,15 @@ describe("/auth/password/reset route", () => {
 
     const res = await POST(req);
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { code?: string; errors?: unknown };
+    const body = (await res.json()) as {
+      code?: string;
+      error?: string;
+      errors?: unknown;
+      reason?: string;
+    };
     expect(body.code).toBe("VALIDATION_ERROR");
+    expect(body.error).toBe("validation_error");
+    expect(body.reason).toBe("Invalid password reset payload");
     expect(body.errors).toBeDefined();
   });
 
@@ -96,7 +105,11 @@ describe("/auth/password/reset route", () => {
 
     const res = await POST(req);
     expect(res.status).toBe(400);
-    await expect(res.json()).resolves.toMatchObject({ code: "RESET_FAILED" });
+    await expect(res.json()).resolves.toMatchObject({
+      code: "RESET_FAILED",
+      error: "reset_failed",
+      reason: "Password reset failed",
+    });
     expect(UPDATE_USER_MOCK).not.toHaveBeenCalled();
   });
 

--- a/src/app/auth/password/reset/route.ts
+++ b/src/app/auth/password/reset/route.ts
@@ -9,6 +9,7 @@ import type { EmailOtpType } from "@supabase/supabase-js";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { parseJsonBody } from "@/lib/api/route-helpers";
+import { authRouteErrorResponse } from "@/lib/auth/route-error-response";
 import { createServerSupabase } from "@/lib/supabase/server";
 import { emitOperationalAlertOncePerWindow } from "@/lib/telemetry/degraded-mode";
 import { createServerLogger } from "@/lib/telemetry/logger";
@@ -21,15 +22,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const parsedBody = await parseJsonBody(request, { maxBytes: MAX_BODY_BYTES });
   if (!parsedBody.ok) {
     if (parsedBody.error.status === 413) {
-      return NextResponse.json(
-        { code: "PAYLOAD_TOO_LARGE", message: "Request body exceeds limit" },
-        { status: 413 }
-      );
+      return authRouteErrorResponse({
+        code: "PAYLOAD_TOO_LARGE",
+        reason: "Request body exceeds limit",
+        status: 413,
+      });
     }
-    return NextResponse.json(
-      { code: "BAD_REQUEST", message: "Malformed JSON" },
-      { status: 400 }
-    );
+    return authRouteErrorResponse({
+      code: "BAD_REQUEST",
+      reason: "Malformed JSON",
+      status: 400,
+    });
   }
 
   const payload = passwordResetPayloadSchema.safeParse(parsedBody.data);
@@ -39,14 +42,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       field: path.length > 0 ? String(path[0]) : "unknown",
       message,
     }));
-    return NextResponse.json(
-      {
-        code: "VALIDATION_ERROR",
-        errors: fieldErrors,
-        message: "Invalid password reset payload",
-      },
-      { status: 400 }
-    );
+    return authRouteErrorResponse({
+      code: "VALIDATION_ERROR",
+      extras: { errors: fieldErrors },
+      reason: "Invalid password reset payload",
+      status: 400,
+    });
   }
 
   const { token, newPassword } = payload.data;
@@ -75,10 +76,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       status: verifyError.status,
     });
     // Use uniform error code to avoid leaking which step failed
-    return NextResponse.json(
-      { code: "RESET_FAILED", message: "Password reset failed" },
-      { status: 400 }
-    );
+    return authRouteErrorResponse({
+      code: "RESET_FAILED",
+      reason: "Password reset failed",
+      status: 400,
+    });
   }
 
   const { error: updateError } = await supabase.auth.updateUser({
@@ -101,10 +103,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       status: updateError.status,
     });
     // Use uniform error code to avoid leaking which step failed
-    return NextResponse.json(
-      { code: "RESET_FAILED", message: "Password reset failed" },
-      { status: 400 }
-    );
+    return authRouteErrorResponse({
+      code: "RESET_FAILED",
+      reason: "Password reset failed",
+      status: 400,
+    });
   }
 
   return NextResponse.json({ ok: true });

--- a/src/lib/auth/__tests__/route-error-response.test.ts
+++ b/src/lib/auth/__tests__/route-error-response.test.ts
@@ -41,8 +41,10 @@ describe("authRouteErrorResponse", () => {
       error: "invalid_auth_request",
       extras: {
         code: "OTHER_CODE",
+        error: "other_error",
         errors: [{ field: "email", message: "Invalid email" }],
         message: "Other message",
+        reason: "Other reason",
       },
       reason: "Invalid auth request",
       status: 400,

--- a/src/lib/auth/__tests__/route-error-response.test.ts
+++ b/src/lib/auth/__tests__/route-error-response.test.ts
@@ -1,0 +1,60 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+import { authRouteErrorResponse } from "../route-error-response";
+
+describe("authRouteErrorResponse", () => {
+  it("returns standardized errors with legacy auth fields", async () => {
+    const response = authRouteErrorResponse({
+      code: "RESET_FAILED",
+      reason: "Password reset failed",
+      status: 400,
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      code: "RESET_FAILED",
+      error: "reset_failed",
+      message: "Password reset failed",
+      reason: "Password reset failed",
+    });
+  });
+
+  it("uses explicit error codes when no legacy code is provided", async () => {
+    const response = authRouteErrorResponse({
+      error: "logout_failed",
+      reason: "signout failed",
+      status: 500,
+    });
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "logout_failed",
+      message: "signout failed",
+      reason: "signout failed",
+    });
+  });
+
+  it("preserves extras without allowing them to override compatibility fields", async () => {
+    const response = authRouteErrorResponse({
+      code: "VALIDATION_ERROR",
+      error: "invalid_auth_request",
+      extras: {
+        code: "OTHER_CODE",
+        errors: [{ field: "email", message: "Invalid email" }],
+        message: "Other message",
+      },
+      reason: "Invalid auth request",
+      status: 400,
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      code: "VALIDATION_ERROR",
+      error: "invalid_auth_request",
+      errors: [{ field: "email", message: "Invalid email" }],
+      message: "Invalid auth request",
+      reason: "Invalid auth request",
+    });
+  });
+});

--- a/src/lib/auth/route-error-response.ts
+++ b/src/lib/auth/route-error-response.ts
@@ -26,10 +26,18 @@ export function authRouteErrorResponse({
   reason,
   status,
 }: AuthRouteErrorResponseOptions): NextResponse {
-  const responseExtras: Record<string, unknown> = {
-    ...extras,
-    message: reason,
-  };
+  const reservedKeys = new Set(["code", "error", "message", "reason"]);
+  const responseExtras: Record<string, unknown> = {};
+
+  if (extras) {
+    for (const [key, value] of Object.entries(extras)) {
+      if (!reservedKeys.has(key)) {
+        responseExtras[key] = value;
+      }
+    }
+  }
+
+  responseExtras.message = reason;
 
   if (code) {
     responseExtras.code = code;

--- a/src/lib/auth/route-error-response.ts
+++ b/src/lib/auth/route-error-response.ts
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Auth route error response helpers.
+ */
+
+import type { NextResponse } from "next/server";
+import { errorResponse } from "@/lib/api/route-helpers";
+
+interface AuthRouteErrorResponseOptions {
+  code?: string;
+  error?: string;
+  extras?: Record<string, unknown>;
+  reason: string;
+  status: number;
+}
+
+/**
+ * Builds a standardized auth route error response while preserving legacy fields.
+ *
+ * @param options - Response code, reason, status, and optional compatibility fields.
+ * @returns Standardized Next.js JSON error response.
+ */
+export function authRouteErrorResponse({
+  code,
+  error,
+  extras,
+  reason,
+  status,
+}: AuthRouteErrorResponseOptions): NextResponse {
+  const responseExtras: Record<string, unknown> = {
+    ...extras,
+    message: reason,
+  };
+
+  if (code) {
+    responseExtras.code = code;
+  }
+
+  return errorResponse({
+    error: error ?? code?.toLowerCase() ?? "auth_error",
+    extras: responseExtras,
+    reason,
+    status,
+  });
+}

--- a/src/scripts/__tests__/check-api-route-errors.test.ts
+++ b/src/scripts/__tests__/check-api-route-errors.test.ts
@@ -1,0 +1,121 @@
+/** @vitest-environment node */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const scriptPath = join(process.cwd(), "scripts/check-api-route-errors.mjs");
+
+function runScannerInTempRepo(files: Record<string, string>) {
+  const tempDir = mkdtempSync(join(tmpdir(), "tripsage-route-error-scan-"));
+
+  try {
+    execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+
+    for (const [filePath, contents] of Object.entries(files)) {
+      const absolutePath = join(tempDir, filePath);
+      mkdirSync(dirname(absolutePath), { recursive: true });
+      writeFileSync(absolutePath, contents);
+    }
+
+    execFileSync("git", ["add", "."], { cwd: tempDir, stdio: "ignore" });
+
+    return spawnSync(process.execPath, [scriptPath, "--full"], {
+      cwd: tempDir,
+      encoding: "utf8",
+    });
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
+describe("check-api-route-errors", () => {
+  it("detects legacy code payloads in auth route error responses", () => {
+    const result = runScannerInTempRepo({
+      "src/app/auth/password/reset/route.ts": `
+        import { NextResponse } from "next/server";
+
+        export function POST() {
+          return NextResponse.json(
+            { code: "RESET_FAILED", message: "Password reset failed" },
+            { status: 400 }
+          );
+        }
+      `,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("src/app/auth/password/reset/route.ts");
+    expect(result.stderr).toContain("NextResponse.json");
+    expect(result.stderr).toContain("authRouteErrorResponse");
+  });
+
+  it("detects error payloads in API route error responses", () => {
+    const result = runScannerInTempRepo({
+      "src/app/api/example/route.ts": `
+        import { NextResponse } from "next/server";
+
+        export function GET() {
+          return NextResponse.json({ error: "bad_request" }, { status: 400 });
+        }
+      `,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("src/app/api/example/route.ts");
+  });
+
+  it("allows success JSON and shared error helpers in covered routes", () => {
+    const result = runScannerInTempRepo({
+      "src/app/api/example/route.ts": `
+        import { NextResponse } from "next/server";
+        import { errorResponse } from "@/lib/api/route-helpers";
+
+        export function GET() {
+          if (Math.random() > 2) {
+            return errorResponse({
+              error: "bad_request",
+              reason: "Bad request",
+              status: 400,
+            });
+          }
+          return NextResponse.json({ ok: true });
+        }
+      `,
+      "src/app/auth/logout/route.ts": `
+        import { NextResponse } from "next/server";
+        import { authRouteErrorResponse } from "@/lib/auth/route-error-response";
+
+        export function POST() {
+          if (Math.random() > 2) {
+            return authRouteErrorResponse({
+              error: "logout_failed",
+              reason: "signout failed",
+              status: 500,
+            });
+          }
+          return NextResponse.json({ success: true });
+        }
+      `,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("OK: no forbidden inline route error responses");
+  });
+
+  it("ignores route handlers outside API and auth trees", () => {
+    const result = runScannerInTempRepo({
+      "src/app/robots/route.ts": `
+        import { NextResponse } from "next/server";
+
+        export function GET() {
+          return NextResponse.json({ code: "STATIC_ROUTE" }, { status: 400 });
+        }
+      `,
+    });
+
+    expect(result.status).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `authRouteErrorResponse()` for consistent auth route error payloads with legacy compatibility
- Migrate seven `src/app/auth/**` routes off inline `NextResponse.json` error responses
- Extend `check-api-route-errors` to scan auth routes and add script regression tests
- Pin Corepack in CI and add `pnpm deps:audit` plus high-severity audit gates

## Why
- Auth routes used inconsistent inline JSON error shapes (`code`/`message` only)
- PR #784 standardized password change via local helper; this consolidates all auth routes on one shared contract
- CI lacked explicit dependency usage and high-severity audit gates

## Scope
### Included
- `authRouteErrorResponse` helper + unit tests
- Auth routes: delete, email resend/verify, logout, password change/reset/reset-request + route tests
- Guard scripts: `check-api-route-errors`, `check-no-unknown-casts` existsSync filter
- CI: Corepack pin, deps audit gates, `pnpm exec vitest` / `pnpm exec semantic-release`
- README and release-automation doc alignment

### Not included
- Deterministic `nowIso` sweep, schemas, hooks, lib/domain/AI bulk changes (~162 remaining dirty files)
- Unrelated calendar API README tweak in local worktree

## Release Please version impact
Versioning track:
- [x] Pre-1.0 development track
- [ ] Stable 1.0+ SemVer track
- [ ] Explicit repo override applies

Expected Release Please bump after merge to `main`:
- [ ] None
- [x] Patch
- [ ] Minor
- [ ] Major

Public API impact:
- [ ] No public API change
- [ ] Public API added
- [x] Public API changed, backward compatible
- [ ] Public API changed, breaking

Breaking changes:
- [x] None
- [ ] Yes

If breaking, describe the change, affected users/systems, and required migration steps:
- N/A — auth error JSON adds `error` and `reason` alongside existing `code` and `message`

## Related issues / context
- Follow-up to PR #784 (theme/auth slice)
- Part of TripSage modernization release program
- Next planned slice: `refactor/runtime-determinism-quality-sweep`

## Implementation notes
- `authRouteErrorResponse` wraps `errorResponse()` and always sets `message` to match `reason` for legacy clients
- Validation routes pass field errors via `extras.errors` without changing status semantics
- Password change drops local `passwordChangeErrorResponse` in favor of shared helper

## Review guide
Recommended review order:
1. `src/lib/auth/route-error-response.ts` + tests
2. Auth route migrations under `src/app/auth/**`
3. `scripts/check-api-route-errors.mjs` + CI workflow changes

Areas needing extra attention:
- Auth error payload shape compatibility for existing clients
- CI job ordering and Corepack pin version

Specific feedback requested:
- [x] Correctness
- [ ] Architecture
- [x] API design
- [ ] Performance
- [ ] Security
- [x] Backward compatibility / migration
- [ ] UX / accessibility / copy

## Validation
### Automated
- [x] Tests added or updated
- [x] Type checks pass (`pnpm type-check`)
- [x] Lint passes (`pnpm biome:fix`)
- [ ] Build passes

### Manual
1. `pnpm test:affected` — passed
2. `pnpm check:api-route-errors` — passed
3. `pnpm check:no-new-unknown-casts` — passed
4. Targeted vitest (33 auth/script tests) — passed

## Risk
Risk level:
- [ ] Low
- [x] Medium
- [ ] High

Main risks:
- All auth HTTP error paths touched; additive fields should preserve existing client parsing
- New CI audit gates may surface pre-existing dependency findings

## Rollout / rollback
- Feature flag: N/A
- Deployment notes: Standard deploy; no migration required
- Monitoring to watch: Auth error rates and client parsing failures
- Rollback plan: Revert PR

## Artifacts
- Screenshots: N/A
- Logs: N/A
- Benchmarks: N/A
- Sample payloads: N/A

## Checklist
- [x] PR is focused and single-purpose
- [x] PR title follows Conventional Commits
- [x] Expected Release Please bump selected
- [x] Public API impact documented
- [x] Breaking changes and migration steps documented if applicable
- [ ] Linked issue(s) included where applicable
- [x] Validation evidence included
- [x] Risks and rollback documented
- [x] Review guidance included