### PR TITLE
refactor: runtime determinism and quality sweep

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -9,6 +9,8 @@
 
 FROM node:24-alpine
 
+ARG COREPACK_VERSION=0.35.0
+
 # Set working directory
 WORKDIR /app
 
@@ -21,7 +23,7 @@ RUN apk add --no-cache \
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Install pnpm and dependencies
-RUN npm install -g corepack@latest && \
+RUN npm install -g "corepack@${COREPACK_VERSION}" && \
     corepack enable pnpm && \
     corepack install && \
     pnpm ci

--- a/docs/api/internal/jobs.md
+++ b/docs/api/internal/jobs.md
@@ -94,7 +94,6 @@ one of these conditions for the attachment/RAG path:
 Use the shared mocks for unit tests. For local integration, set
 `UPSTASH_USE_EMULATOR=1`, point `UPSTASH_REDIS_REST_URL` at the Redis REST
 emulator, and set `UPSTASH_QSTASH_DEV_URL` to the QStash dev server endpoint.
-`UPSTASH_EMULATOR_URL` remains a legacy Redis alias only.
 
 Live smoke tests use production-compatible env names for credentials:
 `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, and `QSTASH_TOKEN`.

--- a/docs/architecture/calendar-service.md
+++ b/docs/architecture/calendar-service.md
@@ -125,9 +125,9 @@ Tools are automatically available in chat via `toolRegistry` in `src/ai/tools/in
 
 ### Trip Export
 
-- Trip detail page (`/dashboard/trips/[id]`) includes "Export to Calendar" button
+- Trip-to-ICS conversion utilities live in `src/lib/calendar/trip-export.ts`
 - Converts trip destinations, activities, and transportation to calendar events
-- Downloads ICS file for import into any calendar application
+- The current trip detail page does not expose a dedicated export button
 
 ### AI Chat Integration
 

--- a/docs/architecture/decisions/adr-0009-consolidate-ci-to-two-workflows-and-remove-custom-composites.md
+++ b/docs/architecture/decisions/adr-0009-consolidate-ci-to-two-workflows-and-remove-custom-composites.md
@@ -52,7 +52,7 @@ Partial simplification with some utility steps. Rejected: still adds maintenance
 
 ## References
 
-- GitHub Docs: secret_scanning.yml paths-ignore (UNVERIFIED)
+- GitHub Docs: [Excluding folders and files from secret scanning](https://docs.github.com/en/code-security/secret-scanning/using-advanced-secret-scanning-and-push-protection-features/excluding-folders-and-files-from-secret-scanning)
 - Internal CI analysis and security scanning review (this PR)
 
 ## Implementation status (last updated: 2026-02-17)

--- a/docs/architecture/decisions/adr-0038-hybrid-frontend-agents.md
+++ b/docs/architecture/decisions/adr-0038-hybrid-frontend-agents.md
@@ -20,7 +20,7 @@ We will replace the Python-based destination research and itinerary agents with 
 
 1. **Next.js Route Handlers** under `src/app/api/agents/destinations` and `.../itineraries` will host ToolLoopAgent instances bound to our TypeScript tool registry. The handlers stream UI messages via `toUIMessageStreamResponse()`.
 2. **Hybrid Guardrails**: each tool invocation passes through deterministic validators (Zod schemas, Upstash rate limits, cache lookups). The ToolLoop is capped via `stopWhen` conditions and summarized deterministically before responding.
-3. **Shared Schemas & Prompts**: destination + itinerary request/response schemas, prompt templates, and telemetry contracts are centralized in `src/schemas` and `src/prompts` for reuse by UI, tests, and observability.
+3. **Shared Schemas & Prompts**: destination + itinerary request/response schemas, prompt templates, and telemetry contracts are centralized in `src/domain/schemas` (via `@schemas/*`) and `src/prompts` for reuse by UI, tests, and observability.
 4. **AI Elements-first UX**: chat quick actions, structured cards, and timelines render the new agent outputs without dumping JSON, reusing the existing AI Elements Conversation/PromptInput components.
 5. **Telemetry & Rollout**: tool-level metrics (cache hits, validator rejections, budgets) flow through the existing telemetry stack. For this program, rollout uses full cutover (no flags); rollback is a deploy revert.
 
@@ -28,7 +28,9 @@ We will replace the Python-based destination research and itinerary agents with 
 
 - P0 (framework hardening) completed.
 - P1 (flights + accommodations, part of the wider migration) completed on the frontend.
-- Next: P2 – Budget & Memory agents, followed by P3 – Router & Error Recovery.
+- P2 (budget + memory + destination + itinerary agents) completed on the frontend.
+- P3 (router + error recovery) completed on the frontend.
+- Current runtime: TripSage agent orchestration is fully Next.js / AI SDK v6.
 
 ## Consequences
 

--- a/docs/architecture/decisions/adr-0055-flatten-frontend-root-structure.md
+++ b/docs/architecture/decisions/adr-0055-flatten-frontend-root-structure.md
@@ -8,9 +8,19 @@
 **Related ADRs:** ADR-0013 (Next.js 16 Proxy Adoption)【46†L31-L39】, ADR-0016 (Tailwind CSS v4 Config)【46†L33-L36】  
 **Related Specs:** SPEC-0002 (Next.js 16 Migration)【39†L29-L37】
 
+## Current Implementation Status
+
+This ADR is implemented. The live repository has no top-level `frontend/`
+directory; the Next.js app runs from the repository root with `src/`,
+`package.json`, `pnpm-lock.yaml`, `next.config.ts`, `tsconfig.json`, and
+`pnpm-workspace.yaml` at root. Use `AGENTS.md` and
+[`docs/architecture/repo-structure.md`](../repo-structure.md) for current
+repo-structure rules. The context and alternatives below describe the
+pre-flattening state and the decision that removed it.
+
 ## Context
 
-The TripSage repository currently isolates the Next.js application in a top-level `frontend/` directory. All source code, dependencies, and configuration for the app live under `frontend/`, with infrastructure (Supabase, Docker, docs, etc.) at the root. This split originated to separate concerns (and perhaps to allow multi-package expansion), but in practice TripSage is a single application. The indirection adds complexity:
+Before this ADR was implemented, the TripSage repository isolated the Next.js application in a top-level `frontend/` directory. All source code, dependencies, and configuration for the app lived under `frontend/`, with infrastructure (Supabase, Docker, docs, etc.) at the root. This split originated to separate concerns (and perhaps to allow multi-package expansion), but in practice TripSage is a single application. The indirection added complexity:
 
 - Developer workflow friction: Contributors must remember to change directory into `frontend/` for nearly every action, for example installing packages, running `pnpm dev`, tests, linting, etc.【2†L75-L83】. Missing this step leads to confusion (for example running commands in root does nothing or operates on a different context).
 - Duplicate configuration: Many config files exist in or refer to `frontend/` where a single config at root would suffice. Examples: separate `frontend/package.json`, `frontend/.npmrc`【63†L1-L4】, `frontend/tsconfig.json` (with path aliases), and a root `.nvmrc` and `Makefile` that assume the subdir. This duplication requires coordination, for example Node version is defined in root, but `pnpm-lock.yaml` is inside frontend.
@@ -18,26 +28,26 @@ The TripSage repository currently isolates the Next.js application in a top-leve
 - Next.js best practices: Next.js (especially App Router projects) usually reside at the repo root or under a `src/` folder, not an extra monorepo-style folder, unless there are multiple apps. Here we have one app, so the indirection is unnecessary.
 - Maintenance overhead: Every update needs to touch both root and `frontend` in some way. For example, Dependabot or version bumps might update root config and frontend separately. Code owners file lists many `frontend/*` patterns【70†L25-L34】 that need mirroring if structure changes. This creates opportunities for inconsistency and increases cognitive load (developers must remember “frontend” prefix everywhere).
 
-In short, the current structure is a remnant of a potential monorepo architecture that is not needed now. Simplifying to a single unified project directory will reduce errors and onboarding time, and make the repository align with community norms.
+In short, the old structure was a remnant of a potential monorepo architecture that was not needed. Simplifying to a single unified project directory reduced errors and onboarding time, and made the repository align with community norms.
 
 ## Decision
 
-We will flatten the Next.js application structure by moving all contents of `frontend/` to the repository root, establishing a single-package architecture. Concretely:
+We flattened the Next.js application structure by moving all contents of `frontend/` to the repository root, establishing a single-package architecture. Concretely:
 
-- The `frontend/src` directory becomes `src` at root. The Next.js app’s entry (`src/app` with all route files) stays the same relative to `src`, just no parent `frontend` folder.
-- Config and support files in `frontend/` will be moved or merged into root. For example, `frontend/package.json` becomes the root `package.json`, combining with any root devDependencies if needed. `frontend/tsconfig.json` moves to root (adjusting paths as required).
-- Redundant or conflicting files will be resolved. For instance, if a root `README.md` and `frontend/README.md` both exist, they might be merged (likely the root README serves as main documentation, and the frontend README can be folded into it or moved under `docs/`).
-- Build and runtime configs will be updated to reflect the new layout:
-  - Next.js config (`next.config.ts`) will reside at root. Its settings (like `turbopack.root`) will be reviewed because previously `turbopack.root: "."` pointed to `frontend`. In the new structure `"."` should correctly point to root.
-  - Tailwind/PostCSS config: Under Tailwind CSS v4, we have a “CSS-first” approach with minimal config. We will ensure that if a Tailwind config file is needed (even if mostly empty) it is correctly placed at root and that the `content` paths cover `./src/**/*.{ts,tsx,mdx}` so Tailwind can find all class usage.
-  - Path aliases currently defined in `frontend/tsconfig.json` (like `"@/*": ["src/*"]`, `"@domain/*": ["src/domain/*"]`) remain logically the same. The tsconfig moves location. The baseUrl will be `"."` at root instead of inside frontend.
+- The `frontend/src` directory became `src` at root. The Next.js app’s entry (`src/app` with all route files) stayed the same relative to `src`, just with no parent `frontend` folder.
+- Config and support files in `frontend/` were moved or merged into root. For example, `frontend/package.json` became the root `package.json`, and `frontend/tsconfig.json` moved to root with paths adjusted as required.
+- Redundant or conflicting files were resolved. Root documentation became the main documentation surface, while superseded frontend-specific guidance was folded into root docs or archived.
+- Build and runtime configs were updated to reflect the new layout:
+  - Next.js config (`next.config.ts`) resides at root. Settings such as `turbopack.root` were reviewed so `"."` points to the repository root.
+  - Tailwind/PostCSS config follows the Tailwind CSS v4 CSS-first approach from root.
+  - Path aliases formerly defined in `frontend/tsconfig.json` (like `"@/*": ["src/*"]`, `"@domain/*": ["src/domain/*"]`) remain logically the same from the root `tsconfig.json`.
 - Tooling adjustments:
-  - CI workflows: Update GitHub Actions YAML to use the repository root as the working directory (remove `working-directory: frontend` everywhere) and change path filters (for example trigger on changes to `src/**` instead of `frontend/**`)【48†L5-L13】【48†L49-L58】. Also, cache keys referencing `frontend/package.json` or lockfile will be changed to the new paths【48†L55-L63】.
-  - Code owners: Modify `.github/CODEOWNERS` to replace `/frontend/` patterns with the corresponding root or `src/` patterns (so ownership rules remain effective)【70†L25-L34】【70†L39-L43】.
-  - Dev scripts: In `package.json` scripts and any npmrc config, remove assumptions of a subdirectory. For example, the `boundary:check` script will be `node scripts/check-boundaries.mjs` instead of `node ../scripts/...` when run from root【61†L33-L37】. Scripts referencing paths like `frontend/coverage` will be updated to `coverage` at root.
-- Documentation: All README and docs references to `cd frontend` or any `frontend/` file paths will be updated to the new locations. The primary README quick start will simplify to a single `pnpm install && pnpm dev` (no subdirectory step)【2†L75-L83】. Architecture docs may remove the extra layer in diagrams or text【2†L125-L133】.
+  - CI workflows: GitHub Actions YAML was updated to use the repository root as the working directory and root path filters such as `src/**` instead of `frontend/**`.
+  - Ownership and governance files were updated where applicable to remove `/frontend/` ownership patterns and use root or `src/` patterns instead.
+  - Dev scripts: `package.json` scripts and npm config assumptions were moved to root. Scripts referencing paths like `frontend/coverage` were updated to root paths.
+- Documentation: README and active docs references to `cd frontend` or old `frontend/` app paths were updated to the new locations. The primary README quick start simplified to root commands such as `pnpm install && pnpm dev` (no subdirectory step). Architecture docs removed the extra layer in diagrams or text.
 
-This decision aligns the repository with the one-app reality and modern Next.js project conventions. It eliminates the cost of maintaining parallel structures and reduces potential for mistakes.
+This decision aligned the repository with the one-app reality and modern Next.js project conventions. It eliminated the cost of maintaining parallel structures and reduced potential for mistakes.
 
 ## Consequences
 

--- a/docs/architecture/decisions/adr-0060-supabase-storage-attachments.md
+++ b/docs/architecture/decisions/adr-0060-supabase-storage-attachments.md
@@ -76,7 +76,7 @@ chat/550e8400-e29b-41d4-a716-446655440000/a1b2c3d4-vacation-photo.jpg
 1. **Server-side uploads**: Use `supabase.storage.from("attachments").upload()` with validated content type
 2. **Metadata persistence**: Insert into `file_attachments` after successful storage upload
 3. **Validation**: Zod v4 schemas enforce size limits (10MB per file), MIME types, and file counts (max 5)
-4. **Cache invalidation**: Use `revalidateTag('attachments')` and Upstash `bumpTag()` for listing cache
+4. **Cache invalidation**: Use `revalidateTag("attachments", { expire: 0 })` and Upstash `bumpTag()` for listing cache
 
 #### Signed URL TTL and Refresh Strategy
 

--- a/docs/architecture/decisions/adr-0070-stripe-webhook-verification-and-idempotency.md
+++ b/docs/architecture/decisions/adr-0070-stripe-webhook-verification-and-idempotency.md
@@ -78,6 +78,7 @@ Rejected: payment/webhook code is privileged and must integrate with server-only
 
 ## References
 
-- Stripe Node v20.2.0 release: <https://github.com/stripe/stripe-node/releases/tag/v20.2.0>
+- Stripe Node SDK version: `package.json` (`stripe`)
+- Stripe Node releases: <https://github.com/stripe/stripe-node/releases>
 - Stripe webhooks (signatures): <https://stripe.com/docs/webhooks>
 - Upstash idempotency patterns: `src/lib/idempotency/redis.ts` and ADR-0048

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -18,14 +18,14 @@ graph TD
 
 ## Stack Versions (source of truth: package.json)
 
-- ai: 6.0.49
-- @ai-sdk/react: 3.0.51
-- @ai-sdk/openai: 3.0.18
-- @ai-sdk/anthropic: 3.0.23
-- @ai-sdk/xai: 3.0.33
-- @ai-sdk/togetherai: 2.0.20
-- @ai-sdk/provider: 3.0.5
-- zod: 4.3.6
+- ai: 6.0.191
+- @ai-sdk/react: 3.0.193
+- @ai-sdk/openai: 3.0.65
+- @ai-sdk/anthropic: 3.0.79
+- @ai-sdk/xai: 3.0.92
+- @ai-sdk/togetherai: 2.0.53
+- @ai-sdk/provider: 3.0.10
+- zod: 4.4.3
 
 ## Stack Snapshot (high level)
 
@@ -38,7 +38,7 @@ graph TD
 
 ## Key Capabilities
 
-- Streaming chat and tool calling via AI SDK v6 using shared Zod schemas in `src/schemas`.
+- Streaming chat and tool calling via AI SDK v6 using shared Zod schemas in `src/domain/schemas` via `@schemas/*`.
 - Agent routes for flights, accommodations, destinations, itineraries, budget, and memory (`/api/agents/*`) with domain-specific tool sets.
 - BYOK + Vercel AI Gateway routing; provider resolution order is owned by `docs/operations/runbooks/byok-gateway-operator.md`.
 - Memory pipeline backed by Supabase Postgres + pgvector; QStash jobs cap inserts to 50 messages per batch and enforce idempotency.
@@ -52,7 +52,7 @@ graph TD
 
 - App Router with RSC-first rendering; client components only where interactivity is required.
 - Route handlers live in `src/app/api/**/route.ts`. They parse input (Zod), create request-scoped collaborators (Supabase, rate limiter, providers), and delegate to pure handlers. No module-scope state.
-- AI SDK v6 is the only LLM transport (`streamText`, `generateText` + `Output.object`); structured outputs use Zod schemas under `src/schemas`.
+- AI SDK v6 is the only LLM transport (`streamText`, `generateText` + `Output.object`); structured outputs use Zod schemas under `src/domain/schemas` via `@schemas/*`.
 - Caching and rate limiting use per-request Upstash Redis/RateLimit instances. Auth-dependent routes remain dynamic (no cache).
 - Background/async work uses QStash webhooks; handlers are stateless and idempotent.
 

--- a/docs/development/backend/server-actions.md
+++ b/docs/development/backend/server-actions.md
@@ -107,7 +107,7 @@ export async function deleteTripAction(tripId: string): Promise<never> {
 3. **Auth:** Use `createServerSupabase()` for authenticated client
 4. **Returns:** Only serializable data (no Supabase client, no functions)
 5. **Errors:** Throw descriptive errors; client receives error message
-6. **Revalidation:** Call `revalidatePath()` or `revalidateTag()` after mutations
+6. **Revalidation:** Call `revalidatePath()`, `updateTag()`, or `revalidateTag(tag, "max")` after mutations
 
 ## Calling Server Actions
 
@@ -211,13 +211,13 @@ revalidatePath(`/trips/${tripId}`);
 // In data fetching:
 // - Use fetch for external HTTP endpoints
 // - Use the Supabase client for DB reads/writes
-// - Fetch data first, then call revalidateTag() for affected tags
+// - Fetch data first, then call revalidateTag(tag, "max") for affected tags
 // Example:
 // const res = await fetch("https://example.com/api/resource", { next: { tags: ["resource"] } });
 
 // In action after mutation:
 import { revalidateTag } from "next/cache";
-revalidateTag("trips");
+revalidateTag("trips", "max");
 ```
 
 ## Error Handling

--- a/docs/development/backend/server-actions.md
+++ b/docs/development/backend/server-actions.md
@@ -107,7 +107,7 @@ export async function deleteTripAction(tripId: string): Promise<never> {
 3. **Auth:** Use `createServerSupabase()` for authenticated client
 4. **Returns:** Only serializable data (no Supabase client, no functions)
 5. **Errors:** Throw descriptive errors; client receives error message
-6. **Revalidation:** Call `revalidatePath()`, `updateTag()`, or `revalidateTag(tag, "max")` after mutations
+6. **Revalidation:** Call `revalidatePath()` or `updateTag()` after Server Action mutations; use `revalidateTag(tag, "max")` only when stale-while-revalidate is acceptable
 
 ## Calling Server Actions
 
@@ -211,13 +211,13 @@ revalidatePath(`/trips/${tripId}`);
 // In data fetching:
 // - Use fetch for external HTTP endpoints
 // - Use the Supabase client for DB reads/writes
-// - Fetch data first, then call revalidateTag(tag, "max") for affected tags
+// - Fetch data first, then call updateTag(tag) for affected tags in Server Actions
 // Example:
 // const res = await fetch("https://example.com/api/resource", { next: { tags: ["resource"] } });
 
 // In action after mutation:
-import { revalidateTag } from "next/cache";
-revalidateTag("trips", "max");
+import { updateTag } from "next/cache";
+updateTag("trips");
 ```
 
 ## Error Handling

--- a/docs/development/core/development-guide.md
+++ b/docs/development/core/development-guide.md
@@ -200,7 +200,7 @@ const tripData = validation.data;
 - Domain status payloads return `200` when the route successfully reports the requested state, such as `{ connected: false }` for a disconnected calendar or fallback insights with `success: false`.
 - Partial mutation success returns `207` with explicit failed keys or records so clients can retry only the failed subset.
 - Primary dependency outages return a transport error, usually `503`, when the requested operation cannot complete normally. Routes may still include deterministic fallback data in the error response body, such as accommodations personalization fallback results.
-- Run `pnpm check:api-route-errors:full` before release-sensitive API work to verify current route files do not return ad hoc error JSON where helpers apply.
+- Run `pnpm check:api-route-errors:full` before release-sensitive API/auth work to verify current route files do not return ad hoc error JSON where helpers apply.
 
 See [Zod Schema Guide](../standards/zod-schema-guide.md) for schema patterns and [Standards](../standards/standards.md#zod-schemas-v4) for conventions.
 

--- a/docs/development/core/quick-start.md
+++ b/docs/development/core/quick-start.md
@@ -4,7 +4,7 @@ Canonical path to get TripSage running locally, with the minimal commands and th
 
 ## Prerequisites
 
-- **Runtime:** Node.js 24.x and pnpm `11.3.0` via Corepack (`corepack enable`; use `corepack install` from the repo root; use `corepack pnpm ...` if `pnpm` is not already on PATH)
+- **Runtime:** Node.js 24.x and pnpm 11.x via Corepack (`corepack enable`; use `corepack install` from the repo root; use `corepack pnpm ...` if `pnpm` is not already on PATH)
 - **Tooling:** Git
 - **Accounts/keys:** Supabase project, Upstash Redis (and QStash if you test jobs), at least one model key (AI Gateway recommended)
 - **Optional:** Docker (required for local Supabase; optional if using a hosted Supabase project), Playwright browsers for E2E

--- a/docs/development/deps/upgrade-optimizations-2026-02.md
+++ b/docs/development/deps/upgrade-optimizations-2026-02.md
@@ -28,19 +28,22 @@ Exception marker (rare): add `zod-v4-ok:` on the violating line with a short jus
 
 Script: `scripts/check-api-route-errors.mjs`
 
-Goal: enforce standardized error responses for `src/app/api/**`:
+Goal: enforce standardized error responses for `src/app/api/**` and JSON auth routes in `src/app/auth/**`:
 
 - Forbidden:
   - `NextResponse.json({ error: ... }, ...)`
+  - `NextResponse.json({ code: ... }, ...)`
   - `new Response(JSON.stringify({ error: ... }), ...)`
+  - `new Response(JSON.stringify({ code: ... }), ...)`
 - Required:
   - Use helpers from `@/lib/api/route-helpers`:
     - `errorResponse({ error, reason, status })`
     - `unauthorizedResponse()`, `forbiddenResponse()`, `notFoundResponse()`
+  - Auth route handlers can use `authRouteErrorResponse()` from `@/lib/auth/route-error-response`
 
 Commands:
 
 - `pnpm check:api-route-errors` (diff-based)
-- `pnpm check:api-route-errors:full` (scan all tracked `src/app/api/**`)
+- `pnpm check:api-route-errors:full` (scan all tracked `src/app/api/**` and `src/app/auth/**`)
 
 Exception marker (rare): add `api-route-error-ok:` on the violating line with a short justification.

--- a/docs/development/frontend/cache-components.md
+++ b/docs/development/frontend/cache-components.md
@@ -34,8 +34,9 @@ If you must cache while using runtime APIs, use `'use cache: private'` **only** 
 
 - Prefer component/function-level caching over file-level unless the whole module is safe.
 - Always set an explicit lifetime with `cacheLife(...)` when the default profile is not appropriate.
-- When cached data has a clear invalidation signal, tag it with `cacheTag(...)` and invalidate via `revalidateTag(...)`.
+- When cached data has a clear invalidation signal, tag it with `cacheTag(...)` and invalidate with an explicit `revalidateTag` profile.
   - Prefer `revalidateTag(tag, { expire: 0 })` for immediate expiration semantics (common for admin/config updates and webhook-driven invalidation).
+  - Prefer `revalidateTag(tag, "max")` when stale-while-revalidate behavior is acceptable.
   - Avoid `updateTag(...)` in Route Handlers; it is intended for Server Actions / same-request consumers.
 
 ## Request-scoped memoization (React.cache)

--- a/docs/development/frontend/frontend-readme-archive.md
+++ b/docs/development/frontend/frontend-readme-archive.md
@@ -122,6 +122,7 @@ webSearch.execute({
 - **Time Filters**: Use `tbs` parameter (`qdr:d` for past day, `qdr:w` for
   week, etc.)
 - **Location**: Geographic filtering (e.g., `"Germany"`)
+- **Country**: Two-letter country code for geo-targeting (e.g., `"DE"`)
 - **Content Scraping**: Optional `scrapeOptions` to fetch full page
   content
 
@@ -147,6 +148,7 @@ webSearch.execute({
   categories: ["research"],
   tbs: "qdr:m", // Past month
   location: "United States",
+  country: "US",
   timeoutMs: 30000,
   scrapeOptions: {
     formats: ["markdown"],

--- a/e2e/calendar-integration.spec.ts
+++ b/e2e/calendar-integration.spec.ts
@@ -76,30 +76,3 @@ test.describe("Calendar Integration", () => {
     await expect(page.getByRole("link", { name: /calendar/i })).toBeVisible();
   });
 });
-
-test.describe("Calendar Export from Trip", () => {
-  test("trip detail page has export to calendar button", async ({ page }) => {
-    // Navigate to a trip detail page (assuming trips exist)
-    await resetTestAuth(page);
-    await authenticateAsTestUser(page);
-    await page.goto("/dashboard/trips", { waitUntil: "load" });
-
-    // Check if trips are listed with timeout
-    const detailLinks = page.getByRole("link", { name: "View Details" });
-    const count = await detailLinks.count();
-
-    if (count > 0) {
-      // Click first trip
-      await detailLinks.first().click();
-      await page.waitForLoadState("load");
-
-      // Verify export button exists
-      await expect(
-        page.getByRole("button", { name: /export to calendar/i })
-      ).toBeVisible({ timeout: 5000 });
-    } else {
-      // Skip test if no trips exist (common in test environments)
-      test.skip();
-    }
-  });
-});

--- a/e2e/critical-flows.spec.ts
+++ b/e2e/critical-flows.spec.ts
@@ -126,6 +126,7 @@ test.describe("Critical production flows", () => {
   test("runs search, calendar, and BYOK UI shells with deterministic providers", async ({
     page,
   }) => {
+    test.setTimeout(60_000);
     const providerMocks = await mockCriticalProviderRoutes(page);
     await authenticateAsTestUser(page);
 
@@ -146,6 +147,7 @@ test.describe("Critical production flows", () => {
     await expect
       .poll(providerMocks.flightSearchRequests, {
         message: "flight search API request should be issued",
+        timeout: 15_000,
       })
       .toBe(1);
     await expect(page.getByText("Search Started")).toBeVisible();
@@ -163,6 +165,11 @@ test.describe("Critical production flows", () => {
     ).toBeVisible({ timeout: 15_000 });
     await expect(page.getByText("TestAir", { exact: true })).toBeVisible();
     await expect(page.getByText("TS123")).toBeVisible();
+    await expect(
+      page.getByRole("button", {
+        name: "Select TestAir TS123 from SFO to LAX",
+      })
+    ).toBeVisible();
 
     await page.goto("/dashboard/calendar", { waitUntil: "domcontentloaded" });
     await expect(
@@ -176,8 +183,16 @@ test.describe("Critical production flows", () => {
     await expect(
       page.getByRole("heading", { name: /Bring Your Own Key/ })
     ).toBeVisible();
-    await expect(page.getByRole("combobox", { name: "Provider" })).toBeVisible();
-    await expect(page.getByRole("textbox", { name: "API Key" })).toBeVisible();
-    await expect(page.getByText("Gateway Fallback Consent")).toBeVisible();
+    await expect(page.getByRole("combobox", { name: "Provider" })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByRole("textbox", { name: "API Key" })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      page.getByRole("switch", { name: "Allow fallback to team Gateway" })
+    ).toHaveAccessibleDescription(
+      /When no BYOK key is present, permit using the team Vercel AI Gateway\.\s+You can change this at any time\./
+    );
   });
 });

--- a/e2e/dashboard-functionality.spec.ts
+++ b/e2e/dashboard-functionality.spec.ts
@@ -5,28 +5,35 @@ const navigationTimeoutMs = 15_000;
 const visibilityTimeoutMs = navigationTimeoutMs;
 
 function getUserMenuTrigger(page: Page): Locator {
-  return page
-    .getByRole("banner")
-    .getByRole("button", { name: /Test User|test@example\.com|User/i });
+  return page.getByRole("banner").getByRole("button", {
+    name: /Open account menu for (Test User|test@example\.com|user)/i,
+  });
 }
 
 async function openUserMenu(page: Page): Promise<Locator> {
-  const trigger = getUserMenuTrigger(page);
-  await expect(trigger).toBeVisible({ timeout: visibilityTimeoutMs });
-
   const logoutItem = page.getByRole("menuitem", { name: "Log Out" });
   const menuContent = page.getByRole("menu").filter({ has: logoutItem });
 
-  for (let attempt = 0; attempt < 2; attempt++) {
-    await trigger.click();
+  if (await menuContent.isVisible({ timeout: 500 }).catch(() => false)) {
+    return menuContent;
+  }
+
+  const trigger = getUserMenuTrigger(page);
+  await expect(trigger).toBeVisible({ timeout: visibilityTimeoutMs });
+
+  for (let attempt = 0; attempt < 3; attempt++) {
     try {
+      if (!(await menuContent.isVisible({ timeout: 500 }).catch(() => false))) {
+        await trigger.click();
+      }
       await expect(menuContent).toBeVisible({ timeout: visibilityTimeoutMs });
       await expect(menuContent).toHaveAttribute("data-state", "open", {
         timeout: visibilityTimeoutMs,
       });
       return menuContent;
     } catch (error) {
-      if (attempt === 1) throw error;
+      if (attempt === 2) throw error;
+      await page.keyboard.press("Escape").catch(() => undefined);
       await page.waitForTimeout(200);
     }
   }
@@ -59,6 +66,27 @@ async function clickAndWaitForUrl(
   }
 }
 
+async function clickUserMenuItemAndWaitForUrl(
+  page: Page,
+  itemName: "Log Out" | "Profile" | "Settings",
+  url: RegExp | string
+): Promise<void> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const menuContent = await openUserMenu(page);
+    const menuItem = menuContent.getByRole("menuitem", { name: itemName });
+    await expect(menuItem).toBeVisible({ timeout: visibilityTimeoutMs });
+    await menuItem.click({ force: attempt > 0, timeout: navigationTimeoutMs });
+
+    try {
+      await expect(page).toHaveURL(url, { timeout: navigationTimeoutMs });
+      return;
+    } catch (error) {
+      if (attempt === 2) throw error;
+      await page.waitForTimeout(300);
+    }
+  }
+}
+
 test.describe("Dashboard Functionality", () => {
   test.describe.configure({ timeout: 60_000 });
 
@@ -75,6 +103,12 @@ test.describe("Dashboard Functionality", () => {
     // Verify login page loads
     await expect(page).toHaveTitle(/TripSage/);
     await expect(page.getByRole("heading", { name: /sign in/i })).toBeVisible();
+    await expect(page.getByLabel("Email")).toHaveAccessibleDescription(
+      "Access your TripSage dashboard"
+    );
+    await expect(page.getByLabel("Password")).toHaveAccessibleDescription(
+      "Access your TripSage dashboard"
+    );
 
     await authenticateAsTestUser(page);
     await page.goto("/dashboard", { waitUntil: "domcontentloaded" });
@@ -82,6 +116,11 @@ test.describe("Dashboard Functionality", () => {
     // Verify dashboard content
     await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
     await expect(page.getByText("Welcome to TripSage AI")).toBeVisible();
+    await expect(
+      page
+        .getByRole("banner")
+        .getByRole("button", { name: "Open account menu for Test User" })
+    ).toBeVisible({ timeout: visibilityTimeoutMs });
 
     // Verify quick actions are present
     await expect(page.getByText("Search Flights").first()).toBeVisible();
@@ -150,11 +189,7 @@ test.describe("Dashboard Functionality", () => {
     });
 
     // Test profile navigation
-    await clickAndWaitForUrl(
-      page,
-      menuContent.getByRole("menuitem", { name: "Profile" }),
-      "/dashboard/profile"
-    );
+    await clickUserMenuItemAndWaitForUrl(page, "Profile", "/dashboard/profile");
     await page.waitForLoadState("domcontentloaded");
 
     // Navigate back and test settings
@@ -164,23 +199,16 @@ test.describe("Dashboard Functionality", () => {
       page.getByRole("banner").getByRole("button", { name: "Toggle theme" })
     ).toBeVisible({ timeout: visibilityTimeoutMs });
 
-    const settingsMenu = await openUserMenu(page);
-    await clickAndWaitForUrl(
-      page,
-      settingsMenu.getByRole("menuitem", { name: "Settings" }),
-      "/dashboard/settings"
-    );
+    await clickUserMenuItemAndWaitForUrl(page, "Settings", "/dashboard/settings");
   });
 
   test("logout functionality works", async ({ page }) => {
     await authenticateAsTestUser(page);
     await page.goto("/dashboard", { waitUntil: "domcontentloaded" });
 
-    const menuContent = await openUserMenu(page);
-    await menuContent.getByRole("menuitem", { name: "Log Out" }).click();
+    await clickUserMenuItemAndWaitForUrl(page, "Log Out", /\/login/);
 
     // Wait for redirect to login page
-    await page.waitForURL(/\/login/, { timeout: navigationTimeoutMs });
     await expect(page.getByRole("heading", { name: /sign in/i })).toBeVisible({
       timeout: visibilityTimeoutMs,
     });

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "deps:cycles": "madge --circular --extensions ts,tsx --ts-config ./tsconfig.json src/ai/agents"
   },
   "simple-git-hooks": {
-    "pre-commit": "pnpm check:no-secrets:staged"
+    "pre-commit": "node scripts/check-no-secrets.mjs --staged"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "3.0.79",

--- a/scripts/check-no-new-domain-infra-imports.mjs
+++ b/scripts/check-no-new-domain-infra-imports.mjs
@@ -102,10 +102,9 @@ function parseDiffForViolations(diffText) {
 
     // Only flag import-ish lines to avoid false positives in text literals.
     const trimmed = line.trimStart();
+    const isDynamicImport = /(?:^|[\s=(:,])(?:await\s+)?import\s*\(/.test(trimmed);
     const isImportish =
-      trimmed.startsWith("import ") ||
-      trimmed.startsWith("export ") ||
-      trimmed.includes("import(");
+      trimmed.startsWith("import ") || trimmed.startsWith("export ") || isDynamicImport;
     if (!isImportish) continue;
 
     violations.push({ filePath: currentFile, line });

--- a/src/ai/lib/__tests__/tool-factory.test.ts
+++ b/src/ai/lib/__tests__/tool-factory.test.ts
@@ -5,6 +5,7 @@ import type { ToolExecutionOptions } from "ai";
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { z } from "zod";
 import { setupUpstashTestEnvironment } from "@/test/upstash/setup";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
 
 const headerStore = new Map<string, string>();
 const setMockHeaders = (values: Record<string, string | undefined>) => {
@@ -148,6 +149,8 @@ afterAll(upstashAfterAllHook);
 
 describe("createAiTool", () => {
   test("creates AI SDK compatible tool with caching", async () => {
+    const performanceNowSpy = vi.spyOn(performance, "now").mockReturnValue(432.5);
+    const cacheHitStartedAt: number[] = [];
     const executeSpy = vi.fn(async ({ id }: { id: string }) => ({
       fromCache: false,
       id,
@@ -161,7 +164,10 @@ describe("createAiTool", () => {
           hashInput: false,
           key: ({ id }) => id,
           namespace: "tool:test:cache",
-          onHit: (cached, _params, _meta) => ({ ...cached, fromCache: true }),
+          onHit: (cached, _params, meta) => {
+            cacheHitStartedAt.push(meta.startedAt);
+            return { ...cached, fromCache: true };
+          },
           ttlSeconds: 60,
         },
       },
@@ -175,72 +181,85 @@ describe("createAiTool", () => {
       toolCallId: "test-call-1",
     };
 
-    // First call - should execute and cache
-    const firstResult = await cachedTool.execute?.({ id: "abc" }, callOptions);
-    expect(firstResult).toEqual({ fromCache: false, id: "abc" });
-    expect(executeSpy).toHaveBeenCalledTimes(1);
-    // Verify cache was written
-    expect(getUpstashCache().store.size).toBeGreaterThan(0);
+    try {
+      // First call - should execute and cache
+      const firstResult = await cachedTool.execute?.({ id: "abc" }, callOptions);
+      expect(firstResult).toEqual({ fromCache: false, id: "abc" });
+      expect(executeSpy).toHaveBeenCalledTimes(1);
+      // Verify cache was written
+      expect(getUpstashCache().store.size).toBeGreaterThan(0);
 
-    // Set up cache hit for second call - need to check actual cache key
-    // The cache key is: namespace + ":" + key(params)
-    // namespace defaults to `tool:${toolName}` if not provided, or uses cache.namespace
-    // So it should be "tool:test:cache:abc" (namespace:tool:test:cache, key:abc)
-    const cachedValue = { fromCache: false, id: "abc" };
-    // Check what key was actually used in first call by inspecting cache store
-    const cacheKeys = Array.from(getUpstashCache().store.keys());
-    expect(cacheKeys.length).toBeGreaterThan(0);
-    const actualCacheKey = cacheKeys[0];
-    getUpstashCache().store.set(actualCacheKey, JSON.stringify(cachedValue));
-    executeSpy.mockClear();
+      // Set up cache hit for second call - need to check actual cache key
+      // The cache key is: namespace + ":" + key(params)
+      // namespace defaults to `tool:${toolName}` if not provided, or uses cache.namespace
+      // So it should be "tool:test:cache:abc" (namespace:tool:test:cache, key:abc)
+      const cachedValue = { fromCache: false, id: "abc" };
+      // Check what key was actually used in first call by inspecting cache store
+      const cacheKeys = Array.from(getUpstashCache().store.keys());
+      expect(cacheKeys.length).toBeGreaterThan(0);
+      const actualCacheKey = cacheKeys[0];
+      getUpstashCache().store.set(actualCacheKey, JSON.stringify(cachedValue));
+      executeSpy.mockClear();
 
-    // Second call - should use cache
-    const secondResult = await cachedTool.execute?.({ id: "abc" }, callOptions);
-    expect(secondResult).toEqual({ fromCache: true, id: "abc" });
-    expect(executeSpy).not.toHaveBeenCalled();
+      // Second call - should use cache
+      const secondResult = await cachedTool.execute?.({ id: "abc" }, callOptions);
+      expect(secondResult).toEqual({ fromCache: true, id: "abc" });
+      expect(cacheHitStartedAt).toEqual([432.5]);
+      expect(executeSpy).not.toHaveBeenCalled();
 
-    // Verify tool has AI SDK Tool structure
-    expect(cachedTool).toHaveProperty("description");
-    expect(cachedTool).toHaveProperty("execute");
-    expect(cachedTool).toHaveProperty("inputSchema");
+      // Verify tool has AI SDK Tool structure
+      expect(cachedTool).toHaveProperty("description");
+      expect(cachedTool).toHaveProperty("execute");
+      expect(cachedTool).toHaveProperty("inputSchema");
+    } finally {
+      performanceNowSpy.mockRestore();
+    }
   });
 
-  test("throws tool error when rate limit exceeded", async () => {
-    upstashMocks.ratelimit.__force({
-      limit: 1,
-      remaining: 0,
-      reset: Date.now() + 60_000,
-      success: false,
-    });
+  test(
+    "throws tool error when rate limit exceeded",
+    withFakeTimers(async () => {
+      vi.setSystemTime(new Date("2026-02-03T04:05:06.000Z"));
 
-    const limitedTool = createAiTool({
-      description: "limited tool for testing",
-      execute: async () => ({ ok: true }),
-      guardrails: {
-        rateLimit: {
-          errorCode: TOOL_ERROR_CODES.webSearchRateLimited,
-          identifier: ({ id }: { id: string }) => `user-${id}`,
-          limit: 1,
-          prefix: "ratelimit:test",
-          window: "1 m",
+      upstashMocks.ratelimit.__force({
+        limit: 1,
+        remaining: 0,
+        reset: Date.parse("2026-02-03T04:06:06.000Z"),
+        success: false,
+      });
+
+      const limitedTool = createAiTool({
+        description: "limited tool for testing",
+        execute: async () => ({ ok: true }),
+        guardrails: {
+          rateLimit: {
+            errorCode: TOOL_ERROR_CODES.webSearchRateLimited,
+            identifier: ({ id }: { id: string }) => `user-${id}`,
+            limit: 1,
+            prefix: "ratelimit:test",
+            window: "1 m",
+          },
         },
-      },
-      inputSchema: z.object({ id: z.string() }),
-      name: "limitedTool",
-    });
+        inputSchema: z.object({ id: z.string() }),
+        name: "limitedTool",
+      });
 
-    const callOptions: ToolExecutionOptions = {
-      messages: [],
-      toolCallId: "test-call-limited",
-    };
+      const callOptions: ToolExecutionOptions = {
+        messages: [],
+        toolCallId: "test-call-limited",
+      };
 
-    await expect(limitedTool.execute?.({ id: "1" }, callOptions)).rejects.toMatchObject(
-      {
+      await expect(
+        limitedTool.execute?.({ id: "1" }, callOptions)
+      ).rejects.toMatchObject({
         code: TOOL_ERROR_CODES.webSearchRateLimited,
-      }
-    );
-    expect(recordedRateLimitIdentifiers.length).toBeGreaterThan(0);
-  });
+        meta: expect.objectContaining({
+          retryAfter: 60,
+        }),
+      });
+      expect(recordedRateLimitIdentifiers.length).toBeGreaterThan(0);
+    })
+  );
 
   test("passes ToolExecutionOptions to execute function", async () => {
     let capturedCallOptions: ToolExecutionOptions | null = null;

--- a/src/ai/lib/tool-factory.ts
+++ b/src/ai/lib/tool-factory.ts
@@ -294,7 +294,7 @@ export function createAiTool<InputValue, OutputValue>(
   const toolDefinition: Tool<InputValue, ToolOutputValue<OutputValue>> = {
     description: options.description,
     execute: (params: InputValue, callOptions: ToolExecutionOptions) => {
-      const startedAt = Date.now();
+      const startedAt = performance.now();
       return withTelemetrySpan(
         `tool.${telemetryName}`,
         {
@@ -644,9 +644,8 @@ async function enforceRateLimit<InputValue>(
       ? "ip"
       : "unknown";
   span.addEvent("rate_limited", { "ratelimit.subject_type": subjectType });
-  const nowMs = Date.now();
   const retryAfter = validatedResult.reset
-    ? computeRetryAfterSeconds(validatedResult.reset, nowMs)
+    ? computeRetryAfterSeconds(validatedResult.reset)
     : undefined;
   throw createToolError(config.errorCode, undefined, {
     limit: validatedResult.limit,

--- a/src/ai/tools/server/__tests__/travel-advisory-state-department.test.ts
+++ b/src/ai/tools/server/__tests__/travel-advisory-state-department.test.ts
@@ -2,7 +2,7 @@
 
 import { StateDepartmentProvider } from "@ai/tools/server/travel-advisory/providers/state-department";
 import { HttpResponse, http } from "msw";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { server } from "@/test/msw/server";
 
 const TRAVEL_ADVISORIES_URL = "https://cadataapi.state.gov/api/TravelAdvisories";
@@ -30,7 +30,10 @@ const mockAdvisoryResponse = [
   },
 ];
 
-afterEach(() => server.resetHandlers());
+afterEach(() => {
+  vi.restoreAllMocks();
+  server.resetHandlers();
+});
 
 describe("StateDepartmentProvider", () => {
   let provider: StateDepartmentProvider;
@@ -105,6 +108,42 @@ describe("StateDepartmentProvider", () => {
       await provider.getCountryAdvisory("US");
       await provider.getCountryAdvisory("FR");
       expect(requestCount).toBe(1);
+    });
+
+    test("expires the feed cache using monotonic elapsed time", async () => {
+      const dayMs = 24 * 60 * 60 * 1000;
+      const nowSpy = vi.spyOn(performance, "now");
+      let requestCount = 0;
+      let response = mockAdvisoryResponse;
+      const refreshedAdvisoryResponse = [
+        {
+          ...mockAdvisoryResponse[0],
+          Summary: "<p>Do not travel due to terrorism.</p>",
+          Title: "United States - Level 4: Do Not Travel",
+        },
+      ];
+
+      server.use(
+        http.get(TRAVEL_ADVISORIES_URL, () => {
+          requestCount += 1;
+          return HttpResponse.json(response);
+        })
+      );
+
+      nowSpy.mockReturnValue(1_000);
+      const initialResult = await provider.getCountryAdvisory("US");
+
+      response = refreshedAdvisoryResponse;
+      nowSpy.mockReturnValue(1_000 + dayMs - 1);
+      const cachedResult = await provider.getCountryAdvisory("US");
+
+      nowSpy.mockReturnValue(1_000 + dayMs + 1);
+      const refreshedResult = await provider.getCountryAdvisory("US");
+
+      expect(requestCount).toBe(2);
+      expect(initialResult?.overallScore).toBe(85);
+      expect(cachedResult?.overallScore).toBe(85);
+      expect(refreshedResult?.overallScore).toBe(10);
     });
 
     test("normalizes Level 2 advisory correctly", async () => {

--- a/src/ai/tools/server/__tests__/weather.test.ts
+++ b/src/ai/tools/server/__tests__/weather.test.ts
@@ -55,6 +55,12 @@ describe("getCurrentWeather", () => {
 
   test("builds correct URL for city query and maps response fields", async () => {
     const execute = await getWeatherExecute();
+    const performanceNowSpy = vi
+      .spyOn(performance, "now")
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(50)
+      .mockReturnValueOnce(62.5)
+      .mockReturnValue(62.5);
     let lastRequestUrl: URL | undefined;
     server.use(
       http.get("https://api.openweathermap.org/data/2.5/weather", ({ request }) => {
@@ -81,55 +87,59 @@ describe("getCurrentWeather", () => {
       })
     );
 
-    const out = await execute(
-      {
+    try {
+      const out = await execute(
+        {
+          city: "Paris",
+          coordinates: null,
+          fresh: true,
+          lang: "en",
+          units: "metric",
+          zip: null,
+        },
+        mockContext
+      );
+
+      expect(lastRequestUrl?.toString()).toContain(
+        "https://api.openweathermap.org/data/2.5/weather"
+      );
+      expect(lastRequestUrl?.searchParams.get("q")).toBe("Paris");
+      expect(lastRequestUrl?.searchParams.get("units")).toBe("metric");
+      expect(lastRequestUrl?.searchParams.get("lang")).toBe("en");
+      expect(lastRequestUrl?.searchParams.get("appid")).toBe("test-key");
+
+      expect(out).toMatchObject({
         city: "Paris",
-        coordinates: null,
-        fresh: true,
-        lang: "en",
-        units: "metric",
-        zip: null,
-      },
-      mockContext
-    );
-
-    expect(lastRequestUrl?.toString()).toContain(
-      "https://api.openweathermap.org/data/2.5/weather"
-    );
-    expect(lastRequestUrl?.searchParams.get("q")).toBe("Paris");
-    expect(lastRequestUrl?.searchParams.get("units")).toBe("metric");
-    expect(lastRequestUrl?.searchParams.get("lang")).toBe("en");
-    expect(lastRequestUrl?.searchParams.get("appid")).toBe("test-key");
-
-    expect(out).toMatchObject({
-      city: "Paris",
-      clouds: 20,
-      country: "FR",
-      description: "clear sky",
-      feelsLike: 21.8,
-      fromCache: false,
-      humidity: 65,
-      icon: "01d",
-      pressure: 1013,
-      provider: "http_get",
-      rain: 0.5,
-      snow: 0.2,
-      status: "success",
-      sunrise: 123,
-      sunset: 456,
-      temp: 22.5,
-      tempMax: 25,
-      tempMin: 20,
-      timezone: 3600,
-      visibility: 10000,
-      windDirection: 180,
-      windGust: 5.2,
-      windSpeed: 3.5,
-    });
-    if (isAsyncIterable(out)) {
-      throw new Error("Unexpected streaming tool output in test");
+        clouds: 20,
+        country: "FR",
+        description: "clear sky",
+        feelsLike: 21.8,
+        fromCache: false,
+        humidity: 65,
+        icon: "01d",
+        pressure: 1013,
+        provider: "http_get",
+        rain: 0.5,
+        snow: 0.2,
+        status: "success",
+        sunrise: 123,
+        sunset: 456,
+        temp: 22.5,
+        tempMax: 25,
+        tempMin: 20,
+        timezone: 3600,
+        visibility: 10000,
+        windDirection: 180,
+        windGust: 5.2,
+        windSpeed: 3.5,
+      });
+      if (isAsyncIterable(out)) {
+        throw new Error("Unexpected streaming tool output in test");
+      }
+      expect(out.tookMs).toBe(12.5);
+    } finally {
+      performanceNowSpy.mockRestore();
     }
-    expect(typeof out.tookMs).toBe("number");
   });
 
   test("uses coordinates when provided", async () => {

--- a/src/ai/tools/server/__tests__/web-search-batch.test.ts
+++ b/src/ai/tools/server/__tests__/web-search-batch.test.ts
@@ -75,39 +75,50 @@ const mockContext = {
 describe("webSearchBatch", () => {
   test("executes webSearch for each query and normalizes results", async () => {
     const { webSearchBatch } = await import("@ai/tools/server/web-search-batch");
+    const performanceNowSpy = vi
+      .spyOn(performance, "now")
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(22.25)
+      .mockReturnValue(22.25);
     const exec = webSearchBatch.execute as
       | ((params: unknown, ctx: unknown) => Promise<unknown>)
       | undefined;
     if (!exec) {
       throw new Error("webSearchBatch.execute is undefined");
     }
-    const out = await exec(
-      {
-        country: "de",
-        limit: 2,
-        queries: ["q1"],
-      },
-      mockContext
-    );
-    const outAny = unsafeCast<{
-      results: Array<{
-        query: string;
-        ok: boolean;
-        value?: {
-          results: Array<{ url: string; title?: string; snippet?: string }>;
-          fromCache: boolean;
-          tookMs: number;
-        };
-      }>;
-      tookMs: number;
-    }>(out);
-    expect(outAny.results[0].query).toBe("q1");
-    expect(outAny.results[0].ok).toBe(true);
-    expect(outAny.results[0].value?.results[0]?.url).toBe("https://example.com");
-    expect(webSearchExecuteMock).toHaveBeenCalledWith(
-      expect.objectContaining({ country: "DE", query: "q1" }),
-      mockContext
-    );
+    try {
+      const out = await exec(
+        {
+          country: "de",
+          limit: 2,
+          queries: ["q1"],
+        },
+        mockContext
+      );
+      const outAny = unsafeCast<{
+        results: Array<{
+          query: string;
+          ok: boolean;
+          value?: {
+            results: Array<{ url: string; title?: string; snippet?: string }>;
+            fromCache: boolean;
+            tookMs: number;
+          };
+        }>;
+        tookMs: number;
+      }>(out);
+      expect(outAny.results[0].query).toBe("q1");
+      expect(outAny.results[0].ok).toBe(true);
+      expect(outAny.results[0].value?.results[0]?.url).toBe("https://example.com");
+      expect(outAny.tookMs).toBe(12.25);
+      expect(webSearchExecuteMock).toHaveBeenCalledWith(
+        expect.objectContaining({ country: "DE", query: "q1" }),
+        mockContext
+      );
+    } finally {
+      performanceNowSpy.mockRestore();
+    }
   });
 
   test("falls back to direct HTTP when webSearch throws an unexpected error", async () => {

--- a/src/ai/tools/server/__tests__/web-search.test.ts
+++ b/src/ai/tools/server/__tests__/web-search.test.ts
@@ -78,6 +78,12 @@ describe("webSearch", () => {
   });
 
   test("validates inputs and calls Firecrawl with metadata", async () => {
+    const performanceNowSpy = vi
+      .spyOn(performance, "now")
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(20.25)
+      .mockReturnValueOnce(33.75)
+      .mockReturnValue(33.75);
     let receivedBody: Record<string, unknown> | undefined;
     server.use(
       http.post("https://api.firecrawl.dev/v2/search", async ({ request }) => {
@@ -110,48 +116,52 @@ describe("webSearch", () => {
 
     if (!execute) throw new Error("webSearch.execute is undefined");
 
-    const out = await execute(
-      {
-        categories: null,
+    try {
+      const out = await execute(
+        {
+          categories: null,
+          country: "US",
+          fresh: true,
+          limit: 2,
+          location: null,
+          query: "test",
+          scrapeOptions: null,
+          sources: null,
+          tbs: null,
+          timeoutMs: null,
+          userId: null,
+        },
+        mockContext
+      );
+
+      const outAny = unsafeCast<{
+        results: Array<{
+          url: string;
+          title?: string;
+          snippet?: string;
+          publishedAt?: string;
+        }>;
+        fromCache: boolean;
+        tookMs: number;
+      }>(out);
+
+      expect(Array.isArray(outAny.results)).toBe(true);
+      expect(outAny.results[0].url).toBe("https://x");
+      expect(outAny.results[0].snippet).toBe("Web summary");
+      expect(outAny.results[1].publishedAt).toBe("2026-05-01");
+      expect(outAny.fromCache).toBe(false);
+      expect(outAny.tookMs).toBe(13.5);
+      expect(Object.keys(outAny).sort()).toEqual(["fromCache", "results", "tookMs"]);
+      expect(withTelemetrySpan).toHaveBeenCalled();
+      expect(receivedBody).toBeDefined();
+      expect(receivedBody).toMatchObject({
         country: "US",
-        fresh: true,
         limit: 2,
-        location: null,
         query: "test",
-        scrapeOptions: null,
-        sources: null,
-        tbs: null,
-        timeoutMs: null,
-        userId: null,
-      },
-      mockContext
-    );
-
-    const outAny = unsafeCast<{
-      results: Array<{
-        url: string;
-        title?: string;
-        snippet?: string;
-        publishedAt?: string;
-      }>;
-      fromCache: boolean;
-      tookMs: number;
-    }>(out);
-
-    expect(Array.isArray(outAny.results)).toBe(true);
-    expect(outAny.results[0].url).toBe("https://x");
-    expect(outAny.results[0].snippet).toBe("Web summary");
-    expect(outAny.results[1].publishedAt).toBe("2026-05-01");
-    expect(outAny.fromCache).toBe(false);
-    expect(typeof outAny.tookMs).toBe("number");
-    expect(Object.keys(outAny).sort()).toEqual(["fromCache", "results", "tookMs"]);
-    expect(withTelemetrySpan).toHaveBeenCalled();
-    expect(receivedBody).toBeDefined();
-    expect(receivedBody).toMatchObject({
-      country: "US",
-      limit: 2,
-      query: "test",
-    });
+      });
+    } finally {
+      performanceNowSpy.mockRestore();
+    }
   });
 
   test("throws when not configured", async () => {

--- a/src/ai/tools/server/travel-advisory/providers/state-department.ts
+++ b/src/ai/tools/server/travel-advisory/providers/state-department.ts
@@ -61,7 +61,7 @@ export class StateDepartmentProvider implements AdvisoryProvider {
    * @throws Error if API request fails.
    */
   private async fetchFeed(): Promise<StateDepartmentAdvisory[]> {
-    const now = Date.now();
+    const now = performance.now();
 
     if (this.feedCache && now - this.feedCacheTimestamp < this.feedCacheTtl) {
       return this.feedCache;

--- a/src/ai/tools/server/weather.ts
+++ b/src/ai/tools/server/weather.ts
@@ -151,7 +151,7 @@ export const getCurrentWeather = createAiTool<GetCurrentWeatherInput, WeatherRes
     "Results cached for 10 minutes.",
   execute: async (params) => {
     const validated = getCurrentWeatherInputSchema.parse(params);
-    const startedAt = Date.now();
+    const startedAt = performance.now();
 
     const queryParams: Record<string, unknown> = {
       units: validated.units,
@@ -168,7 +168,7 @@ export const getCurrentWeather = createAiTool<GetCurrentWeatherInput, WeatherRes
 
     const { data, provider } = await executeWeatherQuery(queryParams);
     const weatherData = data as Record<string, unknown>;
-    const tookMs = Date.now() - startedAt;
+    const tookMs = performance.now() - startedAt;
 
     const main = weatherData.main as Record<string, unknown> | undefined;
     const weather = (weatherData.weather as unknown[])?.[0] as
@@ -228,7 +228,7 @@ export const getCurrentWeather = createAiTool<GetCurrentWeatherInput, WeatherRes
         ...cached,
         fromCache: true,
         provider: cached.provider ?? "cache",
-        tookMs: Date.now() - meta.startedAt,
+        tookMs: performance.now() - meta.startedAt,
       }),
       shouldBypass: (params) => Boolean(params.fresh),
       ttlSeconds: WEATHER_CACHE_TTL_SECONDS,

--- a/src/ai/tools/server/web-crawl.ts
+++ b/src/ai/tools/server/web-crawl.ts
@@ -307,7 +307,7 @@ async function pollCrawlStatus(
     maxResults,
     maxWaitTime,
   } = options;
-  const startTime = Date.now();
+  const startTime = performance.now();
   const maxWaitMs = maxWaitTime ? maxWaitTime * 1000 : timeoutMs;
   let pageCount = 0;
   let resultCount = 0;
@@ -315,7 +315,7 @@ async function pollCrawlStatus(
   let next: string | null = null;
 
   while (true) {
-    const elapsed = Date.now() - startTime;
+    const elapsed = performance.now() - startTime;
     if (elapsed > maxWaitMs) {
       throw new Error(`web_crawl_timeout:${maxWaitMs}ms`);
     }

--- a/src/ai/tools/server/web-search-batch.ts
+++ b/src/ai/tools/server/web-search-batch.ts
@@ -100,7 +100,7 @@ export const webSearchBatch = createAiTool({
   description:
     "Run multiple web searches in a single call, reusing per-query cache and rate limits.",
   execute: async ({ queries, userId, ...rest }, callOptions: ToolExecutionOptions) => {
-    const started = Date.now();
+    const started = performance.now();
     // Optional top-level rate limiting (in addition to per-query limits)
     try {
       if (userId) {
@@ -201,7 +201,7 @@ export const webSearchBatch = createAiTool({
             if (rest.scrapeOptions != null) body.scrapeOptions = rest.scrapeOptions;
             if (rest.sources != null) body.sources = rest.sources;
             if (rest.tbs != null) body.tbs = rest.tbs;
-            const startedAt = Date.now();
+            const startedAt = performance.now();
             // Clamp timeouts to safe bounds to avoid too-short/unbounded requests and align with provider expectations.
             const timeoutMs = Math.min(20000, Math.max(5000, rest.timeoutMs ?? 12000));
             body.timeout = timeoutMs;
@@ -249,7 +249,7 @@ export const webSearchBatch = createAiTool({
             const validatedValue = {
               fromCache: false,
               results: normalizedResults,
-              tookMs: Date.now() - startedAt,
+              tookMs: performance.now() - startedAt,
             };
             results.push({
               ok: true,
@@ -300,7 +300,7 @@ export const webSearchBatch = createAiTool({
     // Validate final output against strict schema
     const rawOut = {
       results,
-      tookMs: Date.now() - started,
+      tookMs: performance.now() - started,
     };
     return WEB_SEARCH_BATCH_OUTPUT_SCHEMA.parse(rawOut);
   },

--- a/src/ai/tools/server/web-search.ts
+++ b/src/ai/tools/server/web-search.ts
@@ -60,7 +60,7 @@ export const webSearch = createAiTool<WebSearchInput, WebSearchResult>({
       onHit: (cached, _params, meta) => ({
         ...cached,
         fromCache: true,
-        tookMs: Date.now() - meta.startedAt,
+        tookMs: performance.now() - meta.startedAt,
       }),
       shouldBypass: (params) => Boolean(params.fresh),
       ttlSeconds: (params) => inferTtlSeconds(params.query),
@@ -111,7 +111,7 @@ async function runWebSearch(
 ): Promise<WebSearchResult> {
   try {
     const apiKey = resolveFirecrawlApiKey();
-    const startedAt = Date.now();
+    const startedAt = performance.now();
     const scrapeOptions =
       params.scrapeOptions === null
         ? undefined
@@ -157,7 +157,7 @@ async function runWebSearch(
     return WEB_SEARCH_OUTPUT_SCHEMA.parse({
       fromCache: false,
       results: normalized,
-      tookMs: Date.now() - startedAt,
+      tookMs: performance.now() - startedAt,
     });
   } catch (error) {
     if (isToolError(error)) {

--- a/src/app/(app)/dashboard/search/flights/results/flight-results-client.tsx
+++ b/src/app/(app)/dashboard/search/flights/results/flight-results-client.tsx
@@ -349,7 +349,8 @@ export default function FlightResultsClient({ searchId }: FlightResultsClientPro
                       <Button
                         className="w-24"
                         disabled
-                        title="Flight selection is not available yet."
+                        aria-label={`Select ${flight.airline} ${flight.flightNumber} from ${flight.origin} to ${flight.destination}`}
+                        title={`Flight selection for ${flight.airline} ${flight.flightNumber} from ${flight.origin} to ${flight.destination} is not available yet.`}
                       >
                         Select
                       </Button>

--- a/src/app/(app)/dashboard/trips/__tests__/page.test.tsx
+++ b/src/app/(app)/dashboard/trips/__tests__/page.test.tsx
@@ -3,17 +3,8 @@
 import type { UiTrip } from "@schemas/trips";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  type MockInstance,
-  test,
-  vi,
-} from "vitest";
-import { ApiError, type AppError } from "@/lib/api/error-types";
+import { beforeEach, describe, expect, it, test, vi } from "vitest";
+import { ApiError } from "@/lib/api/error-types";
 
 // Mock Lucide icons
 vi.mock("lucide-react", () => {
@@ -41,7 +32,7 @@ vi.mock("lucide-react", () => {
 // Mock trip data
 const mockTrips = vi.hoisted(() => vi.fn((): UiTrip[] => []));
 const mockIsLoading = vi.hoisted(() => vi.fn(() => false));
-const mockError = vi.hoisted(() => vi.fn((): AppError | null => null));
+const mockError = vi.hoisted(() => vi.fn((): ApiError | null => null));
 const mockIsConnected = vi.hoisted(() => vi.fn(() => true));
 const mockRealtimeStatus = vi.hoisted(() =>
   vi.fn(() => ({ errors: [] as Error[], isConnected: true }))
@@ -51,6 +42,8 @@ const mockCreateIsPending = vi.hoisted(() => vi.fn(() => false));
 const mockDeleteTrip = vi.hoisted(() => vi.fn());
 const mockDeleteIsPending = vi.hoisted(() => vi.fn(() => false));
 const mockToast = vi.hoisted(() => vi.fn());
+const mockRecordClientErrorOnActiveSpan = vi.hoisted(() => vi.fn());
+const mockNowIso = vi.hoisted(() => vi.fn(() => "2025-06-15T00:00:00.000Z"));
 
 const DEFAULT_USER_ID = "11111111-1111-4111-8aaa-111111111111";
 
@@ -74,6 +67,14 @@ vi.mock("@/hooks/use-trips", () => ({
 
 vi.mock("@/components/ui/use-toast", () => ({
   useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock("@/lib/telemetry/client-errors", () => ({
+  recordClientErrorOnActiveSpan: mockRecordClientErrorOnActiveSpan,
+}));
+
+vi.mock("@/lib/security/random", () => ({
+  nowIso: mockNowIso,
 }));
 
 // Mock child components
@@ -123,6 +124,8 @@ describe("TripsPage", () => {
     mockDeleteTrip.mockReset();
     mockDeleteIsPending.mockReset();
     mockToast.mockReset();
+    mockRecordClientErrorOnActiveSpan.mockReset();
+    mockNowIso.mockReset();
     mockTrips.mockReturnValue([]);
     mockIsLoading.mockReturnValue(false);
     mockError.mockReturnValue(null);
@@ -130,6 +133,7 @@ describe("TripsPage", () => {
     mockRealtimeStatus.mockReturnValue({ errors: [], isConnected: true });
     mockCreateIsPending.mockReturnValue(false);
     mockDeleteIsPending.mockReturnValue(false);
+    mockNowIso.mockReturnValue("2025-06-15T00:00:00.000Z");
   });
 
   describe("Loading state", () => {
@@ -244,26 +248,18 @@ describe("TripsPage", () => {
       expect(screen.getByTestId("connection-status")).toBeInTheDocument();
     });
 
-    it("logs trips errors to console in development mode", async () => {
-      const originalNodeEnv = process.env.NODE_ENV;
-      vi.stubEnv("NODE_ENV", "development");
-
-      const consoleErrorSpy = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => undefined);
+    it("reports trips errors through telemetry", async () => {
       const error = new ApiError("Failed to load trips", 500);
       mockError.mockReturnValue(error);
 
-      try {
-        render(<TripsPage />);
+      render(<TripsPage />);
 
-        await waitFor(() => {
-          expect(consoleErrorSpy).toHaveBeenCalledWith("Trips error:", error);
+      await waitFor(() => {
+        expect(mockRecordClientErrorOnActiveSpan).toHaveBeenCalledWith(error, {
+          action: "loadTrips",
+          context: "TripsClient",
         });
-      } finally {
-        vi.stubEnv("NODE_ENV", originalNodeEnv);
-        consoleErrorSpy.mockRestore();
-      }
+      });
     });
   });
 
@@ -784,19 +780,6 @@ describe("TripsPage", () => {
         visibility: "private",
       },
     ];
-
-    let nowSpy: MockInstance<() => number> | null = null;
-
-    beforeEach(() => {
-      nowSpy = vi
-        .spyOn(Date, "now")
-        .mockReturnValue(new Date("2025-06-15T00:00:00Z").getTime());
-    });
-
-    afterEach(() => {
-      nowSpy?.mockRestore();
-      nowSpy = null;
-    });
 
     const selectFilter = async (name: string) => {
       const trigger = screen.getByRole("combobox", { name: /filter trips/i });

--- a/src/app/(app)/dashboard/trips/create/__tests__/page.test.tsx
+++ b/src/app/(app)/dashboard/trips/create/__tests__/page.test.tsx
@@ -83,6 +83,10 @@ vi.mock("@/hooks/use-trips", () => ({
   }),
 }));
 
+vi.mock("@/lib/security/random", () => ({
+  nowIso: vi.fn(() => "2026-01-01T12:00:00.000Z"),
+}));
+
 // Import after mocks so Vitest applies them before module evaluation.
 import CreateTripClient from "../create-trip-client";
 
@@ -119,6 +123,13 @@ describe("CreateTripClient", () => {
     await waitFor(() => {
       expect(createButton).toBeEnabled();
     });
+  });
+
+  it("uses centralized clock defaults for trip dates", () => {
+    render(<CreateTripClient initialSuggestionLimit={6} />);
+
+    expect(screen.getByLabelText("Start date (optional)")).toHaveValue("2026-01-02");
+    expect(screen.getByLabelText("End date (optional)")).toHaveValue("2026-01-09");
   });
 
   it("prefills from cached suggestions when the suggestion is available", async () => {

--- a/src/app/(app)/dashboard/trips/create/create-trip-client.tsx
+++ b/src/app/(app)/dashboard/trips/create/create-trip-client.tsx
@@ -45,6 +45,7 @@ import { useZodForm } from "@/hooks/use-zod-form";
 import { ApiError, getErrorMessage } from "@/lib/api/error-types";
 import { DateUtils } from "@/lib/dates/unified-date-utils";
 import { keys } from "@/lib/keys";
+import { nowIso } from "@/lib/security/random";
 import {
   computeDefaultTripDates,
   computeDefaultTripTitle,
@@ -64,6 +65,10 @@ export interface CreateTripClientProps {
   initialBudgetMax?: number;
   initialSuggestionId?: string;
   initialSuggestionLimit: number;
+}
+
+function getDefaultTripDates(): { endDate: string; startDate: string } {
+  return computeDefaultTripDates(new Date(nowIso()));
 }
 
 /**
@@ -88,7 +93,7 @@ export default function CreateTripClient({
   const { toast } = useToast();
   const createTripMutation = useCreateTrip();
 
-  const [defaultDates] = useState(() => computeDefaultTripDates(new Date()));
+  const [defaultDates] = useState(getDefaultTripDates);
 
   const form = useZodForm({
     defaultValues: {

--- a/src/app/(app)/dashboard/trips/trips-client.tsx
+++ b/src/app/(app)/dashboard/trips/trips-client.tsx
@@ -45,6 +45,7 @@ import { TripCard } from "@/features/trips/components/trip-card";
 import { type Trip, useCreateTrip, useDeleteTrip, useTrips } from "@/hooks/use-trips";
 import { getErrorMessage } from "@/lib/api/error-types";
 import { nowIso } from "@/lib/security/random";
+import { recordClientErrorOnActiveSpan } from "@/lib/telemetry/client-errors";
 import { parseTripDate } from "@/lib/trips/parse-trip-date";
 
 /**
@@ -94,6 +95,8 @@ const isInvalidTripDateRange = (
   endDate: Date | null
 ): boolean => !!startDate && !!endDate && endDate.getTime() < startDate.getTime();
 
+const getCurrentTripsPageTimestampMs = (): number => Date.parse(nowIso());
+
 type TripStatus = "draft" | "upcoming" | "active" | "completed";
 type SortOption = "name" | "date" | "budget" | "destinations";
 type FilterOption = "all" | "draft" | "upcoming" | "active" | "completed";
@@ -122,7 +125,7 @@ function countTripsByStatus(trips: Trip[]): TripStatusCounts {
     return { active: 0, completed: 0, draft: 0, upcoming: 0 };
   }
 
-  const nowTs = Date.now();
+  const nowTs = getCurrentTripsPageTimestampMs();
   const counts: TripStatusCounts = { active: 0, completed: 0, draft: 0, upcoming: 0 };
   for (const trip of trips) {
     counts[getTripStatus(trip, nowTs)] += 1;
@@ -141,7 +144,7 @@ function filterAndSortTrips(params: {
   if (trips.length === 0) return [];
 
   let filtered = trips;
-  const nowTs = Date.now();
+  const nowTs = getCurrentTripsPageTimestampMs();
   const searchQueryLower = searchQuery.toLowerCase();
 
   if (searchQuery) {
@@ -279,14 +282,15 @@ export default function TripsClient({ userId }: { userId: string }) {
       const message = getErrorMessage(error) || "Unable to load trips.";
       if (message !== lastErrorMessageRef.current) {
         lastErrorMessageRef.current = message;
+        recordClientErrorOnActiveSpan(error, {
+          action: "loadTrips",
+          context: "TripsClient",
+        });
         toast({
           description: message,
           title: "Unable to load trips",
           variant: "destructive",
         });
-      }
-      if (process.env.NODE_ENV === "development") {
-        console.error("Trips error:", error);
       }
     } else {
       lastErrorMessageRef.current = null;

--- a/src/app/__tests__/error-boundaries-integration.test.tsx
+++ b/src/app/__tests__/error-boundaries-integration.test.tsx
@@ -5,13 +5,13 @@ import { act, screen } from "@testing-library/react";
 import { createRoot, type Root } from "react-dom/client";
 import type { MockInstance } from "vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GlobalErrorContent } from "@/components/error/global-error-content";
 import { MAIN_CONTENT_ID } from "@/lib/a11y/landmarks";
 import { render } from "@/test/test-utils";
 import DashboardError from "../(app)/dashboard/error";
 import AuthError from "../(auth)/error";
 // Import the error boundary components
 import ErrorComponent from "../error";
-import GlobalError from "../global-error";
 
 const { createErrorReportMock, reportErrorMock } = vi.hoisted(() => {
   const createErrorReport = vi.fn(
@@ -66,7 +66,7 @@ function renderGlobalError(error: unknown, reset: () => void) {
   const root = createRoot(container);
 
   act(() => {
-    root.render(<GlobalError error={error} reset={reset} />);
+    root.render(<GlobalErrorContent error={error} reset={reset} />);
   });
 
   globalErrorRoots.set(root, container);

--- a/src/app/api/auth/mfa/__tests__/challenge.route.test.ts
+++ b/src/app/api/auth/mfa/__tests__/challenge.route.test.ts
@@ -1,6 +1,7 @@
 /** @vitest-environment node */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { secureUuid } from "@/lib/security/random";
 import {
   createRouteParamsContext,
   makeJsonRequest,
@@ -57,7 +58,7 @@ describe("POST /api/auth/mfa/challenge", () => {
     const { POST } = await import("../challenge/route");
     const res = await POST(
       makeJsonRequest("http://localhost/api/auth/mfa/challenge", {
-        factorId: crypto.randomUUID(),
+        factorId: secureUuid(),
       }),
       createRouteParamsContext()
     );
@@ -72,7 +73,7 @@ describe("POST /api/auth/mfa/challenge", () => {
     const { POST } = await import("../challenge/route");
     const res = await POST(
       makeJsonRequest("http://localhost/api/auth/mfa/challenge", {
-        factorId: crypto.randomUUID(),
+        factorId: secureUuid(),
       }),
       createRouteParamsContext()
     );

--- a/src/app/api/calendar/__tests__/README.md
+++ b/src/app/api/calendar/__tests__/README.md
@@ -6,7 +6,7 @@ Integration tests for calendar API routes using Vitest with optimized shared moc
 
 ## Test Structure
 
-- **Unit Tests**: Schema validation (`src/schemas/__tests__/calendar.test.ts`)
+- **Unit Tests**: Schema validation (`src/domain/schemas/__tests__/calendar.test.ts`)
 - **Integration Tests**: API route handlers (`src/app/api/calendar/__tests__/`)
 - **E2E Tests**: Full UI flows (`e2e/calendar-integration.spec.ts`)
 

--- a/src/app/api/config/agents/[agentType]/rollback/[versionId]/route.ts
+++ b/src/app/api/config/agents/[agentType]/rollback/[versionId]/route.ts
@@ -13,6 +13,7 @@ import { revalidateTag } from "next/cache";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { createAgentConfigVersionId } from "@/lib/agents/version-id";
 import type { RouteParamsContext } from "@/lib/api/factory";
 import { withApiGuards } from "@/lib/api/factory";
 import {
@@ -23,7 +24,7 @@ import {
 } from "@/lib/api/route-helpers";
 import { bumpTag } from "@/lib/cache/tags";
 import { ensureAdmin, scopeSchema } from "@/lib/config/helpers";
-import { nowIso, secureId } from "@/lib/security/random";
+import { nowIso } from "@/lib/security/random";
 import { getMaybeSingle } from "@/lib/supabase/typed-helpers";
 import { emitOperationalAlert } from "@/lib/telemetry/alerts";
 import { recordTelemetryEvent } from "@/lib/telemetry/span";
@@ -42,7 +43,7 @@ function buildRollbackConfig(existing: AgentConfig, scope: string): AgentConfig 
   return configurationAgentConfigSchema.parse({
     ...existing,
     agentType: existing.agentType,
-    id: `v${Math.floor(Date.now() / 1000)}_${secureId(8)}`,
+    id: createAgentConfigVersionId(),
     scope,
     updatedAt: now,
   });

--- a/src/app/api/config/agents/[agentType]/route.ts
+++ b/src/app/api/config/agents/[agentType]/route.ts
@@ -17,6 +17,7 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import type { z } from "zod";
 import { resolveAgentConfig } from "@/lib/agents/config-resolver";
+import { createAgentConfigVersionId } from "@/lib/agents/version-id";
 import type { RouteParamsContext } from "@/lib/api/factory";
 import { withApiGuards } from "@/lib/api/factory";
 import {
@@ -30,7 +31,7 @@ import {
 } from "@/lib/api/route-helpers";
 import { bumpTag } from "@/lib/cache/tags";
 import { ensureAdmin, scopeSchema } from "@/lib/config/helpers";
-import { nowIso, secureId } from "@/lib/security/random";
+import { nowIso } from "@/lib/security/random";
 import { getMaybeSingle } from "@/lib/supabase/typed-helpers";
 import { emitOperationalAlert } from "@/lib/telemetry/alerts";
 import { recordTelemetryEvent, withTelemetrySpan } from "@/lib/telemetry/span";
@@ -47,8 +48,7 @@ function buildConfigPayload(
   existing?: AgentConfig
 ): AgentConfig {
   const now = nowIso();
-  const baseConfigId =
-    existing?.id ?? `v${Math.floor(Date.now() / 1000)}_${secureId(8)}`;
+  const baseConfigId = existing?.id ?? createAgentConfigVersionId();
   const effectiveModel = body.model ?? existing?.model ?? DEFAULT_AGENT_MODEL_ID;
   return configurationAgentConfigSchema.parse({
     agentType,

--- a/src/app/api/config/agents/__tests__/routes.test.ts
+++ b/src/app/api/config/agents/__tests__/routes.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockApiRouteAuthUser, resetApiRouteMocks } from "@/test/helpers/api-route";
 import { TEST_USER_ID } from "@/test/helpers/ids";
 import { createMockSupabaseClient, getSupabaseMockState } from "@/test/mocks/supabase";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
 
 vi.mock("@/lib/cache/tags", () => ({
   bumpTag: vi.fn(async () => 1),
@@ -208,6 +209,59 @@ describe("config routes", () => {
     );
   });
 
+  it(
+    "PUT creates helper-backed version-shaped config id when no config exists",
+    withFakeTimers(async () => {
+      vi.setSystemTime(new Date("2026-02-03T04:05:06.000Z"));
+
+      const supabase = createMockSupabaseClient({ user: null });
+      const state = getSupabaseMockState(supabase);
+      state.selectByTable.set("agent_config", {
+        count: null,
+        data: [],
+        error: null,
+      });
+      state.rpcResults.set("agent_config_upsert", {
+        count: null,
+        data: [{ version_id: "ver-created" }],
+        error: null,
+      });
+      const rpcSpy = vi.spyOn(supabase, "rpc");
+
+      const { PUT } = await import("../[agentType]/route");
+      const req = new NextRequest("http://localhost/api/config/agents/budgetAgent", {
+        body: JSON.stringify({
+          description: "created",
+          model: "gpt-5.5",
+          temperature: 0.4,
+        }),
+        headers: { "Content-Type": "application/json" },
+        method: "PUT",
+      } as never);
+
+      const res = await PUT(req, {
+        params: Promise.resolve({ agentType: "budgetAgent" }),
+        supabase,
+        user: { app_metadata: { is_admin: true }, id: TEST_USER_ID } as never,
+      } as never);
+
+      expect(res.status).toBe(200);
+      const rpcPayload = rpcSpy.mock.calls[0]?.[1] as
+        | Record<string, unknown>
+        | undefined;
+      const configPayload = rpcPayload?.p_config as
+        | { createdAt?: string; id?: string; updatedAt?: string }
+        | undefined;
+      expect(configPayload).toEqual(
+        expect.objectContaining({
+          createdAt: "2026-02-03T04:05:06.000Z",
+          id: expect.stringMatching(/^v1770091506_[a-z0-9]{8}$/),
+          updatedAt: "2026-02-03T04:05:06.000Z",
+        })
+      );
+    })
+  );
+
   it("versions returns list", async () => {
     const versionsRow = {
       agent_type: "budgetAgent",
@@ -241,48 +295,66 @@ describe("config routes", () => {
     expect(json.versions[0].id).toBe("ver-1");
   });
 
-  it("rollback emits alert", async () => {
-    const supabase = createMockSupabaseClient({ user: null });
-    const state = getSupabaseMockState(supabase);
-    state.selectByTable.set("agent_config_versions", {
-      count: null,
-      data: [supabaseData],
-      error: null,
-    });
-    state.rpcResults.set("agent_config_upsert", {
-      count: null,
-      data: [{ version_id: "ver-rollback" }],
-      error: null,
-    });
+  it(
+    "rollback emits alert and helper-backed version-shaped config id",
+    withFakeTimers(async () => {
+      vi.setSystemTime(new Date("2026-02-03T04:05:06.000Z"));
 
-    const { POST } = await import("../[agentType]/rollback/[versionId]/route");
-    const req = new NextRequest(
-      "http://localhost/api/config/agents/budgetAgent/rollback/11111111-1111-4111-8111-111111111111"
-    );
+      const supabase = createMockSupabaseClient({ user: null });
+      const state = getSupabaseMockState(supabase);
+      state.selectByTable.set("agent_config_versions", {
+        count: null,
+        data: [supabaseData],
+        error: null,
+      });
+      state.rpcResults.set("agent_config_upsert", {
+        count: null,
+        data: [{ version_id: "ver-rollback" }],
+        error: null,
+      });
+      const rpcSpy = vi.spyOn(supabase, "rpc");
 
-    const res = await POST(req, {
-      params: Promise.resolve({
-        agentType: "budgetAgent",
-        versionId: "11111111-1111-4111-8111-111111111111",
-      }),
-      supabase,
-      user: { app_metadata: { is_admin: true }, id: TEST_USER_ID } as never,
-    } as never);
+      const { POST } = await import("../[agentType]/rollback/[versionId]/route");
+      const req = new NextRequest(
+        "http://localhost/api/config/agents/budgetAgent/rollback/11111111-1111-4111-8111-111111111111"
+      );
 
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body).toEqual(
-      expect.objectContaining({
-        versionId: "ver-rollback",
-      })
-    );
-    expect(mockEmit).toHaveBeenCalledWith(
-      "agent_config.rollback",
-      expect.objectContaining({
-        attributes: expect.objectContaining({ agentType: "budgetAgent" }),
-      })
-    );
-  });
+      const res = await POST(req, {
+        params: Promise.resolve({
+          agentType: "budgetAgent",
+          versionId: "11111111-1111-4111-8111-111111111111",
+        }),
+        supabase,
+        user: { app_metadata: { is_admin: true }, id: TEST_USER_ID } as never,
+      } as never);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual(
+        expect.objectContaining({
+          versionId: "ver-rollback",
+        })
+      );
+      const rpcPayload = rpcSpy.mock.calls[0]?.[1] as
+        | Record<string, unknown>
+        | undefined;
+      const configPayload = rpcPayload?.p_config as
+        | { id?: string; updatedAt?: string }
+        | undefined;
+      expect(configPayload).toEqual(
+        expect.objectContaining({
+          id: expect.stringMatching(/^v1770091506_[a-z0-9]{8}$/),
+          updatedAt: "2026-02-03T04:05:06.000Z",
+        })
+      );
+      expect(mockEmit).toHaveBeenCalledWith(
+        "agent_config.rollback",
+        expect.objectContaining({
+          attributes: expect.objectContaining({ agentType: "budgetAgent" }),
+        })
+      );
+    })
+  );
 
   it("rejects non-admin", async () => {
     mockApiRouteAuthUser({ id: TEST_USER_ID } as never);

--- a/src/app/api/embeddings/__tests__/route.test.ts
+++ b/src/app/api/embeddings/__tests__/route.test.ts
@@ -206,6 +206,10 @@ describe("/api/embeddings", () => {
     const json = await res.json();
     expect(json.persisted).toBe(true);
     expect(FROM).toHaveBeenCalledWith("accommodation_embeddings");
+    const persistedPayload = UPSERT.mock.calls[0]?.[0];
+    expect(new Date(persistedPayload.updated_at).toISOString()).toBe(
+      persistedPayload.updated_at
+    );
     expect(UPSERT).toHaveBeenCalledWith(
       expect.objectContaining({
         amenities: "pool, wifi",

--- a/src/app/api/embeddings/route.ts
+++ b/src/app/api/embeddings/route.ts
@@ -26,6 +26,7 @@ import {
 import { getServerEnvVarWithFallback } from "@/lib/env/server";
 import { toPgvector } from "@/lib/rag/pgvector";
 import { isValidInternalKey } from "@/lib/security/internal-key";
+import { nowIso } from "@/lib/security/random";
 import { createAdminSupabase } from "@/lib/supabase/admin";
 import type { TablesInsert } from "@/lib/supabase/database.types";
 import { upsertSingle } from "@/lib/supabase/typed-helpers";
@@ -86,7 +87,7 @@ async function persistAccommodationEmbedding(
     id: property.id,
     name: property.name ?? null,
     source: normalizeSource(property.source),
-    updated_at: new Date().toISOString(),
+    updated_at: nowIso(),
   };
 
   const { error } = await upsertSingle(

--- a/src/app/api/flights/__tests__/popular-destinations-route.test.ts
+++ b/src/app/api/flights/__tests__/popular-destinations-route.test.ts
@@ -9,7 +9,7 @@ import { stubRateLimitDisabled } from "@/test/helpers/env";
 import { TEST_USER_ID } from "@/test/helpers/ids";
 import { createMockNextRequest, createRouteParamsContext } from "@/test/helpers/route";
 
-const redisStore = new Map<string, string>();
+const redisStore = new Map<string, unknown>();
 const redisClient = {
   del: vi.fn((...keys: string[]) => {
     let deleted = 0;
@@ -19,7 +19,7 @@ const redisClient = {
     return deleted;
   }),
   get: vi.fn(async (key: string) => redisStore.get(key) ?? null),
-  set: vi.fn((key: string, value: string) => {
+  set: vi.fn((key: string, value: unknown) => {
     redisStore.set(key, value);
     return "OK";
   }),
@@ -74,10 +74,9 @@ describe("/api/flights/popular-destinations", () => {
   });
 
   it("returns cached destinations when present", async () => {
-    await redisClient.set(
-      "popular-destinations:global",
-      JSON.stringify([{ code: "NYC", name: "New York" }])
-    );
+    await redisClient.set("popular-destinations:global", [
+      { code: "NYC", name: "New York" },
+    ]);
 
     const req = createMockNextRequest({
       method: "GET",
@@ -147,11 +146,8 @@ describe("/api/flights/popular-destinations", () => {
     expect(body).toEqual([{ code: "LAX", name: "LAX" }]);
 
     const cached = await redisClient.get(`popular-destinations:user:${TEST_USER_ID}`);
-    const parsed = cached
-      ? (JSON.parse(cached) as Array<{ code: string; name: string }>)
-      : null;
 
-    expect(parsed).toEqual([{ code: "LAX", name: "LAX" }]);
+    expect(cached).toEqual([{ code: "LAX", name: "LAX" }]);
   });
 
   it("falls back to global destinations when cache is empty and user missing", async () => {

--- a/src/app/api/flights/__tests__/popular-routes-route.test.ts
+++ b/src/app/api/flights/__tests__/popular-routes-route.test.ts
@@ -9,37 +9,32 @@ import { POPULAR_ROUTES_CACHE_KEY_GLOBAL } from "@/lib/flights/popular-routes-ca
 import { stubRateLimitDisabled } from "@/test/helpers/env";
 import { createMockNextRequest, createRouteParamsContext } from "@/test/helpers/route";
 import { createMockSupabaseClient } from "@/test/mocks/supabase";
-import {
-  RedisMockClient,
-  setupUpstashMocks,
-  type UpstashMemoryStore,
-} from "@/test/upstash/redis-mock";
+import { RedisMockClient, setupUpstashMocks } from "@/test/upstash/redis-mock";
 
 const { redis, ratelimit } = setupUpstashMocks();
-
-class RawStringRedisMock extends RedisMockClient {
-  constructor(private readonly rawStore: UpstashMemoryStore) {
-    super(rawStore);
-  }
-
-  override get<T = unknown>(key: string): Promise<T | null> {
-    const entry = this.rawStore.get(key);
-    if (!entry) return Promise.resolve(null);
-    return Promise.resolve(entry.value as T);
-  }
-}
 
 vi.mock("@/lib/redis", async () => {
   const actual = await vi.importActual<typeof import("@/lib/redis")>("@/lib/redis");
   return {
     ...actual,
-    getRedis: vi.fn(() => new RawStringRedisMock(redis.store)),
+    getRedis: vi.fn(() => new RedisMockClient(redis.store)),
   };
 });
 
 vi.mock("next/headers", () => ({
   cookies: vi.fn(() => Promise.resolve(new Map())),
 }));
+
+vi.mock("@/lib/security/random", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/security/random")>(
+    "@/lib/security/random"
+  );
+
+  return {
+    ...actual,
+    nowIso: vi.fn(() => "2025-01-15T12:00:00.000Z"),
+  };
+});
 
 // Import after mocks are registered
 import { GET as getPopularRoutes } from "../popular-routes/route";
@@ -70,7 +65,7 @@ describe("/api/flights/popular-routes", () => {
   });
 
   it("returns cached routes when present", async () => {
-    // Seed cache directly in the shared store (getCachedJson expects raw JSON string)
+    // Seed cache directly in the shared store; RedisMockClient mirrors SDK deserialization.
     redis.store.set(POPULAR_ROUTES_CACHE_KEY_GLOBAL, {
       value: JSON.stringify([
         { date: "May 1, 2026", destination: "Paris", origin: "NYC", price: 123 },
@@ -130,5 +125,15 @@ describe("/api/flights/popular-routes", () => {
     const destinations = body.map((r) => r.destination);
     expect(destinations).toContain("London");
     expect(destinations).toContain("Tokyo");
+
+    // The fallback dates derive from the shared timestamp helper.
+    expect(body.map((route) => route.date)).toEqual([
+      "2026-05-28",
+      "2026-06-15",
+      "2026-06-08",
+      "2026-06-22",
+      "2026-07-10",
+      "2026-07-18",
+    ]);
   });
 });

--- a/src/app/api/flights/popular-routes/route.ts
+++ b/src/app/api/flights/popular-routes/route.ts
@@ -8,6 +8,7 @@ import { withApiGuards } from "@/lib/api/factory";
 import { errorResponse } from "@/lib/api/route-helpers";
 import { getCachedJson, setCachedJson } from "@/lib/cache/upstash";
 import { POPULAR_ROUTES_CACHE_KEY_GLOBAL } from "@/lib/flights/popular-routes-cache";
+import { nowIso } from "@/lib/security/random";
 
 /**
  * Popular flight route entry returned to the client.
@@ -26,13 +27,17 @@ interface PopularRoute {
 
 const POPULAR_ROUTES_TTL_SECONDS = 24 * 60 * 60; // 24 hours
 
+function getNextUtcYear(): number {
+  return new Date(nowIso()).getUTCFullYear() + 1;
+}
+
 /**
  * Builds a static list of popular flight routes for the next year.
  *
  * @returns Array of popular routes with example dates, destinations, and prices.
  */
 function buildGlobalPopularRoutes(): PopularRoute[] {
-  const nextYear = new Date().getUTCFullYear() + 1;
+  const nextYear = getNextUtcYear();
   return [
     {
       date: `${nextYear}-05-28`,

--- a/src/app/api/health/byok/__tests__/route.test.ts
+++ b/src/app/api/health/byok/__tests__/route.test.ts
@@ -47,6 +47,14 @@ function byokHealthRequest(headers?: Record<string, string>): NextRequest {
   });
 }
 
+function mockPerformanceNowSequence(values: number[]) {
+  const nowSpy = vi.spyOn(performance, "now");
+  for (const value of values) {
+    nowSpy.mockReturnValueOnce(value);
+  }
+  return nowSpy;
+}
+
 describe("GET /api/health/byok", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -102,31 +110,37 @@ describe("GET /api/health/byok", () => {
   });
 
   it("returns a secret-free OK response when Vault health passes", async () => {
+    const nowSpy = mockPerformanceNowSequence([10.25, 34.75]);
     const { GET } = await import("../route");
 
-    const res = await GET(byokHealthRequest({ "x-internal-key": TEST_HEALTH_KEY }));
-    const body = await res.json();
+    try {
+      const res = await GET(byokHealthRequest({ "x-internal-key": TEST_HEALTH_KEY }));
+      const body = await res.json();
 
-    expect(res.status).toBe(200);
-    expect(res.headers.get("Cache-Control")).toBe("no-store");
-    expect(body).toMatchObject({
-      checks: { rpc: "ok", vault: "ok" },
-      service: "tripsage-ai",
-      status: "ok",
-    });
-    expect(JSON.stringify(body)).not.toContain(TEST_HEALTH_KEY);
-    expect(MOCK_CHECK_BYOK_VAULT_HEALTH).toHaveBeenCalledTimes(1);
-    expect(MOCK_WITH_TELEMETRY_SPAN).toHaveBeenCalledWith(
-      "health.byok",
-      {
-        attributes: {
-          "health.check": "byok",
-          "health.component": "vault",
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Cache-Control")).toBe("no-store");
+      expect(body).toMatchObject({
+        checks: { rpc: "ok", vault: "ok" },
+        service: "tripsage-ai",
+        status: "ok",
+      });
+      expect(JSON.stringify(body)).not.toContain(TEST_HEALTH_KEY);
+      expect(MOCK_CHECK_BYOK_VAULT_HEALTH).toHaveBeenCalledTimes(1);
+      expect(MOCK_WITH_TELEMETRY_SPAN).toHaveBeenCalledWith(
+        "health.byok",
+        {
+          attributes: {
+            "health.check": "byok",
+            "health.component": "vault",
+          },
         },
-      },
-      expect.any(Function)
-    );
-    expect(MOCK_SPAN.setAttribute).toHaveBeenCalledWith("health.status", "ok");
+        expect.any(Function)
+      );
+      expect(MOCK_SPAN.setAttribute).toHaveBeenCalledWith("health.latency_ms", 24.5);
+      expect(MOCK_SPAN.setAttribute).toHaveBeenCalledWith("health.status", "ok");
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it("accepts bearer tokens for external health monitors", async () => {
@@ -141,33 +155,42 @@ describe("GET /api/health/byok", () => {
   });
 
   it("returns VAULT_UNAVAILABLE when the Vault health RPC fails", async () => {
+    const nowSpy = mockPerformanceNowSequence([40, 47.25]);
     MOCK_CHECK_BYOK_VAULT_HEALTH.mockRejectedValueOnce(new Error("secret leaked"));
     const { GET } = await import("../route");
 
-    const res = await GET(byokHealthRequest({ "x-internal-key": TEST_HEALTH_KEY }));
-    const body = await res.json();
+    try {
+      const res = await GET(byokHealthRequest({ "x-internal-key": TEST_HEALTH_KEY }));
+      const body = await res.json();
 
-    expect(res.status).toBe(503);
-    expect(res.headers.get("Cache-Control")).toBe("no-store");
-    expect(body).toEqual({
-      error: "VAULT_UNAVAILABLE",
-      reason: "BYOK Vault health check failed",
-    });
-    expect(JSON.stringify(body)).not.toContain("secret leaked");
-    expect(MOCK_RECORD_TELEMETRY_EVENT).toHaveBeenCalledWith(
-      "health.byok_failure",
-      expect.objectContaining({
-        attributes: expect.objectContaining({ code: "VAULT_UNAVAILABLE" }),
-        level: "error",
-      })
-    );
-    expect(MOCK_RECORD_ERROR_ON_SPAN).toHaveBeenCalledWith(
-      MOCK_SPAN,
-      expect.objectContaining({ message: "BYOK Vault health check failed" })
-    );
-    expect(MOCK_RECORD_ERROR_ON_SPAN.mock.calls[0]?.[1]?.message).not.toContain(
-      "secret leaked"
-    );
-    expect(MOCK_SPAN.setAttribute).toHaveBeenCalledWith("health.status", "error");
+      expect(res.status).toBe(503);
+      expect(res.headers.get("Cache-Control")).toBe("no-store");
+      expect(body).toEqual({
+        error: "VAULT_UNAVAILABLE",
+        reason: "BYOK Vault health check failed",
+      });
+      expect(JSON.stringify(body)).not.toContain("secret leaked");
+      expect(MOCK_RECORD_TELEMETRY_EVENT).toHaveBeenCalledWith(
+        "health.byok_failure",
+        expect.objectContaining({
+          attributes: expect.objectContaining({
+            code: "VAULT_UNAVAILABLE",
+            latency_ms: 7.25,
+          }),
+          level: "error",
+        })
+      );
+      expect(MOCK_RECORD_ERROR_ON_SPAN).toHaveBeenCalledWith(
+        MOCK_SPAN,
+        expect.objectContaining({ message: "BYOK Vault health check failed" })
+      );
+      expect(MOCK_RECORD_ERROR_ON_SPAN.mock.calls[0]?.[1]?.message).not.toContain(
+        "secret leaked"
+      );
+      expect(MOCK_SPAN.setAttribute).toHaveBeenCalledWith("health.latency_ms", 7.25);
+      expect(MOCK_SPAN.setAttribute).toHaveBeenCalledWith("health.status", "error");
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 });

--- a/src/app/api/health/byok/route.ts
+++ b/src/app/api/health/byok/route.ts
@@ -78,10 +78,10 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       },
     },
     async (span) => {
-      const startedAt = Date.now();
+      const startedAt = performance.now();
       try {
         await checkByokVaultHealth();
-        const latencyMs = Date.now() - startedAt;
+        const latencyMs = performance.now() - startedAt;
         span.setAttribute("health.latency_ms", latencyMs);
         span.setAttribute("health.status", "ok");
 
@@ -98,7 +98,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
           { headers: NO_STORE_HEADERS, status: 200 }
         );
       } catch {
-        const latencyMs = Date.now() - startedAt;
+        const latencyMs = performance.now() - startedAt;
         span.setAttribute("health.latency_ms", latencyMs);
         span.setAttribute("health.status", "error");
         recordErrorOnSpan(span, sanitizedHealthCheckError());

--- a/src/app/api/keys/validate/__tests__/route.test.ts
+++ b/src/app/api/keys/validate/__tests__/route.test.ts
@@ -473,16 +473,19 @@ describe("/api/keys/validate route", () => {
   });
 
   it("passes timeout-aware fetch to Gateway credits validation", async () => {
-    const fetchMock = vi
-      .fn<FetchLike>()
-      .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+    const requestSpy = vi.fn<(request: Request) => void>();
     let gatewayFetch: typeof fetch | undefined;
     const getCredits = vi.fn(async () => ({ balance: "1", totalUsed: "0" }));
     mockCreateGateway.mockImplementation((options: { fetch?: typeof fetch }) => {
       gatewayFetch = options.fetch;
       return { getCredits };
     });
-    vi.stubGlobal("fetch", fetchMock);
+    server.use(
+      http.get("https://gateway.test/credits", ({ request }) => {
+        requestSpy(request);
+        return HttpResponse.json({});
+      })
+    );
 
     const { POST } = await import("../route");
     const req = createMockNextRequest({
@@ -506,12 +509,9 @@ describe("/api/keys/validate route", () => {
     expect(gatewayFetch).toEqual(expect.any(Function));
 
     await gatewayFetch?.("https://gateway.test/credits");
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://gateway.test/credits",
-      expect.objectContaining({
-        signal: expect.any(AbortSignal),
-      })
-    );
+    const capturedRequest = requestSpy.mock.calls[0]?.[0];
+    expect(capturedRequest?.url).toBe("https://gateway.test/credits");
+    expect(capturedRequest?.signal).toEqual(expect.any(AbortSignal));
   });
 
   it("returns REQUEST_TIMEOUT when Gateway credits validation times out", async () => {

--- a/src/app/api/memory/[intent]/[userId]/__tests__/stats.route.test.ts
+++ b/src/app/api/memory/[intent]/[userId]/__tests__/stats.route.test.ts
@@ -131,7 +131,7 @@ describe("/api/memory/stats/[userId] route", () => {
     expect(body.memoryTypes.conversation_context).toBe(2);
     expect(body.storageSize).toBe("Paris".length + "Budget stay".length);
     expect(body.totalMemories).toBe(2);
-    expect(mockNowIso).toHaveBeenCalledOnce();
+    expect(mockNowIso).toHaveBeenCalled();
     expect(mockHandleMemoryIntent).toHaveBeenCalledWith({
       limit: 100,
       sessionId: "",

--- a/src/app/api/memory/[intent]/__tests__/search.route.test.ts
+++ b/src/app/api/memory/[intent]/__tests__/search.route.test.ts
@@ -80,12 +80,13 @@ async function importRoute() {
   return mod.POST;
 }
 
-function mockPerformanceNowSequence(values: number[]) {
-  const nowSpy = vi.spyOn(performance, "now");
-  for (const value of values) {
-    nowSpy.mockReturnValueOnce(value);
-  }
-  return nowSpy;
+function mockPerformanceNowSequence(values: readonly number[]) {
+  let index = 0;
+  return vi.spyOn(performance, "now").mockImplementation(() => {
+    const value = values[Math.min(index, values.length - 1)] ?? 0;
+    index += 1;
+    return value;
+  });
 }
 
 describe("/api/memory/search route", () => {
@@ -114,8 +115,8 @@ describe("/api/memory/search route", () => {
   });
 
   it("returns schema-compliant search results", async () => {
-    const nowSpy = mockPerformanceNowSequence([20.25, 33.75]);
     const post = await importRoute();
+    const performanceNowSpy = mockPerformanceNowSequence([20.25, 33.75]);
 
     const context: MemoryContextResponse[] = [
       {
@@ -172,7 +173,7 @@ describe("/api/memory/search route", () => {
         userId,
       });
     } finally {
-      nowSpy.mockRestore();
+      performanceNowSpy.mockRestore();
     }
   }, 15_000);
 

--- a/src/components/layouts/__tests__/navbar.test.tsx
+++ b/src/components/layouts/__tests__/navbar.test.tsx
@@ -1,0 +1,65 @@
+/** @vitest-environment jsdom */
+
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ROUTES } from "@/lib/routes";
+import { Navbar } from "../navbar";
+
+const USE_PATHNAME_MOCK = vi.hoisted(() => vi.fn(() => "/"));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => USE_PATHNAME_MOCK(),
+}));
+
+vi.mock("@/components/ui/theme-toggle", () => ({
+  ThemeToggle: () => <button type="button">Toggle theme</button>,
+}));
+
+describe("Navbar", () => {
+  beforeEach(() => {
+    USE_PATHNAME_MOCK.mockReturnValue("/");
+  });
+
+  it("marks the active navigation link", () => {
+    USE_PATHNAME_MOCK.mockReturnValue(ROUTES.dashboard.trips);
+
+    render(<Navbar />);
+
+    expect(screen.getByRole("link", { name: "Trips" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+    expect(screen.getByRole("link", { name: "Home" })).not.toHaveAttribute(
+      "aria-current"
+    );
+  });
+
+  it("opens the mobile navigation with auth actions", async () => {
+    const user = userEvent.setup();
+
+    render(<Navbar />);
+
+    await user.click(screen.getByRole("button", { name: "Open navigation menu" }));
+
+    const mobileNav = screen.getByRole("navigation", {
+      name: "Mobile navigation",
+    });
+
+    expect(within(mobileNav).getByRole("link", { name: "Home" })).toHaveAttribute(
+      "href",
+      "/"
+    );
+    expect(within(mobileNav).getByRole("link", { name: "Log in" })).toHaveAttribute(
+      "href",
+      ROUTES.login
+    );
+    expect(within(mobileNav).getByRole("link", { name: "Sign up" })).toHaveAttribute(
+      "href",
+      ROUTES.register
+    );
+    expect(
+      screen.getByRole("button", { name: "Close navigation menu" })
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/src/components/layouts/__tests__/user-nav.test.tsx
+++ b/src/components/layouts/__tests__/user-nav.test.tsx
@@ -33,7 +33,9 @@ describe("UserNav", () => {
   it("opens popover and shows menu items", async () => {
     render(<UserNav user={mockUser} />);
 
-    const trigger = screen.getByRole("button");
+    const trigger = screen.getByRole("button", {
+      name: "Open account menu for Test User",
+    });
     await userEvent.click(trigger);
 
     expect(screen.getByText("test@example.com")).toBeInTheDocument();
@@ -48,7 +50,9 @@ describe("UserNav", () => {
     render(<UserNav user={mockUser} />);
 
     // Open popover
-    await userEvent.click(screen.getByRole("button"));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Open account menu for Test User" })
+    );
 
     // Click logout
     await userEvent.click(screen.getByText("Log Out"));

--- a/src/components/layouts/navbar.tsx
+++ b/src/components/layouts/navbar.tsx
@@ -39,12 +39,15 @@ export function Navbar() {
             TripSage<span className="text-highlight ml-1">AI</span>
           </Link>
 
-          {/* Desktop navigation */}
-          <nav className="hidden md:flex items-center gap-6">
+          <nav
+            aria-label="Primary navigation"
+            className="hidden md:flex items-center gap-6"
+          >
             {NavItems.map((item) => (
               <Link
                 key={item.href}
                 href={item.href}
+                aria-current={pathname === item.href ? "page" : undefined}
                 className={cn(
                   "text-sm font-medium transition-colors hover:text-primary flex items-center",
                   pathname === item.href ? "text-primary" : "text-muted-foreground"
@@ -60,10 +63,10 @@ export function Navbar() {
         {/* User section */}
         <div className="flex items-center gap-2">
           <ThemeToggle />
-          <Button variant="outline" size="sm" asChild>
+          <Button variant="outline" size="sm" className="hidden md:inline-flex" asChild>
             <Link href={ROUTES.login}>Log in</Link>
           </Button>
-          <Button size="sm" asChild>
+          <Button size="sm" className="hidden md:inline-flex" asChild>
             <Link href={ROUTES.register}>Sign up</Link>
           </Button>
 
@@ -90,12 +93,17 @@ export function Navbar() {
 
       {/* Mobile navigation */}
       {mobileMenuOpen && (
-        <nav id="mobile-navigation" className="md:hidden py-4 border-t">
+        <nav
+          id="mobile-navigation"
+          aria-label="Mobile navigation"
+          className="md:hidden py-4 border-t"
+        >
           <div className="mx-auto flex w-full max-w-6xl flex-col space-y-3 px-4 sm:px-6 lg:px-8">
             {NavItems.map((item) => (
               <Link
                 key={item.href}
                 href={item.href}
+                aria-current={pathname === item.href ? "page" : undefined}
                 className={cn(
                   "px-2 py-2 text-sm font-medium rounded-md flex items-center",
                   pathname === item.href
@@ -108,6 +116,18 @@ export function Navbar() {
                 {item.name}
               </Link>
             ))}
+            <div className="grid gap-2 border-t pt-3">
+              <Button variant="outline" size="sm" asChild>
+                <Link href={ROUTES.login} onClick={() => setMobileMenuOpen(false)}>
+                  Log in
+                </Link>
+              </Button>
+              <Button size="sm" asChild>
+                <Link href={ROUTES.register} onClick={() => setMobileMenuOpen(false)}>
+                  Sign up
+                </Link>
+              </Button>
+            </div>
           </div>
         </nav>
       )}

--- a/src/components/layouts/user-nav.tsx
+++ b/src/components/layouts/user-nav.tsx
@@ -58,11 +58,16 @@ export function UserNav({ user }: UserNavProps) {
         .toUpperCase()
         .slice(0, 2)
     : user.email?.slice(0, 2).toUpperCase() || "U";
+  const userLabel = user.displayName || user.email || "user";
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="flex items-center gap-2 px-3 py-2">
+        <Button
+          variant="ghost"
+          className="flex items-center gap-2 px-3 py-2"
+          aria-label={`Open account menu for ${userLabel}`}
+        >
           <Avatar className="h-8 w-8">
             <AvatarImage src={user.avatarUrl} alt={user.displayName || "User"} />
             <AvatarFallback className="bg-primary text-primary-foreground">

--- a/src/components/providers/__tests__/query-error-boundary.test.tsx
+++ b/src/components/providers/__tests__/query-error-boundary.test.tsx
@@ -132,6 +132,17 @@ describe("QueryErrorBoundary", () => {
     );
   });
 
+  it("falls back to the internal login URL when loginHref is unsafe", async () => {
+    renderWithProviders(
+      <QueryErrorBoundary loginHref="javascript:alert(1)">
+        <ThrowingComponent error={new ApiError({ message: "auth", status: 401 })} />
+      </QueryErrorBoundary>
+    );
+
+    const loginLink = await screen.findByRole("link", { name: /go to login/i });
+    expect(loginLink).toHaveAttribute("href", "/login");
+  });
+
   it("invokes onOperationalAlert before onError with metadata", async () => {
     const alertHandler = vi.fn();
     const errorHandler = vi.fn();

--- a/src/components/providers/__tests__/web-vitals-reporter.test.tsx
+++ b/src/components/providers/__tests__/web-vitals-reporter.test.tsx
@@ -1,8 +1,10 @@
 /** @vitest-environment jsdom */
 
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WEB_VITALS_ENDPOINT } from "@/lib/telemetry/web-vitals";
+import { server } from "@/test/msw/server";
 
 type CapturedMetric = {
   delta: number;
@@ -80,18 +82,29 @@ describe("WebVitalsReporter", () => {
 
   it("falls back to keepalive fetch when sendBeacon declines the payload", async () => {
     StubSendBeacon(false);
-    const fetch = vi.fn(() => Promise.resolve(new Response(null, { status: 204 })));
-    vi.stubGlobal("fetch", fetch);
+    let fallbackRequestBody: unknown;
+    let fallbackContentType: string | null = null;
+    server.use(
+      http.post(WEB_VITALS_ENDPOINT, async ({ request }) => {
+        fallbackContentType = request.headers.get("content-type");
+        fallbackRequestBody = await request.json();
+        return new HttpResponse(null, { status: 204 });
+      })
+    );
 
     await RenderReporter();
     ReportMetric();
 
-    expect(fetch).toHaveBeenCalledWith(
-      WEB_VITALS_ENDPOINT,
-      expect.objectContaining({
-        keepalive: true,
-        method: "POST",
-      })
-    );
+    await waitFor(() => {
+      expect(fallbackContentType).toBe("application/json");
+      expect(fallbackRequestBody).toEqual({
+        delta: 15,
+        name: "LCP",
+        navigationType: "navigate",
+        rating: "good",
+        route: "/dashboard/trips/:id",
+        value: 1800,
+      });
+    });
   });
 });

--- a/src/components/providers/query-error-boundary.tsx
+++ b/src/components/providers/query-error-boundary.tsx
@@ -15,6 +15,7 @@ import { getErrorMessage, handleApiError } from "@/lib/api/error-types";
 import { normalizeThrownError } from "@/lib/client/normalize-thrown-error";
 import { getSessionId } from "@/lib/client/session";
 import { errorService } from "@/lib/error-service";
+import { safeHref } from "@/lib/url/safe-href";
 import { cn, fireAndForget } from "@/lib/utils";
 
 type ErrorVariant = "network" | "server" | "auth" | "permission" | "default";
@@ -201,7 +202,7 @@ function QueryErrorFallback({
   const display = VARIANT_DISPLAY[meta.variant];
   const showLogin = meta.variant === "auth";
   const message = meta.variant === "default" ? errorMessage : display.message;
-  const resolvedLoginHref = loginHref ?? "/login";
+  const resolvedLoginHref = safeHref(loginHref) ?? "/login";
   const isInternalLoginHref =
     resolvedLoginHref.startsWith("/") && !resolvedLoginHref.startsWith("//");
 

--- a/src/components/settings/__tests__/api-keys-content.test.tsx
+++ b/src/components/settings/__tests__/api-keys-content.test.tsx
@@ -1,0 +1,99 @@
+/** @vitest-environment jsdom */
+
+import { act, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiKeysContent } from "@/components/settings/api-keys-content";
+import { render } from "@/test/test-utils";
+
+const { mockAuthenticatedApi, mockCancelRequests } = vi.hoisted(() => ({
+  mockAuthenticatedApi: {
+    delete: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+  mockCancelRequests: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-authenticated-api", () => ({
+  useAuthenticatedApi: () => ({
+    authenticatedApi: mockAuthenticatedApi,
+    cancelRequests: mockCancelRequests,
+  }),
+}));
+
+vi.mock("@/app/(app)/dashboard/settings/api-keys/actions", () => ({
+  updateGatewayFallbackPreference: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+describe("ApiKeysContent", () => {
+  const createDeferred = <T,>(): Deferred<T> => {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((promiseResolve) => {
+      resolve = promiseResolve;
+    });
+    return { promise, resolve };
+  };
+
+  beforeEach(() => {
+    mockAuthenticatedApi.delete.mockReset();
+    mockAuthenticatedApi.get.mockReset();
+    mockAuthenticatedApi.post.mockReset();
+    mockCancelRequests.mockReset();
+  });
+
+  it("starts key summary and user setting reads concurrently on initial load", async () => {
+    const keysRequest =
+      createDeferred<
+        Array<{
+          createdAt: string;
+          hasKey: boolean;
+          isValid: boolean;
+          service: "openai";
+        }>
+      >();
+    const settingsRequest = createDeferred<{
+      allowGatewayFallback: boolean | null;
+    }>();
+
+    mockAuthenticatedApi.get.mockImplementation((endpoint: string) => {
+      if (endpoint === "/api/keys") return keysRequest.promise;
+      if (endpoint === "/api/user-settings") return settingsRequest.promise;
+      throw new Error(`Unexpected endpoint: ${endpoint}`);
+    });
+
+    render(<ApiKeysContent />);
+
+    await waitFor(() => {
+      expect(mockAuthenticatedApi.get).toHaveBeenCalledWith("/api/keys");
+      expect(mockAuthenticatedApi.get).toHaveBeenCalledWith("/api/user-settings");
+    });
+
+    await act(async () => {
+      keysRequest.resolve([
+        {
+          createdAt: "2026-01-01T00:00:00.000Z",
+          hasKey: true,
+          isValid: true,
+          service: "openai",
+        },
+      ]);
+      settingsRequest.resolve({ allowGatewayFallback: true });
+      await Promise.all([keysRequest.promise, settingsRequest.promise]);
+    });
+
+    expect(
+      await screen.findByRole("combobox", { name: "Provider" })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("API Key")).toBeInTheDocument();
+    await expect(
+      screen.getByRole("switch", { name: "Allow fallback to team Gateway" })
+    ).toHaveAccessibleDescription(
+      "When no BYOK key is present, permit using the team Vercel AI Gateway. You can change this at any time. Some features may require an active provider key if disabled."
+    );
+  });
+});

--- a/src/components/settings/api-keys-content.tsx
+++ b/src/components/settings/api-keys-content.tsx
@@ -276,6 +276,9 @@ export function ApiKeysContent() {
   // Generate unique ids for form controls to satisfy accessibility and lint rules
   const serviceId = useId();
   const apiKeyId = useId();
+  const gatewayFallbackLabelId = useId();
+  const gatewayFallbackDescriptionId = useId();
+  const gatewayFallbackNoteId = useId();
 
   return (
     <div className="container mx-auto max-w-3xl space-y-6 py-8">
@@ -421,19 +424,26 @@ export function ApiKeysContent() {
             <>
               <div className="flex items-center justify-between py-2">
                 <div className="space-y-1">
-                  <div className="font-medium">Allow fallback to team Gateway</div>
-                  <div className="text-sm text-muted-foreground">
+                  <div className="font-medium" id={gatewayFallbackLabelId}>
+                    Allow fallback to team Gateway
+                  </div>
+                  <div
+                    className="text-sm text-muted-foreground"
+                    id={gatewayFallbackDescriptionId}
+                  >
                     When no BYOK key is present, permit using the team Vercel AI
                     Gateway.
                   </div>
                 </div>
                 <Switch
+                  aria-describedby={`${gatewayFallbackDescriptionId} ${gatewayFallbackNoteId}`}
+                  aria-labelledby={gatewayFallbackLabelId}
                   checked={allowGatewayFallback === true}
                   disabled={isBusy || allowGatewayFallback === null || isPending}
                   onCheckedChange={onToggleFallback}
                 />
               </div>
-              <div className="text-xs text-muted-foreground">
+              <div className="text-xs text-muted-foreground" id={gatewayFallbackNoteId}>
                 You can change this at any time. Some features may require an active
                 provider key if disabled.
               </div>

--- a/src/components/ui/__mocks__/use-toast.ts
+++ b/src/components/ui/__mocks__/use-toast.ts
@@ -4,6 +4,7 @@
  */
 
 import { vi } from "vitest";
+import { secureId } from "@/lib/security/random";
 import type { Toast } from "../use-toast";
 
 /**
@@ -15,7 +16,7 @@ import type { Toast } from "../use-toast";
  */
 export const toast = vi.fn((_props: Toast) => ({
   dismiss: vi.fn(),
-  id: `toast-${Date.now()}`,
+  id: `toast-${secureId()}`,
   update: vi.fn(),
 }));
 

--- a/src/components/ui/__tests__/current-year.test.tsx
+++ b/src/components/ui/__tests__/current-year.test.tsx
@@ -1,0 +1,19 @@
+/** @vitest-environment jsdom */
+
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen } from "@/test/test-utils";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
+import { CurrentYear } from "../current-year";
+
+describe("CurrentYear", () => {
+  it(
+    "renders the current year from the canonical clock helper",
+    withFakeTimers(() => {
+      vi.setSystemTime(new Date("2026-02-03T04:05:06.000Z"));
+
+      renderWithProviders(<CurrentYear />);
+
+      expect(screen.getByText("2026")).toBeInTheDocument();
+    })
+  );
+});

--- a/src/components/ui/__tests__/error-boundary.test.tsx
+++ b/src/components/ui/__tests__/error-boundary.test.tsx
@@ -203,9 +203,10 @@ describe("PageErrorFallback", () => {
     render(<PageErrorFallback error={error} />);
 
     expect(screen.getByText("Page Error")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /go to dashboard/i })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /go to dashboard/i })).toHaveAttribute(
+      "href",
+      "/dashboard"
+    );
   });
 
   it("calls reset when Try Again is clicked", () => {

--- a/src/components/ui/current-year.tsx
+++ b/src/components/ui/current-year.tsx
@@ -1,8 +1,14 @@
 "use client";
 
+import { nowIso } from "@/lib/security/random";
+
+function GetCurrentYear() {
+  return new Date(nowIso()).getFullYear();
+}
+
 /**
  * Displays the current year on the client to avoid server prerender time coupling.
  */
 export function CurrentYear() {
-  return <>{new Date().getFullYear()}</>;
+  return <>{GetCurrentYear()}</>;
 }

--- a/src/domain/accommodations/__tests__/service-amadeus.test.ts
+++ b/src/domain/accommodations/__tests__/service-amadeus.test.ts
@@ -77,6 +77,11 @@ describe("AccommodationsService (Amadeus)", () => {
   });
 
   it("injects geocoded lat/lng and maps provider search result", async () => {
+    const performanceNowSpy = vi
+      .spyOn(performance, "now")
+      .mockReturnValueOnce(12.25)
+      .mockReturnValueOnce(42.75)
+      .mockReturnValue(42.75);
     const provider: AccommodationProviderAdapter = {
       buildBookingPayload: vi.fn(),
       checkAvailability: vi.fn(),
@@ -109,21 +114,26 @@ describe("AccommodationsService (Amadeus)", () => {
       provider,
     });
 
-    const result = await service.search({
-      checkin: "2025-12-01",
-      checkout: "2025-12-02",
-      guests: 1,
-      location: "Paris",
-    });
+    try {
+      const result = await service.search({
+        checkin: "2025-12-01",
+        checkout: "2025-12-02",
+        guests: 1,
+        location: "Paris",
+      });
 
-    expect(result.searchParameters?.lat).toBeCloseTo(1.234);
-    expect(result.searchParameters?.lng).toBeCloseTo(2.345);
-    expect(result.provider).toBe("amadeus");
-    expect(result.resultsReturned).toBe(1);
-    const searchMock = vi.mocked(provider.search);
-    const [searchCallArgs] = searchMock.mock.calls[0] ?? [];
-    expect(searchCallArgs?.lat).toBeCloseTo(1.234);
-    expect(searchCallArgs?.lng).toBeCloseTo(2.345);
+      expect(result.searchParameters?.lat).toBeCloseTo(1.234);
+      expect(result.searchParameters?.lng).toBeCloseTo(2.345);
+      expect(result.provider).toBe("amadeus");
+      expect(result.resultsReturned).toBe(1);
+      expect(result.tookMs).toBe(30.5);
+      const searchMock = vi.mocked(provider.search);
+      const [searchCallArgs] = searchMock.mock.calls[0] ?? [];
+      expect(searchCallArgs?.lat).toBeCloseTo(1.234);
+      expect(searchCallArgs?.lng).toBeCloseTo(2.345);
+    } finally {
+      performanceNowSpy.mockRestore();
+    }
   });
 
   it("keeps listings when cheaper rates are not first", async () => {

--- a/src/domain/accommodations/providers/__tests__/amadeus-adapter.test.ts
+++ b/src/domain/accommodations/providers/__tests__/amadeus-adapter.test.ts
@@ -5,13 +5,18 @@ import {
   AmadeusProviderAdapter,
   mapStatusToProviderCode,
 } from "@domain/accommodations/providers/amadeus-adapter";
-import { vi } from "vitest";
+import { beforeEach, vi } from "vitest";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
 
 vi.mock("@domain/amadeus/client", () => ({
   bookHotelOffer: vi.fn(),
   listHotelsByGeocode: vi.fn(),
   searchHotelOffers: vi.fn(),
 }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe("AmadeusProviderAdapter.buildBookingPayload", () => {
   it("maps Stripe PaymentIntent into Amadeus payments payload", () => {
@@ -70,6 +75,94 @@ describe("AmadeusProviderAdapter.buildBookingPayload", () => {
     });
     expect(data.remarks?.general?.[0]?.text).toContain("StripePaymentIntent=pi_abc123");
   });
+});
+
+describe("AmadeusProviderAdapter.getDetails", () => {
+  it(
+    "defaults missing details dates to current and next UTC ISO dates",
+    withFakeTimers(async () => {
+      vi.setSystemTime(new Date("2025-12-31T23:30:00Z"));
+
+      const adapter = new AmadeusProviderAdapter();
+      const { searchHotelOffers } = await import("@domain/amadeus/client");
+      vi.mocked(searchHotelOffers).mockResolvedValue({ data: [] } as never);
+
+      const result = await adapter.getDetails(
+        { listingId: "H123" },
+        { sessionId: "sess-1", userId: "user-1" }
+      );
+
+      expect(result.ok).toBe(true);
+      expect(searchHotelOffers).toHaveBeenCalledWith({
+        adults: 1,
+        checkInDate: "2025-12-31",
+        checkOutDate: "2026-01-01",
+        hotelIds: ["H123"],
+      });
+    })
+  );
+});
+
+describe("AmadeusProviderAdapter.checkAvailability", () => {
+  it(
+    "sets availability token expiry from the current timestamp helper",
+    withFakeTimers(async () => {
+      vi.setSystemTime(new Date("2026-02-03T04:05:06.000Z"));
+
+      const adapter = new AmadeusProviderAdapter();
+      const { searchHotelOffers } = await import("@domain/amadeus/client");
+      vi.mocked(searchHotelOffers).mockResolvedValue({
+        data: [
+          {
+            hotel: { hotelId: "H123", name: "Hotel Example" },
+            offers: [
+              {
+                checkInDate: "2026-02-10",
+                checkOutDate: "2026-02-12",
+                id: "RATE-1",
+                price: {
+                  base: "100.00",
+                  currency: "USD",
+                  total: "118.40",
+                },
+              },
+            ],
+          },
+        ],
+      } as never);
+
+      const result = await adapter.checkAvailability(
+        {
+          checkIn: "2026-02-10",
+          checkOut: "2026-02-12",
+          guests: 2,
+          priceCheckToken: "RATE-1",
+          propertyId: "H123",
+          rateId: "RATE-1",
+          roomId: "ROOM-1",
+        },
+        { sessionId: "sess-1", userId: "user-1" }
+      );
+
+      expect(result).toEqual({
+        ok: true,
+        retries: 0,
+        value: {
+          bookingToken: "RATE-1",
+          expiresAt: "2026-02-03T04:15:06.000Z",
+          price: {
+            breakdown: {
+              base: "100.00",
+            },
+            currency: "USD",
+            total: "118.40",
+          },
+          propertyId: "H123",
+          rateId: "RATE-1",
+        },
+      });
+    })
+  );
 });
 
 describe("AmadeusProviderAdapter error normalization", () => {
@@ -191,4 +284,33 @@ describe("AmadeusProviderAdapter error normalization", () => {
       vi.useRealTimers();
     }
   });
+
+  it(
+    "clears timeout when the provider operation throws synchronously",
+    withFakeTimers(async () => {
+      const adapter = new AmadeusProviderAdapter({ timeoutMs: 1_000 });
+      const { listHotelsByGeocode, searchHotelOffers } = await import(
+        "@domain/amadeus/client"
+      );
+      vi.mocked(listHotelsByGeocode).mockImplementation(() => {
+        throw new Error("sync provider failure");
+      });
+      vi.mocked(searchHotelOffers).mockResolvedValue({ data: [] } as never);
+
+      const result = await adapter.search(
+        {
+          checkin: "2025-12-01",
+          checkout: "2025-12-02",
+          guests: 1,
+          lat: 1,
+          lng: 1,
+          location: "Paris",
+        },
+        { sessionId: "sess-123", userId: "user-123" }
+      );
+
+      expect(result.ok).toBe(false);
+      expect(vi.getTimerCount()).toBe(0);
+    })
+  );
 });

--- a/src/domain/accommodations/providers/amadeus-adapter.ts
+++ b/src/domain/accommodations/providers/amadeus-adapter.ts
@@ -22,7 +22,9 @@ import type {
   AccommodationDetailsParams,
   AccommodationSearchParams,
 } from "@schemas/accommodations";
+import { todayUtcIsoDate, toUtcIsoDate } from "@/lib/dates/unified-date-utils";
 import { retryWithBackoff } from "@/lib/http/retry";
+import { nowIso } from "@/lib/security/random";
 import { hashTelemetryIdentifier } from "@/lib/telemetry/identifiers";
 import { withTelemetrySpan } from "@/lib/telemetry/span";
 import type {
@@ -38,6 +40,8 @@ import type {
 
 const DEFAULT_PROVIDER_TIMEOUT_MS = 8_000;
 const DEFAULT_RETRYABLE_CODES = new Set([429, 408, 500, 502, 503, 504]);
+const AVAILABILITY_TOKEN_TTL_MS = 10 * 60 * 1000;
+const ONE_DAY_MS = 86_400_000;
 
 /** Adapter configuration options. */
 type AdapterConfig = {
@@ -143,12 +147,11 @@ export class AmadeusProviderAdapter implements AccommodationProviderAdapter {
     ctx?: ProviderContext
   ): Promise<ProviderResult<ProviderDetailsResult>> {
     return this.execute("details", ctx, async () => {
+      const nowMs = currentTimeMs();
       const offers = await searchHotelOffers({
         adults: params.adults ?? 1,
-        checkInDate: params.checkin ?? new Date().toISOString().slice(0, 10),
-        checkOutDate:
-          params.checkout ??
-          new Date(Date.now() + 86_400_000).toISOString().slice(0, 10),
+        checkInDate: params.checkin ?? todayUtcIsoDate(nowMs),
+        checkOutDate: params.checkout ?? toUtcIsoDate(new Date(nowMs + ONE_DAY_MS)),
         hotelIds: [params.listingId],
       });
       const parsed = amadeusHotelOfferContainerSchema.array().parse(offers.data ?? []);
@@ -192,9 +195,12 @@ export class AmadeusProviderAdapter implements AccommodationProviderAdapter {
           provider: this.name,
         });
       }
+      const expiresAt = new Date(
+        currentTimeMs() + AVAILABILITY_TOKEN_TTL_MS
+      ).toISOString();
       return {
         bookingToken: match.id,
-        expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+        expiresAt,
         price: {
           breakdown: {
             base: match.price.base,
@@ -433,16 +439,19 @@ async function withTimeout<T>(
   timeoutMs: number,
   onTimeout: () => Error
 ): Promise<T> {
-  return await new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(onTimeout()), timeoutMs);
-    operation()
-      .then((value) => {
-        clearTimeout(timer);
-        resolve(value);
-      })
-      .catch((error) => {
-        clearTimeout(timer);
-        reject(error);
-      });
-  });
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await new Promise<T>((resolve, reject) => {
+      timer = setTimeout(() => reject(onTimeout()), timeoutMs);
+      Promise.resolve().then(operation).then(resolve, reject);
+    });
+  } finally {
+    if (timer !== null) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+function currentTimeMs(): number {
+  return Date.parse(nowIso());
 }

--- a/src/domain/accommodations/service.ts
+++ b/src/domain/accommodations/service.ts
@@ -128,7 +128,7 @@ export class AccommodationsService {
         redactKeys: ["location", "semanticQuery"],
       },
       async (span) => {
-        const startedAt = Date.now();
+        const startedAt = performance.now();
 
         const baseCacheKey = this.buildCacheKey(params);
         if (baseCacheKey) {
@@ -202,7 +202,7 @@ export class AccommodationsService {
             semanticQuery: params.semanticQuery,
           },
           status: "success" as const,
-          tookMs: Date.now() - startedAt,
+          tookMs: performance.now() - startedAt,
           totalResults: filteredListings.length,
         });
 

--- a/src/domain/activities/__tests__/service.test.ts
+++ b/src/domain/activities/__tests__/service.test.ts
@@ -3,6 +3,7 @@
 import type { Activity, ActivitySearchParams } from "@schemas/search";
 import { describe, expect, it, vi } from "vitest";
 import { unsafeCast } from "@/test/helpers/unsafe-cast";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
 import { NotFoundError } from "../errors";
 import type { ActivitiesCache, PlacesActivitiesAdapter, WebSearchFn } from "../service";
 import { ActivitiesService } from "../service";
@@ -81,36 +82,47 @@ describe("ActivitiesService", () => {
     expect(places.search).not.toHaveBeenCalled();
   });
 
-  it("performs Places search on cache miss and writes to cache", async () => {
-    const placesActivity = makeActivity({ id: "places/1", name: "Museum" });
-    const cache = makeCache();
-    const places = makePlacesAdapter({
-      search: vi.fn(async () => [placesActivity]),
-    });
-    const service = new ActivitiesService({
-      cache,
-      hashInput: () => "qhash",
-      places,
-    });
+  it(
+    "performs Places search on cache miss and writes helper-backed cache timestamps",
+    withFakeTimers(async () => {
+      vi.setSystemTime(new Date("2026-02-03T04:05:06.000Z"));
 
-    const result = await service.search(
-      { category: "museums", destination: "New York" },
-      { userId: "user-1" }
-    );
+      const placesActivity = makeActivity({ id: "places/1", name: "Museum" });
+      const cache = makeCache();
+      const places = makePlacesAdapter({
+        search: vi.fn(async () => [placesActivity]),
+      });
+      const service = new ActivitiesService({
+        cache,
+        hashInput: () => "qhash",
+        places,
+      });
 
-    expect(result.metadata.cached).toBe(false);
-    expect(result.metadata.primarySource).toBe("googleplaces");
-    expect(result.metadata.sources).toEqual(["googleplaces"]);
-    expect(result.activities).toEqual([placesActivity]);
-    expect(cache.putSearch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        destination: "New York",
-        queryHash: "qhash",
-        source: "googleplaces",
-        userId: "user-1",
-      })
-    );
-  });
+      const result = await service.search(
+        { category: "museums", destination: "New York" },
+        { userId: "user-1" }
+      );
+
+      expect(result.metadata.cached).toBe(false);
+      expect(result.metadata.primarySource).toBe("googleplaces");
+      expect(result.metadata.sources).toEqual(["googleplaces"]);
+      expect(result.activities).toEqual([placesActivity]);
+      expect(cache.getSearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nowIso: "2026-02-03T04:05:06.000Z",
+        })
+      );
+      expect(cache.putSearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          destination: "New York",
+          expiresAtIso: "2026-02-04T04:05:06.000Z",
+          queryHash: "qhash",
+          source: "googleplaces",
+          userId: "user-1",
+        })
+      );
+    })
+  );
 
   it("triggers fallback when Places returns zero results", async () => {
     const cache = makeCache();
@@ -145,6 +157,32 @@ describe("ActivitiesService", () => {
     );
     expect(result.activities.some((a) => a.id.startsWith("ai_fallback:"))).toBe(true);
   });
+
+  it(
+    "defaults fallback activity dates to the current UTC ISO date",
+    withFakeTimers(async () => {
+      vi.setSystemTime(new Date("2025-12-31T23:30:00Z"));
+
+      const places = makePlacesAdapter({
+        search: vi.fn(async () => []),
+      });
+      const webSearch: WebSearchFn = vi.fn(async () => ({
+        results: [{ title: "Hidden Gem", url: "https://example.com/activity" }],
+      }));
+      const service = new ActivitiesService({
+        hashInput: () => "qhash",
+        places,
+        webSearch,
+      });
+
+      const result = await service.search(
+        { destination: "Unknown City" },
+        { userId: "user-1" }
+      );
+
+      expect(result.activities[0]?.date).toBe("2025-12-31");
+    })
+  );
 
   it("does not trigger fallback when Places returns sufficient results", async () => {
     const places = makePlacesAdapter({

--- a/src/domain/activities/service.ts
+++ b/src/domain/activities/service.ts
@@ -8,11 +8,14 @@ import { NotFoundError } from "@domain/activities/errors";
 import type { ActivitySearchResult, ServiceContext } from "@domain/activities/types";
 import type { Activity, ActivitySearchParams } from "@schemas/search";
 import { activitySearchParamsSchema } from "@schemas/search";
+import { todayUtcIsoDate } from "@/lib/dates/unified-date-utils";
+import { nowIso } from "@/lib/security/random";
 
 /**
  * Cache TTL for Places-backed activity search results (24 hours).
  */
 const PLACES_CACHE_TTL_SECONDS = 24 * 60 * 60;
+const MS_PER_SECOND = 1000;
 
 const AI_FALLBACK_DEFAULT_DURATION_MINUTES = 120;
 const AI_FALLBACK_DEFAULT_PRICE_TIER = 2;
@@ -136,8 +139,8 @@ const noopTelemetry: ActivitiesTelemetry = {
 };
 
 const defaultClock: ActivitiesClock = {
-  now: () => Date.now(),
-  todayIsoDate: () => new Date().toISOString().split("T")[0] ?? "1970-01-01",
+  now: () => Date.parse(nowIso()),
+  todayIsoDate: () => todayUtcIsoDate(),
 };
 
 /**
@@ -337,8 +340,9 @@ export class ActivitiesService {
 
         if (userId && this.deps.cache) {
           try {
-            const expiresAt = new Date(this.clock.now());
-            expiresAt.setSeconds(expiresAt.getSeconds() + PLACES_CACHE_TTL_SECONDS);
+            const expiresAt = new Date(
+              this.clock.now() + PLACES_CACHE_TTL_SECONDS * MS_PER_SECOND
+            );
 
             await this.deps.cache.putSearch({
               activityType,

--- a/src/domain/flights/__tests__/service.test.ts
+++ b/src/domain/flights/__tests__/service.test.ts
@@ -1,6 +1,7 @@
 /** @vitest-environment node */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { unsafeCast } from "@/test/helpers/unsafe-cast";
 
 // Hoisted mocks per testing.md Pattern A
 const mockFetchDuffelOffers = vi.hoisted(() => vi.fn());
@@ -184,8 +185,9 @@ describe("searchFlightsService", () => {
       };
 
       await expect(
-        // @ts-expect-error - Testing invalid input
-        searchFlightsService(invalidRequest)
+        searchFlightsService(
+          unsafeCast<Parameters<typeof searchFlightsService>[0]>(invalidRequest)
+        )
       ).rejects.toThrow();
     });
 

--- a/src/domain/schemas/__tests__/budget.test.ts
+++ b/src/domain/schemas/__tests__/budget.test.ts
@@ -8,6 +8,7 @@ import {
   budgetSchema,
   budgetStateSchema,
   budgetSummarySchema,
+  calculateBudgetSummary,
   createBudgetAlertRequestSchema,
   createBudgetRequestSchema,
   currencyRateSchema,
@@ -259,6 +260,78 @@ describe("budget schemas", () => {
         totalSpent: 2500,
       });
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe("calculateBudgetSummary", () => {
+    it("calculates date-based summary fields from an explicit current date", () => {
+      const summary = calculateBudgetSummary(
+        {
+          categories: [
+            {
+              amount: 2500,
+              category: "flights",
+              id: "123e4567-e89b-12d3-a456-426614174001",
+              percentage: 50,
+              remaining: 2100,
+              spent: 400,
+            },
+            {
+              amount: 2500,
+              category: "food",
+              id: "123e4567-e89b-12d3-a456-426614174002",
+              percentage: 50,
+              remaining: 2500,
+              spent: 0,
+            },
+          ],
+          createdAt: "2025-05-20T12:00:00Z",
+          currency: "USD",
+          endDate: "2025-06-15",
+          id: "123e4567-e89b-12d3-a456-426614174000",
+          isActive: true,
+          name: "Summer Trip",
+          startDate: "2025-06-01",
+          totalAmount: 5000,
+          updatedAt: "2025-05-20T12:00:00Z",
+        },
+        [
+          {
+            amount: 100,
+            budgetId: "123e4567-e89b-12d3-a456-426614174000",
+            category: "flights",
+            createdAt: "2025-06-02T00:00:00Z",
+            currency: "USD",
+            date: "2025-06-02",
+            description: "Flight",
+            id: "123e4567-e89b-12d3-a456-426614174003",
+            isShared: false,
+            updatedAt: "2025-06-02T00:00:00Z",
+          },
+          {
+            amount: 300,
+            budgetId: "123e4567-e89b-12d3-a456-426614174000",
+            category: "food",
+            createdAt: "2025-06-03T00:00:00Z",
+            currency: "USD",
+            date: "2025-06-03",
+            description: "Meals",
+            id: "123e4567-e89b-12d3-a456-426614174004",
+            isShared: false,
+            updatedAt: "2025-06-03T00:00:00Z",
+          },
+        ],
+        { currentDate: "2025-06-05T00:00:00.000Z" }
+      );
+
+      expect(summary.daysRemaining).toBe(10);
+      expect(summary.dailyAverage).toBe(100);
+      expect(summary.dailyLimit).toBe(460);
+      expect(summary.projectedTotal).toBe(1400);
+      expect(summary.spentByCategory).toEqual({
+        flights: 100,
+        food: 300,
+      });
     });
   });
 

--- a/src/domain/schemas/__tests__/budget.test.ts
+++ b/src/domain/schemas/__tests__/budget.test.ts
@@ -333,6 +333,28 @@ describe("budget schemas", () => {
         food: 300,
       });
     });
+
+    it("does not over-count remaining days before the budget start date", () => {
+      const summary = calculateBudgetSummary(
+        {
+          categories: [],
+          createdAt: "2025-05-20T12:00:00Z",
+          currency: "USD",
+          endDate: "2025-06-15",
+          id: "123e4567-e89b-12d3-a456-426614174000",
+          isActive: true,
+          name: "Future Trip",
+          startDate: "2025-06-01",
+          totalAmount: 5000,
+          updatedAt: "2025-05-20T12:00:00Z",
+        },
+        [],
+        { currentDate: "2025-05-25T00:00:00.000Z" }
+      );
+
+      expect(summary.daysRemaining).toBe(14);
+      expect(summary.dailyAverage).toBe(0);
+    });
   });
 
   describe("budgetAlertSchema", () => {

--- a/src/domain/schemas/__tests__/currency.test.ts
+++ b/src/domain/schemas/__tests__/currency.test.ts
@@ -1,0 +1,36 @@
+/** @vitest-environment node */
+
+import * as currencySchemas from "@schemas/currency";
+import { CURRENCY_CODE_SCHEMA } from "@schemas/shared/money";
+import { describe, expect, it } from "vitest";
+
+describe("currency schemas", () => {
+  it("keeps currency code validation owned by the shared money module", () => {
+    expect(CURRENCY_CODE_SCHEMA.safeParse("USD").success).toBe(true);
+    expect(CURRENCY_CODE_SCHEMA.safeParse("usd").success).toBe(false);
+    expect(Object.hasOwn(currencySchemas, "CURRENCY_CODE_SCHEMA")).toBe(false);
+  });
+
+  it("validates currency metadata with the shared code schema", () => {
+    const parsed = currencySchemas.CURRENCY_SCHEMA.safeParse({
+      code: "EUR",
+      decimals: 2,
+      flag: "EU",
+      name: "Euro",
+      symbol: "EUR",
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects invalid currency codes in currency metadata", () => {
+    const parsed = currencySchemas.CURRENCY_SCHEMA.safeParse({
+      code: "eur",
+      decimals: 2,
+      name: "Euro",
+      symbol: "EUR",
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/src/domain/schemas/__tests__/performance.test.ts
+++ b/src/domain/schemas/__tests__/performance.test.ts
@@ -91,7 +91,7 @@ describe("Validation Performance", () => {
     });
 
     it.concurrent("should validate future date quickly", () => {
-      const futureDate = new Date(Date.now() + 86400000).toISOString();
+      const futureDate = "2999-01-01T00:00:00Z";
       const start = performance.now();
 
       for (let i = 0; i < iterations; i++) {

--- a/src/domain/schemas/__tests__/profile.test.ts
+++ b/src/domain/schemas/__tests__/profile.test.ts
@@ -1,0 +1,60 @@
+/** @vitest-environment node */
+
+import { createPersonalInfoFormSchema, personalInfoFormSchema } from "@schemas/profile";
+import { describe, expect, it } from "vitest";
+
+const VALID_PROFILE = {
+  displayName: "Alex Traveler",
+  firstName: "Alex",
+  lastName: "Traveler",
+};
+
+describe("profile schemas", () => {
+  describe("personalInfoFormSchema", () => {
+    const schema = createPersonalInfoFormSchema("2026-05-25T12:00:00.000");
+
+    it("rejects users who have not reached the minimum age birthday", () => {
+      expect(
+        schema.safeParse({
+          ...VALID_PROFILE,
+          dateOfBirth: "2013-05-26",
+        }).success
+      ).toBe(false);
+    });
+
+    it("accepts users on the minimum age birthday", () => {
+      expect(
+        schema.safeParse({
+          ...VALID_PROFILE,
+          dateOfBirth: "2013-05-25",
+        }).success
+      ).toBe(true);
+    });
+
+    it("rejects users past the maximum age birthday", () => {
+      expect(
+        schema.safeParse({
+          ...VALID_PROFILE,
+          dateOfBirth: "1905-05-25",
+        }).success
+      ).toBe(false);
+    });
+
+    it("rejects impossible ISO date values", () => {
+      expect(
+        schema.safeParse({
+          ...VALID_PROFILE,
+          dateOfBirth: "2013-02-31",
+        }).success
+      ).toBe(false);
+    });
+
+    it("keeps the default personal info schema available", () => {
+      expect(
+        personalInfoFormSchema.safeParse({
+          ...VALID_PROFILE,
+        }).success
+      ).toBe(true);
+    });
+  });
+});

--- a/src/domain/schemas/__tests__/registry.test.ts
+++ b/src/domain/schemas/__tests__/registry.test.ts
@@ -1,6 +1,7 @@
 /** @vitest-environment node */
 
 import {
+  createFutureDateSchema,
   type Email,
   type IsoDateTime,
   primitiveSchemas,
@@ -274,16 +275,21 @@ describe("transformSchemas", () => {
 
 describe("refinedSchemas", () => {
   describe("futureDate", () => {
-    it.concurrent("should validate future date", () => {
-      const futureDate = new Date(Date.now() + 86400000).toISOString(); // Tomorrow
-      const result = refinedSchemas.futureDate.safeParse(futureDate);
+    it.concurrent("creates deterministic future-date schemas", () => {
+      const schema = createFutureDateSchema("2025-06-01T00:00:00Z");
+      const result = schema.safeParse("2025-06-01T00:00:01Z");
       expect(result.success).toBe(true);
     });
 
-    it.concurrent("should reject past date", () => {
-      const pastDate = new Date(Date.now() - 86400000).toISOString(); // Yesterday
-      const result = refinedSchemas.futureDate.safeParse(pastDate);
+    it.concurrent("rejects values before the deterministic reference date", () => {
+      const schema = createFutureDateSchema("2025-06-01T00:00:00Z");
+      const result = schema.safeParse("2025-05-31T23:59:59Z");
       expect(result.success).toBe(false);
+    });
+
+    it.concurrent("keeps the registry future-date schema available", () => {
+      const result = refinedSchemas.futureDate.safeParse("2999-01-01T00:00:00Z");
+      expect(result.success).toBe(true);
     });
   });
 

--- a/src/domain/schemas/__tests__/runtime-clock.test.ts
+++ b/src/domain/schemas/__tests__/runtime-clock.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { schemaNowIso } from "../shared/runtime-clock";
+
+describe("schemaNowIso", () => {
+  it("normalizes deterministic timestamp references", () => {
+    const isoTimestamp = "2026-05-25T12:34:56.789Z";
+
+    expect(schemaNowIso(Date.parse(isoTimestamp))).toBe(isoTimestamp);
+    expect(schemaNowIso(isoTimestamp)).toBe(isoTimestamp);
+    expect(schemaNowIso(new Date(isoTimestamp))).toBe(isoTimestamp);
+  });
+
+  it("returns a current ISO timestamp by default", () => {
+    const beforeMs = Date.now();
+    const timestamp = schemaNowIso();
+    const afterMs = Date.now();
+
+    const parsedMs = Date.parse(timestamp);
+
+    expect(timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(parsedMs).toBeGreaterThanOrEqual(beforeMs);
+    expect(parsedMs).toBeLessThanOrEqual(afterMs);
+  });
+
+  it("rejects invalid timestamp references", () => {
+    expect(() => schemaNowIso("not-a-date")).toThrow(
+      "Invalid schema timestamp reference"
+    );
+  });
+});

--- a/src/domain/schemas/__tests__/shared-time.test.ts
+++ b/src/domain/schemas/__tests__/shared-time.test.ts
@@ -1,6 +1,7 @@
 /** @vitest-environment node */
 
 import {
+  createFutureLocalDateSchema,
   DATE_RANGE_SCHEMA,
   FUTURE_DATE_SCHEMA,
   ISO_DATE_STRING,
@@ -183,29 +184,28 @@ describe("ISO_DATETIME_STRING", () => {
 
 describe("FUTURE_DATE_SCHEMA", () => {
   describe("valid future dates", () => {
-    it.concurrent("should accept date in the future", () => {
-      // Create a date 1 year from now
-      const futureDate = new Date();
-      futureDate.setFullYear(futureDate.getFullYear() + 1);
-      const dateStr = futureDate.toISOString().split("T")[0];
+    it.concurrent("should accept dates after a deterministic reference day", () => {
+      const schema = createFutureLocalDateSchema("2025-06-01T12:00:00");
+      const result = schema.safeParse("2025-06-02");
+      expect(result.success).toBe(true);
+    });
 
-      const result = FUTURE_DATE_SCHEMA.safeParse(dateStr);
+    it.concurrent("keeps the default future-date schema available", () => {
+      const result = FUTURE_DATE_SCHEMA.safeParse("2999-01-01");
       expect(result.success).toBe(true);
     });
   });
 
   describe("invalid dates", () => {
-    it.concurrent("should reject date in the past", () => {
-      const result = FUTURE_DATE_SCHEMA.safeParse("2020-01-01");
+    it.concurrent("should reject dates before a deterministic reference day", () => {
+      const schema = createFutureLocalDateSchema("2025-06-01T12:00:00");
+      const result = schema.safeParse("2025-05-31");
       expect(result.success).toBe(false);
     });
 
-    it.concurrent("should reject yesterday", () => {
-      const yesterday = new Date();
-      yesterday.setDate(yesterday.getDate() - 1);
-      const dateStr = yesterday.toISOString().split("T")[0];
-
-      const result = FUTURE_DATE_SCHEMA.safeParse(dateStr);
+    it.concurrent("should reject the deterministic reference day", () => {
+      const schema = createFutureLocalDateSchema("2025-06-01T12:00:00");
+      const result = schema.safeParse("2025-06-01");
       expect(result.success).toBe(false);
     });
   });

--- a/src/domain/schemas/budget.ts
+++ b/src/domain/schemas/budget.ts
@@ -3,7 +3,6 @@
  */
 
 import { z } from "zod";
-import { nowIso } from "@/lib/security/random";
 import { primitiveSchemas } from "./registry";
 
 // ===== CORE SCHEMAS =====
@@ -455,6 +454,8 @@ export type BudgetState = z.infer<typeof budgetStateSchema>;
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
+const currentIsoTimestamp = (): string => new Date().toISOString();
+
 type BudgetSummaryOptions = {
   /** Date used for time-based summary calculations. Defaults to the current clock. */
   currentDate?: Date | number | string;
@@ -477,7 +478,7 @@ const getBudgetTimestampMs = (value: Date | number | string): number => {
 
 const getCurrentBudgetTimestampMs = (
   currentDate: BudgetSummaryOptions["currentDate"]
-): number => getBudgetTimestampMs(currentDate ?? nowIso());
+): number => getBudgetTimestampMs(currentDate ?? currentIsoTimestamp());
 
 /**
  * Validates budget data from external sources.

--- a/src/domain/schemas/budget.ts
+++ b/src/domain/schemas/budget.ts
@@ -3,7 +3,9 @@
  */
 
 import { z } from "zod";
+
 import { primitiveSchemas } from "./registry";
+import { schemaNowIso } from "./shared/runtime-clock";
 
 // ===== CORE SCHEMAS =====
 // Core business logic schemas for budget and expense management
@@ -454,8 +456,6 @@ export type BudgetState = z.infer<typeof budgetStateSchema>;
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
-const currentIsoTimestamp = (): string => new Date().toISOString();
-
 type BudgetSummaryOptions = {
   /** Date used for time-based summary calculations. Defaults to the current clock. */
   currentDate?: Date | number | string;
@@ -478,7 +478,7 @@ const getBudgetTimestampMs = (value: Date | number | string): number => {
 
 const getCurrentBudgetTimestampMs = (
   currentDate: BudgetSummaryOptions["currentDate"]
-): number => getBudgetTimestampMs(currentDate ?? currentIsoTimestamp());
+): number => getBudgetTimestampMs(currentDate ?? schemaNowIso());
 
 /**
  * Validates budget data from external sources.

--- a/src/domain/schemas/budget.ts
+++ b/src/domain/schemas/budget.ts
@@ -536,6 +536,7 @@ export const safeValidateExpense = (data: unknown) => {
  *
  * @param budget - Budget to analyze
  * @param expenses - Associated expenses for calculation
+ * @param options - Optional calculation controls, including the current date.
  * @returns Comprehensive budget summary with percentages and projections
  *
  * @example
@@ -581,7 +582,10 @@ export const calculateBudgetSummary = (
     const currentTimestampMs = getCurrentBudgetTimestampMs(options.currentDate);
 
     const totalDays = Math.ceil((endTimestampMs - startTimestampMs) / MS_PER_DAY);
-    const daysPassed = Math.ceil((currentTimestampMs - startTimestampMs) / MS_PER_DAY);
+    const daysPassed = Math.max(
+      0,
+      Math.ceil((currentTimestampMs - startTimestampMs) / MS_PER_DAY)
+    );
     daysRemaining = Math.max(0, totalDays - daysPassed);
 
     if (daysPassed > 0) {

--- a/src/domain/schemas/budget.ts
+++ b/src/domain/schemas/budget.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from "zod";
+import { nowIso } from "@/lib/security/random";
 import { primitiveSchemas } from "./registry";
 
 // ===== CORE SCHEMAS =====
@@ -452,6 +453,32 @@ export type BudgetState = z.infer<typeof budgetStateSchema>;
 // ===== UTILITY FUNCTIONS =====
 // Validation helpers and business logic functions
 
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+type BudgetSummaryOptions = {
+  /** Date used for time-based summary calculations. Defaults to the current clock. */
+  currentDate?: Date | number | string;
+};
+
+const getBudgetTimestampMs = (value: Date | number | string): number => {
+  const timestampMs =
+    value instanceof Date
+      ? value.getTime()
+      : typeof value === "number"
+        ? value
+        : Date.parse(value);
+
+  if (!Number.isFinite(timestampMs)) {
+    throw new Error("Invalid budget summary date");
+  }
+
+  return timestampMs;
+};
+
+const getCurrentBudgetTimestampMs = (
+  currentDate: BudgetSummaryOptions["currentDate"]
+): number => getBudgetTimestampMs(currentDate ?? nowIso());
+
 /**
  * Validates budget data from external sources.
  * Performs comprehensive validation including category allocation checks.
@@ -520,7 +547,8 @@ export const safeValidateExpense = (data: unknown) => {
  */
 export const calculateBudgetSummary = (
   budget: Budget,
-  expenses: Expense[]
+  expenses: Expense[],
+  options: BudgetSummaryOptions = {}
 ): BudgetSummary => {
   const budgetExpenses = expenses.filter((expense) => expense.budgetId === budget.id);
   const totalSpent = budgetExpenses.reduce((sum, expense) => sum + expense.amount, 0);
@@ -547,16 +575,12 @@ export const calculateBudgetSummary = (
   let daysRemaining: number | undefined;
 
   if (budget.startDate && budget.endDate) {
-    const startDate = new Date(budget.startDate);
-    const endDate = new Date(budget.endDate);
-    const today = new Date();
+    const startTimestampMs = getBudgetTimestampMs(budget.startDate);
+    const endTimestampMs = getBudgetTimestampMs(budget.endDate);
+    const currentTimestampMs = getCurrentBudgetTimestampMs(options.currentDate);
 
-    const totalDays = Math.ceil(
-      (endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)
-    );
-    const daysPassed = Math.ceil(
-      (today.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)
-    );
+    const totalDays = Math.ceil((endTimestampMs - startTimestampMs) / MS_PER_DAY);
+    const daysPassed = Math.ceil((currentTimestampMs - startTimestampMs) / MS_PER_DAY);
     daysRemaining = Math.max(0, totalDays - daysPassed);
 
     if (daysPassed > 0) {

--- a/src/domain/schemas/budget.ts
+++ b/src/domain/schemas/budget.ts
@@ -536,7 +536,8 @@ export const safeValidateExpense = (data: unknown) => {
  *
  * @param budget - Budget to analyze
  * @param expenses - Associated expenses for calculation
- * @param options - Optional calculation controls, including the current date.
+ * @param options - Optional calculation settings; defaults to `{}` and supports
+ * injected `currentDate` for deterministic time-based projections.
  * @returns Comprehensive budget summary with percentages and projections
  *
  * @example
@@ -582,9 +583,9 @@ export const calculateBudgetSummary = (
     const currentTimestampMs = getCurrentBudgetTimestampMs(options.currentDate);
 
     const totalDays = Math.ceil((endTimestampMs - startTimestampMs) / MS_PER_DAY);
-    const daysPassed = Math.max(
-      0,
-      Math.ceil((currentTimestampMs - startTimestampMs) / MS_PER_DAY)
+    const daysPassed = Math.min(
+      totalDays,
+      Math.max(0, Math.ceil((currentTimestampMs - startTimestampMs) / MS_PER_DAY))
     );
     daysRemaining = Math.max(0, totalDays - daysPassed);
 

--- a/src/domain/schemas/currency.ts
+++ b/src/domain/schemas/currency.ts
@@ -6,9 +6,6 @@ import { z } from "zod";
 import { primitiveSchemas } from "./registry";
 import { CURRENCY_CODE_SCHEMA } from "./shared/money";
 
-// Re-export for backwards compatibility
-export { CURRENCY_CODE_SCHEMA };
-
 // ===== CORE SCHEMAS =====
 // Core business logic schemas for currency management
 

--- a/src/domain/schemas/profile.ts
+++ b/src/domain/schemas/profile.ts
@@ -72,6 +72,9 @@ const getReferenceDateParts = (reference?: DateOfBirthReference): DateParts => {
 /**
  * Zod schema for personal information form validation.
  * Validates user profile data including name, bio, location, and contact information.
+ *
+ * @param referenceDate - Optional reference date for age validation.
+ * @returns Zod schema for personal information form validation.
  */
 export const createPersonalInfoFormSchema = (referenceDate?: DateOfBirthReference) =>
   z.object({
@@ -106,6 +109,7 @@ export const createPersonalInfoFormSchema = (referenceDate?: DateOfBirthReferenc
     website: primitiveSchemas.url.optional().or(z.literal("")),
   });
 
+/** Default personal information form schema using the runtime date for age validation. */
 export const personalInfoFormSchema = createPersonalInfoFormSchema();
 
 /** TypeScript type for personal information form data. */

--- a/src/domain/schemas/profile.ts
+++ b/src/domain/schemas/profile.ts
@@ -73,8 +73,8 @@ const getReferenceDateParts = (reference?: DateOfBirthReference): DateParts => {
  * Zod schema for personal information form validation.
  * Validates user profile data including name, bio, location, and contact information.
  *
- * @param referenceDate - Optional reference date for age validation.
- * @returns Zod schema for personal information form validation.
+ * @param referenceDate - Optional reference date used to evaluate age bounds.
+ * @returns Zod schema for personal information form data.
  */
 export const createPersonalInfoFormSchema = (referenceDate?: DateOfBirthReference) =>
   z.object({
@@ -109,7 +109,7 @@ export const createPersonalInfoFormSchema = (referenceDate?: DateOfBirthReferenc
     website: primitiveSchemas.url.optional().or(z.literal("")),
   });
 
-/** Default personal information form schema using the runtime date for age validation. */
+/** Default personal-info form schema using the runtime clock as DOB reference. */
 export const personalInfoFormSchema = createPersonalInfoFormSchema();
 
 /** TypeScript type for personal information form data. */

--- a/src/domain/schemas/profile.ts
+++ b/src/domain/schemas/profile.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from "zod";
+import { nowIso } from "@/lib/security/random";
 import { primitiveSchemas } from "./registry";
 import { EMAIL_SCHEMA, NAME_SCHEMA, PHONE_SCHEMA } from "./shared/person";
 import { ISO_DATE_STRING } from "./shared/time";
@@ -12,40 +13,99 @@ import { ISO_DATE_STRING } from "./shared/time";
 
 const CURRENCY_SCHEMA = primitiveSchemas.isoCurrency;
 
+type DateParts = {
+  day: number;
+  month: number;
+  year: number;
+};
+
+type DateOfBirthReference = Date | number | string;
+
+const parseIsoDateParts = (date: string): DateParts | null => {
+  const [yearStr, monthStr, dayStr] = date.split("-");
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const day = Number(dayStr);
+
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) {
+    return null;
+  }
+
+  const parsedDate = new Date(year, month - 1, day);
+  if (
+    parsedDate.getFullYear() !== year ||
+    parsedDate.getMonth() !== month - 1 ||
+    parsedDate.getDate() !== day
+  ) {
+    return null;
+  }
+
+  return { day, month, year };
+};
+
+const calculateAge = (birthDate: DateParts, today: DateParts): number => {
+  const birthdayHasPassed =
+    today.month > birthDate.month ||
+    (today.month === birthDate.month && today.day >= birthDate.day);
+
+  return today.year - birthDate.year - (birthdayHasPassed ? 0 : 1);
+};
+
+const getReferenceDateParts = (reference?: DateOfBirthReference): DateParts => {
+  const today =
+    reference instanceof Date
+      ? new Date(reference.getTime())
+      : new Date(reference ?? nowIso());
+
+  if (!Number.isFinite(today.getTime())) {
+    throw new Error("Invalid date-of-birth reference");
+  }
+
+  return {
+    day: today.getDate(),
+    month: today.getMonth() + 1,
+    year: today.getFullYear(),
+  };
+};
+
 /**
  * Zod schema for personal information form validation.
  * Validates user profile data including name, bio, location, and contact information.
  */
-export const personalInfoFormSchema = z.object({
-  bio: z
-    .string()
-    .max(500, { error: "Bio must be less than 500 characters" })
-    .optional(),
-  currency: CURRENCY_SCHEMA.optional(),
-  dateOfBirth: ISO_DATE_STRING.refine(
-    (date) => {
-      const birthDate = new Date(date);
-      const today = new Date();
-      const age = today.getFullYear() - birthDate.getFullYear();
-      return age >= 13 && age <= 120;
-    },
-    { error: "You must be between 13 and 120 years old" }
-  ).optional(),
-  displayName: z
-    .string()
-    .min(1, { error: "Display name is required" })
-    .max(50, { error: "Display name must be less than 50 characters" }),
-  firstName: NAME_SCHEMA,
-  language: z.string().min(2).max(5).optional(),
-  lastName: NAME_SCHEMA,
-  location: z
-    .string()
-    .max(100, { error: "Location must be less than 100 characters" })
-    .optional(),
-  phoneNumber: PHONE_SCHEMA.optional(),
-  timezone: z.string().optional(),
-  website: primitiveSchemas.url.optional().or(z.literal("")),
-});
+export const createPersonalInfoFormSchema = (referenceDate?: DateOfBirthReference) =>
+  z.object({
+    bio: z
+      .string()
+      .max(500, { error: "Bio must be less than 500 characters" })
+      .optional(),
+    currency: CURRENCY_SCHEMA.optional(),
+    dateOfBirth: ISO_DATE_STRING.refine(
+      (date) => {
+        const birthDate = parseIsoDateParts(date);
+        if (!birthDate) return false;
+
+        const age = calculateAge(birthDate, getReferenceDateParts(referenceDate));
+        return age >= 13 && age <= 120;
+      },
+      { error: "You must be between 13 and 120 years old" }
+    ).optional(),
+    displayName: z
+      .string()
+      .min(1, { error: "Display name is required" })
+      .max(50, { error: "Display name must be less than 50 characters" }),
+    firstName: NAME_SCHEMA,
+    language: z.string().min(2).max(5).optional(),
+    lastName: NAME_SCHEMA,
+    location: z
+      .string()
+      .max(100, { error: "Location must be less than 100 characters" })
+      .optional(),
+    phoneNumber: PHONE_SCHEMA.optional(),
+    timezone: z.string().optional(),
+    website: primitiveSchemas.url.optional().or(z.literal("")),
+  });
+
+export const personalInfoFormSchema = createPersonalInfoFormSchema();
 
 /** TypeScript type for personal information form data. */
 export type PersonalInfoFormData = z.infer<typeof personalInfoFormSchema>;

--- a/src/domain/schemas/profile.ts
+++ b/src/domain/schemas/profile.ts
@@ -3,8 +3,10 @@
  */
 
 import { z } from "zod";
+
 import { primitiveSchemas } from "./registry";
 import { EMAIL_SCHEMA, NAME_SCHEMA, PHONE_SCHEMA } from "./shared/person";
+import { schemaNowIso } from "./shared/runtime-clock";
 import { ISO_DATE_STRING } from "./shared/time";
 
 // ===== FORM SCHEMAS =====
@@ -19,8 +21,6 @@ type DateParts = {
 };
 
 type DateOfBirthReference = Date | number | string;
-
-const currentIsoTimestamp = (): string => new Date().toISOString();
 
 const parseIsoDateParts = (date: string): DateParts | null => {
   const [yearStr, monthStr, dayStr] = date.split("-");
@@ -56,7 +56,7 @@ const getReferenceDateParts = (reference?: DateOfBirthReference): DateParts => {
   const today =
     reference instanceof Date
       ? new Date(reference.getTime())
-      : new Date(reference ?? currentIsoTimestamp());
+      : new Date(reference ?? schemaNowIso());
 
   if (!Number.isFinite(today.getTime())) {
     throw new Error("Invalid date-of-birth reference");

--- a/src/domain/schemas/profile.ts
+++ b/src/domain/schemas/profile.ts
@@ -3,7 +3,6 @@
  */
 
 import { z } from "zod";
-import { nowIso } from "@/lib/security/random";
 import { primitiveSchemas } from "./registry";
 import { EMAIL_SCHEMA, NAME_SCHEMA, PHONE_SCHEMA } from "./shared/person";
 import { ISO_DATE_STRING } from "./shared/time";
@@ -20,6 +19,8 @@ type DateParts = {
 };
 
 type DateOfBirthReference = Date | number | string;
+
+const currentIsoTimestamp = (): string => new Date().toISOString();
 
 const parseIsoDateParts = (date: string): DateParts | null => {
   const [yearStr, monthStr, dayStr] = date.split("-");
@@ -55,7 +56,7 @@ const getReferenceDateParts = (reference?: DateOfBirthReference): DateParts => {
   const today =
     reference instanceof Date
       ? new Date(reference.getTime())
-      : new Date(reference ?? nowIso());
+      : new Date(reference ?? currentIsoTimestamp());
 
   if (!Number.isFinite(today.getTime())) {
     throw new Error("Invalid date-of-birth reference");

--- a/src/domain/schemas/registry.ts
+++ b/src/domain/schemas/registry.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from "zod";
+import { nowIso } from "@/lib/security/random";
 
 /**
  * Base primitive schemas with enhanced validation (Zod v4 patterns)
@@ -66,15 +67,50 @@ export const transformSchemas = {
  * Refinement schemas for complex validation
  * Uses Zod v4 .refine() with unified error option
  */
+type DateTimeReference = Date | number | string;
+
+const getDateTimeReferenceMs = (reference: DateTimeReference): number => {
+  const timestampMs =
+    reference instanceof Date
+      ? reference.getTime()
+      : typeof reference === "number"
+        ? reference
+        : Date.parse(reference);
+
+  if (!Number.isFinite(timestampMs)) {
+    throw new Error("Invalid datetime reference");
+  }
+
+  return timestampMs;
+};
+
+/**
+ * Creates an ISO datetime schema that validates values after the supplied reference time.
+ *
+ * @param referenceTime - Optional reference clock. Defaults to the current runtime timestamp.
+ * @returns Zod schema for future ISO datetimes.
+ */
+export const createFutureDateSchema = (referenceTime?: DateTimeReference) =>
+  z.iso.datetime().refine(
+    (date) => {
+      const referenceTimestampMs =
+        referenceTime === undefined
+          ? Date.parse(nowIso())
+          : getDateTimeReferenceMs(referenceTime);
+      return getDateTimeReferenceMs(date) > referenceTimestampMs;
+    },
+    {
+      error: "Date must be in the future",
+    }
+  );
+
 export const refinedSchemas = {
   adultAge: z
     .number()
     .int()
     .min(0)
     .refine((age) => age >= 18, { error: "Must be 18 or older" }),
-  futureDate: z.iso.datetime().refine((date) => new Date(date) > new Date(), {
-    error: "Date must be in the future",
-  }),
+  futureDate: createFutureDateSchema(),
 
   strongPassword: z
     .string()

--- a/src/domain/schemas/registry.ts
+++ b/src/domain/schemas/registry.ts
@@ -4,7 +4,7 @@
 
 import { z } from "zod";
 
-const currentIsoTimestamp = (): string => new Date().toISOString();
+import { schemaNowIso } from "./shared/runtime-clock";
 
 /**
  * Base primitive schemas with enhanced validation (Zod v4 patterns)
@@ -96,7 +96,7 @@ export const createFutureDateSchema = (referenceTime?: DateTimeReference) =>
     (date) => {
       const referenceTimestampMs =
         referenceTime === undefined
-          ? Date.parse(currentIsoTimestamp())
+          ? Date.parse(schemaNowIso())
           : getDateTimeReferenceMs(referenceTime);
       return getDateTimeReferenceMs(date) > referenceTimestampMs;
     },

--- a/src/domain/schemas/registry.ts
+++ b/src/domain/schemas/registry.ts
@@ -3,7 +3,8 @@
  */
 
 import { z } from "zod";
-import { nowIso } from "@/lib/security/random";
+
+const currentIsoTimestamp = (): string => new Date().toISOString();
 
 /**
  * Base primitive schemas with enhanced validation (Zod v4 patterns)
@@ -95,7 +96,7 @@ export const createFutureDateSchema = (referenceTime?: DateTimeReference) =>
     (date) => {
       const referenceTimestampMs =
         referenceTime === undefined
-          ? Date.parse(nowIso())
+          ? Date.parse(currentIsoTimestamp())
           : getDateTimeReferenceMs(referenceTime);
       return getDateTimeReferenceMs(date) > referenceTimestampMs;
     },

--- a/src/domain/schemas/shared/runtime-clock.ts
+++ b/src/domain/schemas/shared/runtime-clock.ts
@@ -1,0 +1,27 @@
+/**
+ * @fileoverview Runtime timestamp helpers for pure domain schemas.
+ */
+
+type SchemaTimestampReference = Date | number | string;
+
+const getTimestampDate = (reference?: SchemaTimestampReference): Date => {
+  const date =
+    reference instanceof Date
+      ? new Date(reference.getTime())
+      : new Date(reference ?? Date.now());
+
+  if (!Number.isFinite(date.getTime())) {
+    throw new Error("Invalid schema timestamp reference");
+  }
+
+  return date;
+};
+
+/**
+ * Returns the current runtime timestamp as an ISO 8601 string for schema fallbacks.
+ *
+ * @param reference - Optional timestamp reference for deterministic tests/callers.
+ * @returns ISO timestamp string.
+ */
+export const schemaNowIso = (reference?: SchemaTimestampReference): string =>
+  getTimestampDate(reference).toISOString();

--- a/src/domain/schemas/shared/time.ts
+++ b/src/domain/schemas/shared/time.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from "zod";
+import { nowIso } from "@/lib/security/random";
 import { primitiveSchemas } from "../registry";
 
 export const ISO_DATE_STRING = z
@@ -38,27 +39,41 @@ const parseIsoDateToLocalMidnight = (value: string): Date | null => {
   return date;
 };
 
-const getTodayLocalMidnight = (): Date => {
-  const now = new Date();
+type LocalDateReference = Date | number | string;
+
+const getReferenceLocalMidnight = (reference?: LocalDateReference): Date => {
+  const now =
+    reference instanceof Date
+      ? new Date(reference.getTime())
+      : new Date(reference ?? nowIso());
+
+  if (!Number.isFinite(now.getTime())) {
+    throw new Error("Invalid local date reference");
+  }
+
   return new Date(now.getFullYear(), now.getMonth(), now.getDate());
 };
 
-export const FUTURE_DATE_SCHEMA = ISO_DATE_STRING.superRefine((value, ctx) => {
-  const parsed = parseIsoDateToLocalMidnight(value);
-  if (!parsed) {
-    ctx.addIssue({ code: "custom", message: "Please enter a valid date" });
-    return;
-  }
-
-  if (parsed <= getTodayLocalMidnight()) {
-    ctx.addIssue({ code: "custom", message: "Date must be in the future" });
-  }
-});
-
 /**
- * @deprecated Use `FUTURE_DATE_SCHEMA`. This alias will be removed in a future release.
+ * Creates a local-date schema that requires dates after the supplied reference day.
+ *
+ * @param referenceDate - Optional reference clock. Defaults to the current local day.
+ * @returns Zod schema for future local ISO date strings.
  */
-export const FUTURE_DATE_STRING = FUTURE_DATE_SCHEMA;
+export const createFutureLocalDateSchema = (referenceDate?: LocalDateReference) =>
+  ISO_DATE_STRING.superRefine((value, ctx) => {
+    const parsed = parseIsoDateToLocalMidnight(value);
+    if (!parsed) {
+      ctx.addIssue({ code: "custom", message: "Please enter a valid date" });
+      return;
+    }
+
+    if (parsed <= getReferenceLocalMidnight(referenceDate)) {
+      ctx.addIssue({ code: "custom", message: "Date must be in the future" });
+    }
+  });
+
+export const FUTURE_DATE_SCHEMA = createFutureLocalDateSchema();
 
 export const DATE_RANGE_SCHEMA = z
   .strictObject({

--- a/src/domain/schemas/shared/time.ts
+++ b/src/domain/schemas/shared/time.ts
@@ -74,6 +74,7 @@ export const createFutureLocalDateSchema = (referenceDate?: LocalDateReference) 
     }
   });
 
+/** Default future-local-date schema using the runtime local day as reference. */
 export const FUTURE_DATE_SCHEMA = createFutureLocalDateSchema();
 
 export const DATE_RANGE_SCHEMA = z

--- a/src/domain/schemas/shared/time.ts
+++ b/src/domain/schemas/shared/time.ts
@@ -3,8 +3,9 @@
  */
 
 import { z } from "zod";
-import { nowIso } from "@/lib/security/random";
 import { primitiveSchemas } from "../registry";
+
+const currentIsoTimestamp = (): string => new Date().toISOString();
 
 export const ISO_DATE_STRING = z
   .string()
@@ -45,7 +46,7 @@ const getReferenceLocalMidnight = (reference?: LocalDateReference): Date => {
   const now =
     reference instanceof Date
       ? new Date(reference.getTime())
-      : new Date(reference ?? nowIso());
+      : new Date(reference ?? currentIsoTimestamp());
 
   if (!Number.isFinite(now.getTime())) {
     throw new Error("Invalid local date reference");

--- a/src/domain/schemas/shared/time.ts
+++ b/src/domain/schemas/shared/time.ts
@@ -74,7 +74,7 @@ export const createFutureLocalDateSchema = (referenceDate?: LocalDateReference) 
     }
   });
 
-/** Default future-local-date schema using the runtime local day as reference. */
+/** Default future-date schema using the current local day as reference. */
 export const FUTURE_DATE_SCHEMA = createFutureLocalDateSchema();
 
 export const DATE_RANGE_SCHEMA = z

--- a/src/domain/schemas/shared/time.ts
+++ b/src/domain/schemas/shared/time.ts
@@ -3,9 +3,9 @@
  */
 
 import { z } from "zod";
-import { primitiveSchemas } from "../registry";
 
-const currentIsoTimestamp = (): string => new Date().toISOString();
+import { primitiveSchemas } from "../registry";
+import { schemaNowIso } from "./runtime-clock";
 
 export const ISO_DATE_STRING = z
   .string()
@@ -46,7 +46,7 @@ const getReferenceLocalMidnight = (reference?: LocalDateReference): Date => {
   const now =
     reference instanceof Date
       ? new Date(reference.getTime())
-      : new Date(reference ?? currentIsoTimestamp());
+      : new Date(reference ?? schemaNowIso());
 
   if (!Number.isFinite(now.getTime())) {
     throw new Error("Invalid local date reference");

--- a/src/features/agent-monitoring/store/agent-status-store.ts
+++ b/src/features/agent-monitoring/store/agent-status-store.ts
@@ -147,6 +147,8 @@ const ACTIVE_STATUSES = new Set<AgentStatusType>([
 const MAX_ACTIVITIES = 200;
 const MAX_RESOURCE_SAMPLES = 120;
 
+const getCurrentAgentStatusTimestampMs = (): number => Date.parse(nowIso());
+
 const clampProgress = (value: number | undefined, fallback: number): number => {
   if (typeof value !== "number" || Number.isNaN(value)) {
     return fallback;
@@ -277,7 +279,7 @@ export const useAgentStatusStore = create<AgentStatusState>()(
       removeStaleAgents: (ttlMs) =>
         set((state) => {
           if (ttlMs <= 0) return state;
-          const cutoff = Date.now() - ttlMs;
+          const cutoff = getCurrentAgentStatusTimestampMs() - ttlMs;
           const staleIds: string[] = [];
 
           for (const [agentId, agent] of Object.entries(state.agentsById)) {

--- a/src/features/budget/store/__tests__/budget-calculation.test.ts
+++ b/src/features/budget/store/__tests__/budget-calculation.test.ts
@@ -2,7 +2,7 @@
 
 import type { Budget } from "@schemas/budget";
 import { act, renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   selectActiveBudgetFrom,
   selectBudgetSummaryFrom,
@@ -10,6 +10,8 @@ import {
   selectRecentExpensesFrom,
   useBudgetStore,
 } from "@/features/budget/store/budget-store";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
+import { calculateBudgetSummary } from "../computed";
 
 // Note: persist middleware is mocked in src/test/setup-jsdom.ts
 
@@ -125,6 +127,59 @@ describe("Budget Store - Budget Calculation", () => {
       expect(summary?.spentByCategory.flights).toBe(1000);
       expect(summary?.spentByCategory.accommodations).toBe(800);
     });
+
+    it(
+      "calculates time-based summary fields from the centralized clock",
+      withFakeTimers(() => {
+        vi.setSystemTime(new Date("2025-06-05T00:00:00.000Z"));
+
+        const summary = calculateBudgetSummary(
+          {
+            categories: [],
+            createdAt: "2025-05-20T12:00:00Z",
+            currency: "USD",
+            endDate: "2025-06-15",
+            id: "budget-1",
+            isActive: true,
+            name: "Summer Vacation",
+            startDate: "2025-06-01",
+            totalAmount: 5000,
+            updatedAt: "2025-05-20T12:00:00Z",
+          },
+          [
+            {
+              amount: 100,
+              budgetId: "budget-1",
+              category: "flights",
+              createdAt: "2025-06-02T00:00:00Z",
+              currency: "USD",
+              date: "2025-06-02",
+              description: "Flight",
+              id: "expense-1",
+              isShared: false,
+              updatedAt: "2025-06-02T00:00:00Z",
+            },
+            {
+              amount: 300,
+              budgetId: "budget-1",
+              category: "food",
+              createdAt: "2025-06-03T00:00:00Z",
+              currency: "USD",
+              date: "2025-06-03",
+              description: "Meals",
+              id: "expense-2",
+              isShared: false,
+              updatedAt: "2025-06-03T00:00:00Z",
+            },
+          ]
+        );
+
+        expect(summary.daysRemaining).toBe(10);
+        expect(summary.dailyAverage).toBe(100);
+        expect(summary.dailyLimit).toBe(460);
+        expect(summary.projectedTotal).toBe(1400);
+      })
+    );
 
     it("returns budgets by trip ID", () => {
       const { result } = renderHook(() => useBudgetStore());

--- a/src/features/budget/store/computed.ts
+++ b/src/features/budget/store/computed.ts
@@ -3,14 +3,18 @@
  */
 
 import type { Budget, BudgetSummary, Expense, ExpenseCategory } from "@schemas/budget";
+import { nowIso } from "@/lib/security/random";
 import type { BudgetState } from "./types";
 
 const SELECT_RECENT_EXPENSES_LIMIT = 10;
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
 type TimestampedExpense = { expense: Expense; timestamp: number };
 
 const compareByTimestampDesc = (a: TimestampedExpense, b: TimestampedExpense): number =>
   b.timestamp - a.timestamp;
+
+const getCurrentBudgetTimestampMs = (): number => Date.parse(nowIso());
 
 export function selectRecentExpensesFromExpenses(
   expensesByBudget: Record<string, Expense[]>
@@ -41,6 +45,7 @@ export function calculateBudgetSummary(
   const totalSpent = expenses.reduce((sum, expense) => sum + expense.amount, 0);
   const totalRemaining = totalBudget - totalSpent;
   const percentageSpent = totalBudget > 0 ? (totalSpent / totalBudget) * 100 : 0;
+  const currentTimestampMs = getCurrentBudgetTimestampMs();
 
   // Calculate spent by category
   const spentByCategory = expenses.reduce(
@@ -56,9 +61,8 @@ export function calculateBudgetSummary(
   let daysRemaining: number | undefined;
   if (budget.startDate && budget.endDate) {
     const endDate = new Date(budget.endDate);
-    const today = new Date();
-    const diffTime = endDate.getTime() - today.getTime();
-    daysRemaining = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    const diffTime = endDate.getTime() - currentTimestampMs;
+    daysRemaining = Math.ceil(diffTime / MS_PER_DAY);
     daysRemaining = daysRemaining < 0 ? 0 : daysRemaining;
   }
 
@@ -73,11 +77,11 @@ export function calculateBudgetSummary(
   if (startDate && endDate) {
     const totalDays = Math.max(
       1,
-      Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24))
+      Math.ceil((endDate.getTime() - startDate.getTime()) / MS_PER_DAY)
     );
     const elapsedDays = Math.max(
       1,
-      Math.ceil((Date.now() - startDate.getTime()) / (1000 * 60 * 60 * 24))
+      Math.ceil((currentTimestampMs - startDate.getTime()) / MS_PER_DAY)
     );
 
     dailyAverage = elapsedDays > 0 ? totalSpent / elapsedDays : 0;

--- a/src/features/dashboard/components/__tests__/quick-actions.test.tsx
+++ b/src/features/dashboard/components/__tests__/quick-actions.test.tsx
@@ -118,10 +118,9 @@ describe("QuickActions", () => {
 
   it("applies custom colors to action buttons", () => {
     renderWithProviders(<QuickActions />);
+    const links = screen.getAllByRole("link");
     const hasClassName = (className: string) =>
-      Array.from(document.querySelectorAll("[class]")).some((element) =>
-        element.classList.contains(className)
-      );
+      links.some((element) => element.classList.contains(className));
 
     // Check that custom color classes are applied
     expect(hasClassName("bg-info/10")).toBe(true);

--- a/src/features/dashboard/components/__tests__/quick-actions.test.tsx
+++ b/src/features/dashboard/components/__tests__/quick-actions.test.tsx
@@ -118,17 +118,16 @@ describe("QuickActions", () => {
 
   it("applies custom colors to action buttons", () => {
     renderWithProviders(<QuickActions />);
+    const hasClassName = (className: string) =>
+      Array.from(document.querySelectorAll("[class]")).some((element) =>
+        element.classList.contains(className)
+      );
 
     // Check that custom color classes are applied
-    const infoButton = document.querySelector(".bg-info/10");
-    const successButton = document.querySelector(".bg-success/10");
-    const highlightButton = document.querySelector(".bg-highlight/10");
-    const warningButton = document.querySelector(".bg-warning/10");
-
-    expect(infoButton).toBeInTheDocument();
-    expect(successButton).toBeInTheDocument();
-    expect(highlightButton).toBeInTheDocument();
-    expect(warningButton).toBeInTheDocument();
+    expect(hasClassName("bg-info/10")).toBe(true);
+    expect(hasClassName("bg-success/10")).toBe(true);
+    expect(hasClassName("bg-highlight/10")).toBe(true);
+    expect(hasClassName("bg-warning/10")).toBe(true);
   });
 });
 

--- a/src/features/dashboard/components/__tests__/quick-actions.test.tsx
+++ b/src/features/dashboard/components/__tests__/quick-actions.test.tsx
@@ -117,8 +117,8 @@ describe("QuickActions", () => {
   });
 
   it("applies custom colors to action buttons", () => {
-    renderWithProviders(<QuickActions />);
-    const links = screen.getAllByRole("link");
+    const { container } = renderWithProviders(<QuickActions />);
+    const links = Array.from(container.querySelectorAll("a"));
     const hasClassName = (className: string) =>
       links.some((element) => element.classList.contains(className));
 

--- a/src/features/dashboard/components/__tests__/recent-trips.test.tsx
+++ b/src/features/dashboard/components/__tests__/recent-trips.test.tsx
@@ -4,7 +4,7 @@ import { screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DateUtils } from "@/lib/dates/unified-date-utils";
 import { renderWithProviders } from "@/test/test-utils";
-import { createFakeTimersContext } from "@/test/utils/with-fake-timers";
+import { createFakeTimersContext, withFakeTimers } from "@/test/utils/with-fake-timers";
 
 vi.mock("next/link", () => ({
   default: ({
@@ -194,24 +194,29 @@ describe("RecentTrips", () => {
     expect(screen.getByText("Create your first trip")).toBeInTheDocument();
   });
 
-  it("calculates trip status correctly", () => {
-    const now = new Date();
-    const pastTrip: Record<string, unknown> = {
-      ...MockTrips[0],
-      endDate: new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000).toISOString(),
-      startDate: new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000).toISOString(),
-    };
-    const ongoingTrip: Record<string, unknown> = {
-      ...MockTrips[0],
-      endDate: new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000).toISOString(),
-      id: "ongoing-trip",
-      startDate: new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000).toISOString(),
-    };
-    setTrips([pastTrip, ongoingTrip]);
-    renderWithProviders(<RecentTrips />);
-    expect(screen.getByText("completed")).toBeInTheDocument();
-    expect(screen.getByText("ongoing")).toBeInTheDocument();
-  });
+  it(
+    "calculates trip status correctly",
+    withFakeTimers(() => {
+      const now = new Date("2024-07-15T00:00:00.000Z");
+      vi.setSystemTime(now);
+
+      const pastTrip: Record<string, unknown> = {
+        ...MockTrips[0],
+        endDate: new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+        startDate: new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000).toISOString(),
+      };
+      const ongoingTrip: Record<string, unknown> = {
+        ...MockTrips[0],
+        endDate: new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000).toISOString(),
+        id: "ongoing-trip",
+        startDate: new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+      };
+      setTrips([pastTrip, ongoingTrip]);
+      renderWithProviders(<RecentTrips />);
+      expect(screen.getByText("completed")).toBeInTheDocument();
+      expect(screen.getByText("ongoing")).toBeInTheDocument();
+    })
+  );
 
   it("formats dates correctly", () => {
     setTrips([MockTrips[0]]);

--- a/src/features/dashboard/components/__tests__/upcoming-flights.test.tsx
+++ b/src/features/dashboard/components/__tests__/upcoming-flights.test.tsx
@@ -4,7 +4,7 @@ import type { UseQueryResult } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { UpcomingFlight } from "@/hooks/use-trips";
-import type { AppError } from "@/lib/api/error-types";
+import { ApiError } from "@/lib/api/error-types";
 import { UPCOMING_FLIGHT_A, UPCOMING_FLIGHT_B } from "@/test/fixtures/flights";
 import { render, screen } from "@/test/test-utils";
 import { UpcomingFlights, UpcomingFlightsNoEmptyState } from "../upcoming-flights";
@@ -21,7 +21,7 @@ interface LinkProps {
   [key: string]: unknown;
 }
 
-type UseUpcomingFlightsReturn = UseQueryResult<UpcomingFlight[], AppError>;
+type UseUpcomingFlightsReturn = UseQueryResult<UpcomingFlight[], ApiError>;
 
 const CreateFlightsReturn = (
   data: UpcomingFlight[],
@@ -108,7 +108,10 @@ describe("UpcomingFlights", () => {
   });
 
   it("renders error state when flights fail to load", () => {
-    const mockError = new Error("Failed to load flights") as AppError;
+    const mockError = new ApiError({
+      message: "Failed to load flights",
+      status: 500,
+    });
     vi.mocked(useUpcomingFlights).mockReturnValue({
       ...CreateFlightsReturn([]),
       error: mockError,

--- a/src/features/dashboard/components/recent-trips.tsx
+++ b/src/features/dashboard/components/recent-trips.tsx
@@ -20,6 +20,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { useTrips } from "@/hooks/use-trips";
 import { DateUtils } from "@/lib/dates/unified-date-utils";
+import { nowIso } from "@/lib/security/random";
 
 type Trip = UiTrip;
 
@@ -30,6 +31,10 @@ interface RecentTripsProps {
 type RecentTripsVariantProps = RecentTripsProps & {
   showEmpty: boolean;
 };
+
+function GetCurrentRecentTripsDate(): Date {
+  return new Date(nowIso());
+}
 
 function TripCardSkeleton() {
   return (
@@ -93,7 +98,7 @@ function TripCard({ trip }: { trip: Trip }) {
    */
   const getTripStatus = () => {
     if (!trip.startDate || !trip.endDate) return "draft";
-    const now = new Date();
+    const now = GetCurrentRecentTripsDate();
     const start = DateUtils.parse(trip.startDate);
     const end = DateUtils.parse(trip.endDate);
     const nowTs = now.getTime();

--- a/src/features/profile/components/__tests__/account-settings-section.test.tsx
+++ b/src/features/profile/components/__tests__/account-settings-section.test.tsx
@@ -108,10 +108,22 @@ describe("AccountSettingsSection", () => {
     render(<AccountSettingsSection />);
 
     expect(screen.getByText("Notification Preferences")).toBeInTheDocument();
-    expect(screen.getByText("Email Notifications")).toBeInTheDocument();
-    expect(screen.getByText("Trip Reminders")).toBeInTheDocument();
-    expect(screen.getByText("Price Alerts")).toBeInTheDocument();
-    expect(screen.getByText("Marketing Communications")).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: "Email Notifications" })
+    ).toHaveAccessibleDescription(
+      "Receive trip updates and important account information via email."
+    );
+    expect(
+      screen.getByRole("switch", { name: "Trip Reminders" })
+    ).toHaveAccessibleDescription("Get reminders about upcoming trips and bookings.");
+    expect(
+      screen.getByRole("switch", { name: "Price Alerts" })
+    ).toHaveAccessibleDescription(
+      "Receive notifications when flight or hotel prices drop."
+    );
+    expect(
+      screen.getByRole("switch", { name: "Marketing Communications" })
+    ).toHaveAccessibleDescription("Receive promotional offers and travel tips.");
   });
 
   // Skipped toast assertion on preference toggles to avoid time coupling.

--- a/src/features/profile/components/__tests__/personal-info-section.test.tsx
+++ b/src/features/profile/components/__tests__/personal-info-section.test.tsx
@@ -48,6 +48,14 @@ const MOCK_GET_PUBLIC_URL = vi.fn();
 
 const GET_BROWSER_CLIENT = vi.mocked((await import("@/lib/supabase")).getBrowserClient);
 
+function CreateDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
 const BASE_USER = {
   avatarUrl: "https://example.com/avatars/user-1.jpg",
   bio: "Travel enthusiast",
@@ -181,6 +189,33 @@ describe("PersonalInfoSection", () => {
     );
   });
 
+  it("labels avatar upload trigger and announces upload progress", async () => {
+    const upload = CreateDeferred<{ data: { path: string }; error: null }>();
+    MOCK_UPLOAD.mockReturnValueOnce(upload.promise);
+
+    const { container } = render(<PersonalInfoSection />);
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const trigger = screen.getByRole("button", { name: "Upload profile picture" });
+
+    expect(trigger).toHaveAttribute("aria-controls", fileInput.id);
+    expect(trigger).toHaveAccessibleDescription(/recommended size: 400x400px/i);
+
+    const validFile = new File(["content"], "avatar.jpg", { type: "image/jpeg" });
+    fireEvent.change(fileInput, { target: { files: [validFile] } });
+
+    const busyTrigger = await screen.findByRole("button", {
+      name: "Uploading profile picture",
+    });
+    expect(busyTrigger).toBeDisabled();
+    expect(busyTrigger).toHaveAttribute("aria-busy", "true");
+
+    upload.resolve({
+      data: { path: "avatars/user-1.jpg" },
+      error: null,
+    });
+    await waitFor(() => expect(MOCK_UPDATE_USER).toHaveBeenCalled());
+  });
+
   it("uploads avatar and shows success toast", async () => {
     const { container } = render(<PersonalInfoSection />);
     const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
@@ -198,7 +233,7 @@ describe("PersonalInfoSection", () => {
     expect(MOCK_UPDATE_USER).toHaveBeenCalledWith({
       data: {
         avatar_url: expect.stringMatching(
-          /^https:\/\/cdn\.example\.com\/avatars\/user-1\.jpg\?v=\d+$/
+          /^https:\/\/cdn\.example\.com\/avatars\/user-1\.jpg\?v=[a-z0-9]{1,8}$/
         ),
       },
     });

--- a/src/features/profile/components/__tests__/profile-smoke.test.tsx
+++ b/src/features/profile/components/__tests__/profile-smoke.test.tsx
@@ -1,52 +1,93 @@
 /** @vitest-environment jsdom */
 
 import { screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ProfilePage from "@/app/(app)/dashboard/profile/page";
 import { render } from "@/test/test-utils";
 import { AccountSettingsSection } from "../account-settings-section";
 import { PersonalInfoSection } from "../personal-info-section";
 import { PreferencesSection } from "../preferences-section";
 
-const MOCK_USER = {
-  createdAt: "2025-01-01T00:00:00.000Z",
-  displayName: "John Doe",
-  email: "test@example.com",
-  firstName: "John",
-  id: "user-1",
-  isEmailVerified: true,
-  lastName: "Doe",
-  preferences: {
-    notifications: {
-      email: true,
-      marketing: false,
-      priceAlerts: false,
-      tripReminders: true,
+const { mockAuthState, mockCurrencyState, mockRouter } = vi.hoisted(() => {
+  const user = {
+    createdAt: "2025-01-01T00:00:00.000Z",
+    displayName: "John Doe",
+    email: "test@example.com",
+    firstName: "John",
+    id: "user-1",
+    isEmailVerified: true,
+    lastName: "Doe",
+    preferences: {
+      notifications: {
+        email: true,
+        marketing: false,
+        priceAlerts: false,
+        tripReminders: true,
+      },
     },
-  },
-  updatedAt: "2025-01-01T00:00:00.000Z",
-};
+    updatedAt: "2025-01-01T00:00:00.000Z",
+  };
+
+  return {
+    mockAuthState: {
+      hasInitialized: true,
+      initialize: vi.fn().mockResolvedValue(undefined),
+      isLoading: false,
+      logout: vi.fn(),
+      setUser: vi.fn(),
+      user,
+    },
+    mockCurrencyState: {
+      baseCurrency: "USD",
+      setBaseCurrency: vi.fn(),
+    },
+    mockRouter: {
+      replace: vi.fn(),
+    },
+  };
+});
 
 vi.mock("@/features/auth/store/auth/auth-core", () => ({
-  useAuthCore: () => ({
-    initialize: vi.fn().mockResolvedValue(undefined),
-    isLoading: false,
-    logout: vi.fn(),
-    setUser: vi.fn(),
-    user: MOCK_USER,
-  }),
+  useAuthCore: <T,>(selector?: (state: typeof mockAuthState) => T) =>
+    selector ? selector(mockAuthState) : mockAuthState,
 }));
 
 vi.mock("@/features/shared/store/currency-store", () => ({
-  useCurrencyStore: () => ({
-    baseCurrency: "USD",
-    setBaseCurrency: vi.fn(),
-  }),
+  useCurrencyStore: <T,>(selector?: (state: typeof mockCurrencyState) => T) =>
+    selector ? selector(mockCurrencyState) : mockCurrencyState,
 }));
 
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ replace: vi.fn() }),
+  useRouter: () => mockRouter,
 }));
+
+const RENDER_PHASE_UPDATE_WARNING = "Cannot update a component";
+type ConsoleErrorSpy = {
+  mock: {
+    calls: unknown[][];
+  };
+  mockRestore: () => void;
+};
+
+let consoleErrorSpy: ConsoleErrorSpy;
+
+const ExpectNoRenderPhaseUpdateWarning = () => {
+  expect(
+    consoleErrorSpy.mock.calls.some((call) => {
+      const message: unknown = call[0];
+      return String(message).includes(RENDER_PHASE_UPDATE_WARNING);
+    })
+  ).toBe(false);
+};
+
+beforeEach(() => {
+  consoleErrorSpy = vi.spyOn(console, "error");
+});
+
+afterEach(() => {
+  ExpectNoRenderPhaseUpdateWarning();
+  consoleErrorSpy.mockRestore();
+});
 
 describe("Profile Components Smoke Tests", () => {
   it("renders PersonalInfoSection without crashing", () => {

--- a/src/features/profile/components/account-settings-section.tsx
+++ b/src/features/profile/components/account-settings-section.tsx
@@ -6,7 +6,7 @@
 
 import { type EmailUpdateFormData, emailUpdateFormSchema } from "@schemas/profile";
 import { CheckIcon, MailIcon, Trash2Icon } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -105,8 +105,13 @@ export function AccountSettingsSection() {
   });
 
   const { reset } = emailForm;
+  const didMountRef = useRef(false);
 
   useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
     reset({ email: currentEmail });
   }, [currentEmail, reset]);
 
@@ -387,13 +392,20 @@ export function AccountSettingsSection() {
           <div className="space-y-4">
             <div className="flex items-center justify-between">
               <div className="space-y-0.5">
-                <div className="text-sm font-medium">Email Notifications</div>
-                <div className="text-sm text-muted-foreground">
+                <div id="email-notifications-label" className="text-sm font-medium">
+                  Email Notifications
+                </div>
+                <div
+                  id="email-notifications-description"
+                  className="text-sm text-muted-foreground"
+                >
                   Receive trip updates and important account information via email.
                 </div>
               </div>
               <Switch
                 checked={notificationPrefs.email}
+                aria-labelledby="email-notifications-label"
+                aria-describedby="email-notifications-description"
                 onCheckedChange={(enabled) =>
                   toggleNotificationSetting("email", enabled)
                 }
@@ -402,13 +414,20 @@ export function AccountSettingsSection() {
 
             <div className="flex items-center justify-between">
               <div className="space-y-0.5">
-                <div className="text-sm font-medium">Trip Reminders</div>
-                <div className="text-sm text-muted-foreground">
+                <div id="trip-reminders-label" className="text-sm font-medium">
+                  Trip Reminders
+                </div>
+                <div
+                  id="trip-reminders-description"
+                  className="text-sm text-muted-foreground"
+                >
                   Get reminders about upcoming trips and bookings.
                 </div>
               </div>
               <Switch
                 checked={notificationPrefs.tripReminders}
+                aria-labelledby="trip-reminders-label"
+                aria-describedby="trip-reminders-description"
                 onCheckedChange={(enabled) =>
                   toggleNotificationSetting("tripReminders", enabled)
                 }
@@ -417,13 +436,20 @@ export function AccountSettingsSection() {
 
             <div className="flex items-center justify-between">
               <div className="space-y-0.5">
-                <div className="text-sm font-medium">Price Alerts</div>
-                <div className="text-sm text-muted-foreground">
+                <div id="price-alerts-label" className="text-sm font-medium">
+                  Price Alerts
+                </div>
+                <div
+                  id="price-alerts-description"
+                  className="text-sm text-muted-foreground"
+                >
                   Receive notifications when flight or hotel prices drop.
                 </div>
               </div>
               <Switch
                 checked={notificationPrefs.priceAlerts}
+                aria-labelledby="price-alerts-label"
+                aria-describedby="price-alerts-description"
                 onCheckedChange={(enabled) =>
                   toggleNotificationSetting("priceAlerts", enabled)
                 }
@@ -432,13 +458,23 @@ export function AccountSettingsSection() {
 
             <div className="flex items-center justify-between">
               <div className="space-y-0.5">
-                <div className="text-sm font-medium">Marketing Communications</div>
-                <div className="text-sm text-muted-foreground">
+                <div
+                  id="marketing-communications-label"
+                  className="text-sm font-medium"
+                >
+                  Marketing Communications
+                </div>
+                <div
+                  id="marketing-communications-description"
+                  className="text-sm text-muted-foreground"
+                >
                   Receive promotional offers and travel tips.
                 </div>
               </div>
               <Switch
                 checked={notificationPrefs.marketing}
+                aria-labelledby="marketing-communications-label"
+                aria-describedby="marketing-communications-description"
                 onCheckedChange={(enabled) =>
                   toggleNotificationSetting("marketing", enabled)
                 }

--- a/src/features/profile/components/personal-info-section.tsx
+++ b/src/features/profile/components/personal-info-section.tsx
@@ -298,7 +298,7 @@ export function PersonalInfoSection() {
                 type="button"
                 size="sm"
                 variant="outline"
-                className="h-8 w-8 rounded-full p-0"
+                className="h-10 w-10 rounded-full p-0 sm:h-8 sm:w-8"
                 onClick={() => avatarInputRef.current?.click()}
                 disabled={isUploading}
                 aria-busy={isUploading || undefined}

--- a/src/features/profile/components/personal-info-section.tsx
+++ b/src/features/profile/components/personal-info-section.tsx
@@ -298,7 +298,7 @@ export function PersonalInfoSection() {
                 type="button"
                 size="sm"
                 variant="outline"
-                className="h-10 w-10 rounded-full p-0 sm:h-8 sm:w-8"
+                className="h-11 w-11 rounded-full p-0 touch-manipulation"
                 onClick={() => avatarInputRef.current?.click()}
                 disabled={isUploading}
                 aria-busy={isUploading || undefined}

--- a/src/features/profile/components/personal-info-section.tsx
+++ b/src/features/profile/components/personal-info-section.tsx
@@ -7,6 +7,7 @@
 import { type PersonalInfoFormData, personalInfoFormSchema } from "@schemas/profile";
 import { CameraIcon, UploadIcon } from "lucide-react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { type Control, useFormState } from "react-hook-form";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -31,6 +32,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { useAuthCore } from "@/features/auth/store/auth/auth-core";
 import { useZodForm } from "@/hooks/use-zod-form";
 import { getUnknownErrorMessage } from "@/lib/errors/get-unknown-error-message";
+import { secureId } from "@/lib/security/random";
 import { getBrowserClient } from "@/lib/supabase";
 
 const MAX_AVATAR_BYTES = 5 * 1024 * 1024;
@@ -46,6 +48,7 @@ type SupportedAvatarType = keyof typeof SUPPORTED_AVATAR_TYPES;
 type SupportedAvatarExt = (typeof SUPPORTED_AVATAR_TYPES)[SupportedAvatarType];
 
 export function PersonalInfoSection() {
+  const avatarDescriptionId = useId();
   const avatarInputId = useId();
   const avatarInputRef = useRef<HTMLInputElement | null>(null);
   const { user: authUser, setUser } = useAuthCore();
@@ -77,8 +80,13 @@ export function PersonalInfoSection() {
   });
 
   const resetForm = form.reset;
+  const didMountRef = useRef(false);
 
   useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
     resetForm(defaultValues);
   }, [defaultValues, resetForm]);
 
@@ -204,7 +212,7 @@ export function PersonalInfoSection() {
 
       const { data } = supabase.storage.from("avatars").getPublicUrl(avatarPath);
       // Add cache-busting query parameter so clients fetch the updated image
-      const avatarUrl = `${data.publicUrl}?v=${Date.now()}`;
+      const avatarUrl = `${data.publicUrl}?v=${secureId(8)}`;
 
       const { data: updateResult, error: updateError } = await supabase.auth.updateUser(
         {
@@ -287,11 +295,18 @@ export function PersonalInfoSection() {
             </Avatar>
             <div className="absolute -bottom-2 -right-2">
               <Button
+                type="button"
                 size="sm"
                 variant="outline"
                 className="h-8 w-8 rounded-full p-0"
                 onClick={() => avatarInputRef.current?.click()}
                 disabled={isUploading}
+                aria-busy={isUploading || undefined}
+                aria-controls={avatarInputId}
+                aria-describedby={avatarDescriptionId}
+                aria-label={
+                  isUploading ? "Uploading profile picture" : "Upload profile picture"
+                }
               >
                 {isUploading ? (
                   <UploadIcon aria-hidden="true" className="h-3 w-3 animate-spin" />
@@ -311,7 +326,7 @@ export function PersonalInfoSection() {
           </div>
           <div className="space-y-1">
             <h3 className="font-medium">Profile Picture</h3>
-            <p className="text-sm text-muted-foreground">
+            <p id={avatarDescriptionId} className="text-sm text-muted-foreground">
               Click the camera icon to upload a new profile picture. Recommended size:
               400x400px. Max file size: 5MB.
             </p>
@@ -418,13 +433,25 @@ export function PersonalInfoSection() {
             </div>
 
             <div className="flex justify-end">
-              <Button type="submit" disabled={form.formState.isSubmitting}>
-                {form.formState.isSubmitting ? "Saving…" : "Save Changes"}
-              </Button>
+              <PersonalInfoSubmitButton control={form.control} />
             </div>
           </form>
         </Form>
       </CardContent>
     </Card>
+  );
+}
+
+function PersonalInfoSubmitButton({
+  control,
+}: {
+  control: Control<PersonalInfoFormData>;
+}) {
+  const { isSubmitting } = useFormState({ control });
+
+  return (
+    <Button type="submit" disabled={isSubmitting}>
+      {isSubmitting ? "Saving…" : "Save Changes"}
+    </Button>
   );
 }

--- a/src/features/profile/components/personalization-insights.tsx
+++ b/src/features/profile/components/personalization-insights.tsx
@@ -5,7 +5,6 @@
 "use client";
 
 import type { MemoryContextResponse } from "@schemas/chat";
-// import type { UserPreferences } from "@schemas/memory"; // Future implementation
 import {
   BarChart3Icon,
   BrainIcon,
@@ -32,14 +31,12 @@ import {
   useMemoryContext,
   useMemoryInsights,
   useMemoryStats,
-  // useUpdatePreferences, // Future implementation
 } from "@/hooks/use-memory";
 import { TREND_COLORS } from "@/lib/variants/status";
 export type PersonalizationInsightsProps = {
   userId: string;
   className?: string;
   showRecommendations?: boolean;
-  onPreferenceUpdate?: (preferences: unknown) => void;
 };
 
 import { cn } from "@/lib/utils";
@@ -59,9 +56,7 @@ export function PersonalizationInsights({
   userId,
   className,
   showRecommendations = true,
-  onPreferenceUpdate: _onPreferenceUpdate, // Future implementation
 }: PersonalizationInsightsProps) {
-  // const [isUpdating, setIsUpdating] = useState(false); // Future implementation
   const [selectedView, setSelectedView] = useState<
     "overview" | "budget" | "destinations" | "recommendations"
   >("overview");
@@ -78,8 +73,6 @@ export function PersonalizationInsights({
     userId,
     !!userId
   );
-
-  // const updatePreferences = useUpdatePreferences(userId); // Future implementation
 
   const formatCurrency = (amount: number, currency = "USD") => {
     return new Intl.NumberFormat("en-US", {
@@ -135,22 +128,6 @@ export function PersonalizationInsights({
         );
     }
   };
-
-  // const handlePreferenceUpdate = async (preferences: Partial<UserPreferences>) => { // Future implementation
-  //   setIsUpdating(true);
-  //   try {
-  //     await updatePreferences.mutateAsync({
-  //       preferences,
-  //       merge_strategy: "merge",
-  //     });
-  //     onPreferenceUpdate?.(preferences);
-  //     await refetchInsights();
-  //   } catch (error) {
-  //     console.error("Failed to update preferences:", error);
-  //   } finally {
-  //     setIsUpdating(false);
-  //   }
-  // };
 
   const renderOverview = () => {
     if (!insights?.insights) return null;

--- a/src/features/realtime/components/__tests__/optimistic-trip-updates.test.tsx
+++ b/src/features/realtime/components/__tests__/optimistic-trip-updates.test.tsx
@@ -1,0 +1,138 @@
+/** @vitest-environment jsdom */
+
+import type { UiTrip } from "@schemas/trips";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, renderWithProviders, screen } from "@/test/test-utils";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
+
+const MOCK_RECORD_CLIENT_ERROR_ON_ACTIVE_SPAN = vi.hoisted(() => vi.fn());
+const MOCK_MUTATE_ASYNC = vi.hoisted(() => vi.fn());
+const MOCK_USE_TRIP = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/telemetry/client-errors", () => ({
+  recordClientErrorOnActiveSpan: MOCK_RECORD_CLIENT_ERROR_ON_ACTIVE_SPAN,
+}));
+
+vi.mock("@/hooks/use-current-user-id", () => ({
+  useCurrentUserId: () => "user-123",
+}));
+
+vi.mock("@/hooks/use-trips", () => ({
+  useTrip: MOCK_USE_TRIP,
+  useUpdateTrip: () => ({
+    mutateAsync: MOCK_MUTATE_ASYNC,
+  }),
+}));
+
+import {
+  ApplyTripUpdateToUiTrip,
+  OptimisticTripUpdates,
+} from "../optimistic-trip-updates";
+
+const BASE_TRIP: UiTrip = {
+  budget: 1200,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  currency: "USD",
+  destination: "Paris",
+  destinations: [],
+  endDate: "2026-05-09",
+  id: "42",
+  startDate: "2026-05-01",
+  title: "Original Trip",
+  travelers: 2,
+  updatedAt: "2026-01-02T00:00:00.000Z",
+  visibility: "private",
+};
+
+describe("applyTripUpdateToUiTrip", () => {
+  beforeEach(() => {
+    MOCK_RECORD_CLIENT_ERROR_ON_ACTIVE_SPAN.mockReset();
+    MOCK_MUTATE_ASYNC.mockReset();
+    MOCK_MUTATE_ASYNC.mockResolvedValue(BASE_TRIP);
+    MOCK_USE_TRIP.mockReset();
+    MOCK_USE_TRIP.mockReturnValue({
+      data: BASE_TRIP,
+      error: null,
+      isConnected: true,
+      isLoading: false,
+      realtimeStatus: { errors: [] },
+    });
+  });
+
+  it("maps database update fields to the UI trip shape", () => {
+    const updated = ApplyTripUpdateToUiTrip({
+      field: "name",
+      prev: BASE_TRIP,
+      tripId: 42,
+      value: "Updated Trip",
+    });
+
+    expect(updated.title).toBe("Updated Trip");
+    expect(updated.budget).toBe(BASE_TRIP.budget);
+    expect(updated.destination).toBe(BASE_TRIP.destination);
+    expect(updated.updatedAt).not.toBe(BASE_TRIP.updatedAt);
+    expect(MOCK_RECORD_CLIENT_ERROR_ON_ACTIVE_SPAN).not.toHaveBeenCalled();
+  });
+
+  it("ignores unmapped fields and records sanitized telemetry", () => {
+    const updated = ApplyTripUpdateToUiTrip({
+      field: "description",
+      prev: BASE_TRIP,
+      tripId: 42,
+      value: "private details",
+    });
+
+    expect(updated).toBe(BASE_TRIP);
+    expect(MOCK_RECORD_CLIENT_ERROR_ON_ACTIVE_SPAN).toHaveBeenCalledWith(
+      expect.any(Error),
+      {
+        action: "applyOptimisticTripUpdate",
+        context: "OptimisticTripUpdates",
+        field: "description",
+        tripId: 42,
+        valueType: "string",
+      }
+    );
+  });
+
+  it("keeps the ignored-field fallback stable when telemetry fails", () => {
+    MOCK_RECORD_CLIENT_ERROR_ON_ACTIVE_SPAN.mockImplementationOnce(() => {
+      throw new Error("telemetry unavailable");
+    });
+
+    const updated = ApplyTripUpdateToUiTrip({
+      field: "search_metadata",
+      prev: BASE_TRIP,
+      tripId: 42,
+      value: { source: "test" },
+    });
+
+    expect(updated).toBe(BASE_TRIP);
+  });
+
+  it(
+    "timestamps optimistic update feed entries from the canonical clock helper",
+    withFakeTimers(() => {
+      const fixedNowIso = "2026-02-03T04:05:06.000Z";
+      const expectedTime = new Date(fixedNowIso).toLocaleTimeString();
+      vi.setSystemTime(new Date(fixedNowIso));
+      MOCK_MUTATE_ASYNC.mockImplementationOnce(
+        () => new Promise<never>(() => undefined)
+      );
+
+      renderWithProviders(<OptimisticTripUpdates tripId={42} />);
+
+      fireEvent.change(screen.getByLabelText("Trip Name"), {
+        target: { value: "Updated Trip" },
+      });
+      fireEvent.blur(screen.getByLabelText("Trip Name"));
+
+      expect(screen.getByText("Updated name")).toBeInTheDocument();
+      expect(screen.getByText(expectedTime)).toBeInTheDocument();
+      expect(MOCK_MUTATE_ASYNC).toHaveBeenCalledWith({
+        data: { name: "Updated Trip" },
+        tripId: 42,
+      });
+    })
+  );
+});

--- a/src/features/realtime/components/__tests__/optimistic-trip-updates.test.tsx
+++ b/src/features/realtime/components/__tests__/optimistic-trip-updates.test.tsx
@@ -74,6 +74,24 @@ describe("applyTripUpdateToUiTrip", () => {
     expect(MOCK_RECORD_CLIENT_ERROR_ON_ACTIVE_SPAN).not.toHaveBeenCalled();
   });
 
+  it("ignores non-finite numeric optimistic updates", () => {
+    const updated = ApplyTripUpdateToUiTrip({
+      field: "budget",
+      prev: BASE_TRIP,
+      tripId: 42,
+      value: Number.NaN,
+    });
+
+    expect(updated).toBe(BASE_TRIP);
+    expect(MOCK_RECORD_CLIENT_ERROR_ON_ACTIVE_SPAN).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        action: "applyOptimisticTripUpdate",
+        field: "budget",
+      })
+    );
+  });
+
   it("ignores unmapped fields and records sanitized telemetry", () => {
     const updated = ApplyTripUpdateToUiTrip({
       field: "description",

--- a/src/features/realtime/components/optimistic-trip-updates.tsx
+++ b/src/features/realtime/components/optimistic-trip-updates.tsx
@@ -31,7 +31,9 @@ import { useToast } from "@/components/ui/use-toast";
 import { useCurrentUserId } from "@/hooks/use-current-user-id";
 import { type UpdateTripData, useTrip, useUpdateTrip } from "@/hooks/use-trips";
 import { keys } from "@/lib/keys";
+import { nowIso } from "@/lib/security/random";
 import type { TablesUpdate } from "@/lib/supabase/database.types";
+import { recordClientErrorOnActiveSpan } from "@/lib/telemetry/client-errors";
 import { statusVariants } from "@/lib/variants/status";
 
 type TripUpdate = TablesUpdate<"trips">;
@@ -87,6 +89,101 @@ function GetConnectionBadgeProps(state: ConnectionState) {
   return CONNECTION_BADGE_PROPS[state];
 }
 
+function GetCurrentOptimisticUpdateDate() {
+  return new Date(nowIso());
+}
+
+function RecordIgnoredTripUpdateField(input: {
+  field: TripUpdateKey;
+  tripId: number;
+  value: TripUpdate[TripUpdateKey];
+}) {
+  try {
+    recordClientErrorOnActiveSpan(new Error("Unmapped trip update field"), {
+      action: "applyOptimisticTripUpdate",
+      context: "OptimisticTripUpdates",
+      field: String(input.field),
+      tripId: input.tripId,
+      valueType: typeof input.value,
+    });
+  } catch {
+    // Optimistic UI fallback must not fail if telemetry is unavailable.
+  }
+}
+
+function BuildOptimisticTripPatch(
+  field: TripUpdateKey,
+  value: TripUpdate[TripUpdateKey]
+): Partial<
+  Pick<
+    UiTrip,
+    "budget" | "destination" | "endDate" | "startDate" | "title" | "travelers"
+  >
+> | null {
+  switch (field) {
+    case "budget":
+      return typeof value === "number" ? { budget: value } : null;
+    case "destination":
+      return typeof value === "string" ? { destination: value } : null;
+    case "end_date":
+      return typeof value === "string" ? { endDate: value } : null;
+    case "name":
+      return typeof value === "string" ? { title: value } : null;
+    case "start_date":
+      return typeof value === "string" ? { startDate: value } : null;
+    case "travelers":
+      return typeof value === "number" ? { travelers: value } : null;
+    default:
+      return null;
+  }
+}
+
+function GetTripValueForUpdateField(
+  trip: UiTrip,
+  field: TripUpdateKey
+): UiTrip[keyof UiTrip] | undefined {
+  switch (field) {
+    case "budget":
+      return trip.budget;
+    case "destination":
+      return trip.destination;
+    case "end_date":
+      return trip.endDate;
+    case "name":
+      return trip.title;
+    case "start_date":
+      return trip.startDate;
+    case "travelers":
+      return trip.travelers;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Applies a database trip update field to the UI trip shape.
+ *
+ * Unknown or invalid fields are ignored and reported through client telemetry.
+ */
+export function ApplyTripUpdateToUiTrip(input: {
+  field: TripUpdateKey;
+  prev: UiTrip;
+  tripId: number;
+  value: TripUpdate[TripUpdateKey];
+}): UiTrip {
+  const patch = BuildOptimisticTripPatch(input.field, input.value);
+  if (!patch) {
+    RecordIgnoredTripUpdateField(input);
+    return input.prev;
+  }
+
+  return {
+    ...input.prev,
+    ...patch,
+    updatedAt: nowIso(),
+  };
+}
+
 /**
  * Interface for the optimistic trip updates props.
  */
@@ -140,15 +237,6 @@ export function OptimisticTripUpdates({
   const travelersInputId = useId();
 
   const [trip, setTrip] = useState<UiTrip | null>(null);
-
-  const fieldToUiKey: Partial<Record<TripUpdateKey, keyof UiTrip>> = {
-    budget: "budget",
-    destination: "destination",
-    end_date: "endDate",
-    name: "title",
-    start_date: "startDate",
-    travelers: "travelers",
-  };
 
   useEffect(() => {
     if (!fetchedTrip) return;
@@ -211,7 +299,7 @@ export function OptimisticTripUpdates({
       ...prev,
       [updateKey]: {
         status: "pending",
-        timestamp: new Date(),
+        timestamp: GetCurrentOptimisticUpdateDate(),
         value,
       },
     }));
@@ -219,22 +307,7 @@ export function OptimisticTripUpdates({
     // Update local trip state optimistically
     setTrip((prev) => {
       if (!prev) return prev;
-      const uiKey = fieldToUiKey[field];
-      if (!uiKey) {
-        if (process.env.NODE_ENV === "development") {
-          console.warn("Unmapped trip update field", {
-            field,
-            tripId,
-            value,
-          });
-        }
-        return prev;
-      }
-      return {
-        ...prev,
-        [uiKey]: value as UiTrip[keyof UiTrip],
-        updatedAt: new Date().toISOString(),
-      };
+      return ApplyTripUpdateToUiTrip({ field, prev, tripId, value });
     });
 
     try {
@@ -340,8 +413,7 @@ export function OptimisticTripUpdates({
   const handleInputBlur = (field: keyof TripUpdate) => {
     if (!canEdit) return;
     const value = formData[field];
-    const uiKey = fieldToUiKey[field];
-    const currentValue = uiKey && trip ? trip[uiKey] : undefined;
+    const currentValue = trip ? GetTripValueForUpdateField(trip, field) : undefined;
     if (value !== currentValue) {
       handleOptimisticUpdate(field, value);
     }

--- a/src/features/realtime/components/optimistic-trip-updates.tsx
+++ b/src/features/realtime/components/optimistic-trip-updates.tsx
@@ -134,7 +134,7 @@ function BuildOptimisticTripPatch(
     case "start_date":
       return typeof value === "string" ? { startDate: value } : null;
     case "travelers":
-      return typeof value === "number" && Number.isFinite(value)
+      return typeof value === "number" && Number.isFinite(value) && value >= 1
         ? { travelers: value }
         : null;
     default:
@@ -169,8 +169,10 @@ function GetTripValueForUpdateField(
  *
  * Unknown or invalid fields are ignored and reported through client telemetry.
  *
- * @param input - Trip update details and previous UI trip state.
- * @returns Updated UI trip state, or the previous state when the update is invalid.
+ * @param input - Update context containing field, value, trip id, and previous
+ * UI trip snapshot.
+ * @returns The updated UI trip when mapping succeeds, otherwise the previous
+ * trip unchanged.
  */
 export function ApplyTripUpdateToUiTrip(input: {
   field: TripUpdateKey;

--- a/src/features/realtime/components/optimistic-trip-updates.tsx
+++ b/src/features/realtime/components/optimistic-trip-updates.tsx
@@ -122,7 +122,9 @@ function BuildOptimisticTripPatch(
 > | null {
   switch (field) {
     case "budget":
-      return typeof value === "number" ? { budget: value } : null;
+      return typeof value === "number" && Number.isFinite(value)
+        ? { budget: value }
+        : null;
     case "destination":
       return typeof value === "string" ? { destination: value } : null;
     case "end_date":
@@ -132,7 +134,9 @@ function BuildOptimisticTripPatch(
     case "start_date":
       return typeof value === "string" ? { startDate: value } : null;
     case "travelers":
-      return typeof value === "number" ? { travelers: value } : null;
+      return typeof value === "number" && Number.isFinite(value)
+        ? { travelers: value }
+        : null;
     default:
       return null;
   }
@@ -164,6 +168,9 @@ function GetTripValueForUpdateField(
  * Applies a database trip update field to the UI trip shape.
  *
  * Unknown or invalid fields are ignored and reported through client telemetry.
+ *
+ * @param input - Trip update details and previous UI trip state.
+ * @returns Updated UI trip state, or the previous state when the update is invalid.
  */
 export function ApplyTripUpdateToUiTrip(input: {
   field: TripUpdateKey;

--- a/src/features/realtime/store/realtime-connection-store.ts
+++ b/src/features/realtime/store/realtime-connection-store.ts
@@ -7,6 +7,7 @@ import type { RealtimeChannel } from "@supabase/supabase-js";
 import { create } from "zustand";
 import { computeBackoffDelay, DEFAULT_BACKOFF_CONFIG } from "@/lib/realtime/backoff";
 import { mapChannelStateToStatus } from "@/lib/realtime/status";
+import { nowIso } from "@/lib/security/random";
 import { recordClientErrorOnActiveSpan } from "@/lib/telemetry/client-errors";
 
 export interface RealtimeConnectionEntry {
@@ -50,6 +51,10 @@ interface RealtimeConnectionStore {
   summary: () => RealtimeConnectionSummary;
 }
 
+function getCurrentRealtimeDate(): Date {
+  return new Date(nowIso());
+}
+
 export const useRealtimeConnectionStore = create<RealtimeConnectionStore>(
   (set, get) => ({
     connections: {},
@@ -88,7 +93,7 @@ export const useRealtimeConnectionStore = create<RealtimeConnectionStore>(
         }
 
         set({
-          lastReconnectAt: new Date(),
+          lastReconnectAt: getCurrentRealtimeDate(),
           reconnectAttempts: attempts,
         });
 
@@ -204,7 +209,7 @@ export const useRealtimeConnectionStore = create<RealtimeConnectionStore>(
             ...prev.connections,
             [channelId]: {
               ...existing,
-              lastActivity: new Date(),
+              lastActivity: getCurrentRealtimeDate(),
             },
           },
         };
@@ -218,7 +223,7 @@ export const useRealtimeConnectionStore = create<RealtimeConnectionStore>(
         const status = mapChannelStateToStatus(state, hasError);
         const nextError =
           status === "error" || hasError ? (error ?? existing.lastError ?? null) : null;
-        const nextErrorAt = nextError ? new Date() : null;
+        const nextErrorAt = nextError ? getCurrentRealtimeDate() : null;
         if (nextError && nextError !== existing.lastError) {
           recordClientErrorOnActiveSpan(nextError);
         }

--- a/src/features/shared/components/__tests__/connection-status.dom.test.tsx
+++ b/src/features/shared/components/__tests__/connection-status.dom.test.tsx
@@ -1,7 +1,8 @@
 /** @vitest-environment jsdom */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { renderWithProviders, screen } from "@/test/test-utils";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
 import { ConnectionStatus } from "../connection-status";
 
 describe("ConnectionStatus", () => {
@@ -33,4 +34,29 @@ describe("ConnectionStatus", () => {
     expect(screen.getByText("Uptime")).toBeInTheDocument();
     expect(screen.getByText("Connected")).toBeInTheDocument();
   });
+
+  it(
+    "timestamps last-connected status from the canonical clock helper",
+    withFakeTimers(() => {
+      const fixedNowIso = "2026-02-03T04:05:06.000Z";
+      const expectedTime = new Date(fixedNowIso).toLocaleTimeString();
+      vi.setSystemTime(new Date(fixedNowIso));
+
+      const { rerender } = renderWithProviders(
+        <ConnectionStatus status="connected" variant="detailed" showMetrics={false} />
+      );
+
+      expect(screen.getByText("Connected")).toBeInTheDocument();
+
+      rerender(
+        <ConnectionStatus
+          status="disconnected"
+          variant="detailed"
+          showMetrics={false}
+        />
+      );
+
+      expect(screen.getByText(`Last connected: ${expectedTime}`)).toBeInTheDocument();
+    })
+  );
 });

--- a/src/features/shared/components/connection-status.tsx
+++ b/src/features/shared/components/connection-status.tsx
@@ -37,6 +37,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { nowIso } from "@/lib/security/random";
 import { clampProgress, cn } from "@/lib/utils";
 import { getToneColors, type ToneVariant } from "@/lib/variants/status";
 
@@ -84,6 +85,10 @@ const OPTIMIZATION_ICON_COLORS = {
   latency: "text-destructive",
   packetLoss: "text-warning",
 } as const;
+
+function GetCurrentConnectionStatusDate() {
+  return new Date(nowIso());
+}
 
 // Type for the connection status
 export type ConnectionStatus =
@@ -376,7 +381,7 @@ export const ConnectionStatus: React.FC<ConnectionStatusProps> = ({
     }
 
     if (status === "connected") {
-      setLastConnectedTime(new Date());
+      setLastConnectedTime(GetCurrentConnectionStatusDate());
     }
   }, [status]);
 

--- a/src/features/shared/store/currency/shared.ts
+++ b/src/features/shared/store/currency/shared.ts
@@ -4,11 +4,8 @@
 
 "use client";
 
-import {
-  CURRENCY_CODE_SCHEMA,
-  type Currency,
-  type CurrencyCode,
-} from "@schemas/currency";
+import type { Currency } from "@schemas/currency";
+import { CURRENCY_CODE_SCHEMA, type CurrencyCode } from "@schemas/shared/money";
 
 export const isCurrencyCode = (code: unknown): code is CurrencyCode => {
   return CURRENCY_CODE_SCHEMA.safeParse(code).success;

--- a/src/features/shared/store/currency/slices/conversion.ts
+++ b/src/features/shared/store/currency/slices/conversion.ts
@@ -6,10 +6,10 @@
 
 import {
   CONVERSION_RESULT_SCHEMA,
-  CURRENCY_CODE_SCHEMA,
   type Currency,
   type CurrencyPair,
 } from "@schemas/currency";
+import { CURRENCY_CODE_SCHEMA } from "@schemas/shared/money";
 import type { StateCreator } from "zustand";
 import { getCurrentTimestamp } from "@/features/shared/store/helpers";
 import type { CurrencyStore } from "../../currency-store";

--- a/src/features/trips/components/trip-card.tsx
+++ b/src/features/trips/components/trip-card.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/card";
 import { useBudgetsByTrip } from "@/features/budget/store/budget-store";
 import { DateUtils } from "@/lib/dates/unified-date-utils";
+import { nowIso } from "@/lib/security/random";
 import { cn } from "@/lib/utils";
 import { statusVariants } from "@/lib/variants/status";
 
@@ -38,6 +39,10 @@ interface TripCardProps {
   onDelete?: (tripId: string) => void;
   /** Optional additional CSS classes. */
   className?: string;
+}
+
+function GetCurrentTripCardDate(): Date {
+  return new Date(nowIso());
 }
 
 /**
@@ -73,7 +78,7 @@ export function TripCard({ trip, onEdit, onDelete, className }: TripCardProps) {
    */
   const getTripStatus = () => {
     if (!startDate || !endDate) return "draft";
-    const now = new Date();
+    const now = GetCurrentTripCardDate();
     if (DateUtils.isBefore(now, startDate)) return "upcoming";
     if (DateUtils.isAfter(now, endDate)) return "completed";
     return "active";

--- a/src/features/trips/components/trip-places-panel.tsx
+++ b/src/features/trips/components/trip-places-panel.tsx
@@ -28,6 +28,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { useRemoveSavedPlace, useSavedPlaces, useSavePlace } from "@/hooks/use-trips";
 import { getErrorMessage } from "@/lib/api/error-types";
 import { normalizePlaceIdForStorage } from "@/lib/trips/place-id";
+import { safeHref } from "@/lib/url/safe-href";
 import { fireAndForget } from "@/lib/utils";
 
 type TripPlacesPanelProps = {
@@ -247,6 +248,7 @@ export function TripPlacesPanel({ tripId, userId }: TripPlacesPanelProps) {
                 const isSaved = savedPlaceIds.has(normalizedId);
                 const photoName = place.photoName;
                 const imageSrc = photoName ? GetPhotoUrl(photoName) : null;
+                const mapHref = safeHref(place.url);
 
                 return (
                   <div
@@ -315,10 +317,10 @@ export function TripPlacesPanel({ tripId, userId }: TripPlacesPanelProps) {
                     </div>
 
                     <div className="flex shrink-0 items-center gap-2">
-                      {place.url && (
+                      {mapHref ? (
                         <Button asChild variant="ghost" size="icon">
                           <a
-                            href={place.url}
+                            href={mapHref}
                             target="_blank"
                             rel="noopener noreferrer"
                             aria-label="Open in Maps"
@@ -326,7 +328,7 @@ export function TripPlacesPanel({ tripId, userId }: TripPlacesPanelProps) {
                             <ExternalLinkIcon aria-hidden="true" className="h-4 w-4" />
                           </a>
                         </Button>
-                      )}
+                      ) : null}
                       <Button
                         variant={isSaved ? "secondary" : "default"}
                         disabled={isSaved || savePlaceMutation.isPending}
@@ -380,6 +382,7 @@ export function TripPlacesPanel({ tripId, userId }: TripPlacesPanelProps) {
                   const normalizedId = normalizePlaceIdForStorage(place.placeId);
                   const photoName = place.photoName;
                   const imageSrc = photoName ? GetPhotoUrl(photoName) : null;
+                  const mapHref = safeHref(place.url);
 
                   return (
                     <div
@@ -417,10 +420,10 @@ export function TripPlacesPanel({ tripId, userId }: TripPlacesPanelProps) {
                       </div>
 
                       <div className="flex shrink-0 items-center gap-1">
-                        {place.url && (
+                        {mapHref ? (
                           <Button asChild variant="ghost" size="icon">
                             <a
-                              href={place.url}
+                              href={mapHref}
                               target="_blank"
                               rel="noopener noreferrer"
                               aria-label="Open in Maps"
@@ -431,7 +434,7 @@ export function TripPlacesPanel({ tripId, userId }: TripPlacesPanelProps) {
                               />
                             </a>
                           </Button>
-                        )}
+                        ) : null}
                         <Button
                           variant="ghost"
                           size="icon"

--- a/src/hooks/__tests__/use-authenticated-api.test.tsx
+++ b/src/hooks/__tests__/use-authenticated-api.test.tsx
@@ -170,6 +170,65 @@ describe("useAuthenticatedApi", () => {
     expect(error).toBeInstanceOf(ApiError);
   });
 
+  it("allows concurrent requests without cancelling older in-flight calls", async () => {
+    server.use(
+      http.get(`${API_BASE}/api/slow-endpoint`, async () => {
+        await delay(25);
+        return HttpResponse.json({ endpoint: "slow" });
+      }),
+      http.get(`${API_BASE}/api/fast-endpoint`, () => {
+        return HttpResponse.json({ endpoint: "fast" });
+      })
+    );
+
+    const { result } = renderHook(() => useAuthenticatedApi());
+
+    let responses: unknown[] = [];
+    await act(async () => {
+      responses = await Promise.all([
+        result.current.authenticatedApi.get("/api/slow-endpoint"),
+        result.current.authenticatedApi.get("/api/fast-endpoint"),
+      ]);
+    });
+
+    expect(responses).toEqual([{ endpoint: "slow" }, { endpoint: "fast" }]);
+  });
+
+  it("cancels all concurrent in-flight requests when cancelRequests is called", async () => {
+    server.use(
+      http.get(`${API_BASE}/api/slow-a`, async () => {
+        await delay(100);
+        return HttpResponse.json({ endpoint: "slow-a" });
+      }),
+      http.get(`${API_BASE}/api/slow-b`, async () => {
+        await delay(100);
+        return HttpResponse.json({ endpoint: "slow-b" });
+      })
+    );
+
+    const { result } = renderHook(() => useAuthenticatedApi());
+
+    let errors: unknown[] = [];
+    await act(async () => {
+      const requests = [
+        result.current.authenticatedApi.get("/api/slow-a"),
+        result.current.authenticatedApi.get("/api/slow-b"),
+      ];
+      result.current.cancelRequests();
+      const settled = await Promise.allSettled(requests);
+      errors = settled
+        .filter((entry) => entry.status === "rejected")
+        .map((entry) => entry.reason);
+    });
+
+    expect(errors).toHaveLength(2);
+    expect(errors.every((error) => error instanceof ApiError)).toBe(true);
+    expect(errors.map((error) => (error as ApiError).code)).toEqual([
+      "REQUEST_CANCELLED",
+      "REQUEST_CANCELLED",
+    ]);
+  });
+
   it("handles HTTP errors without code in response body", async () => {
     server.use(
       http.get(`${API_BASE}/api/test-endpoint`, () => {

--- a/src/hooks/__tests__/use-deals.test.ts
+++ b/src/hooks/__tests__/use-deals.test.ts
@@ -3,6 +3,7 @@
 import type { Deal, DealType } from "@schemas/deals";
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
 import { useDealAlerts, useDeals, useFeaturedDeals, useSavedDeals } from "../use-deals";
 
 // Mock current timestamp for consistent testing
@@ -502,6 +503,21 @@ describe("useSavedDeals Hook", () => {
     expect(result.current.sortedByExpiry[0].id).toBe(SAMPLE_DEALS[0].id); // Expires on June 1
     expect(result.current.sortedByExpiry[1].id).toBe(SAMPLE_DEALS[1].id); // Expires on June 15
   });
+
+  it(
+    "should identify saved deals expiring soon from the centralized clock",
+    withFakeTimers(() => {
+      vi.setSystemTime(new Date("2025-06-13T00:00:00.000Z"));
+
+      const { result } = renderHook<ReturnType<typeof useSavedDeals>, void>(() =>
+        useSavedDeals()
+      );
+
+      expect(result.current.expiringSoon.map((deal) => deal.id)).toEqual([
+        SAMPLE_DEALS[1].id,
+      ]);
+    })
+  );
 
   it("should toggle saved status", () => {
     const { result } = renderHook<ReturnType<typeof useSavedDeals>, void>(() =>

--- a/src/hooks/__tests__/use-zod-form.test.ts
+++ b/src/hooks/__tests__/use-zod-form.test.ts
@@ -1,14 +1,24 @@
 /** @vitest-environment jsdom */
 
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
+import { createFakeTimersContext } from "@/test/utils/with-fake-timers";
 import { useZodForm } from "../use-zod-form";
 
 describe("useZodForm", () => {
+  const timers = createFakeTimersContext({ shouldAdvanceTime: true });
+  const nowIso = "2026-01-15T12:00:00.000Z";
   const schema = z.object({
     title: z.string().min(3, { error: "Title must be at least 3 characters" }),
   });
+
+  beforeEach(() => {
+    timers.setup();
+    vi.setSystemTime(new Date(nowIso));
+  });
+
+  afterEach(timers.teardown);
 
   it("validates with trigger() and exposes field errors", async () => {
     const { result } = renderHook(() =>
@@ -29,29 +39,34 @@ describe("useZodForm", () => {
     });
 
     expect(isValid).toBe(false);
-    expect(result.current.formState.errors.title?.message).toBe(
+    expect(result.current.getFieldState("title").error?.message).toBe(
       "Title must be at least 3 characters"
     );
     expect(result.current.isFormComplete).toBe(false);
   });
 
   it("updates isFormComplete when the form becomes valid", async () => {
-    const { result } = renderHook(() =>
-      useZodForm({
+    const { result } = renderHook(() => {
+      const form = useZodForm({
         defaultValues: { title: "" },
         mode: "onChange",
         schema,
-      })
-    );
+      });
+
+      return {
+        form,
+        isFormComplete: form.isFormComplete,
+      };
+    });
 
     act(() => {
-      result.current.register("title");
-      result.current.setValue("title", "Trip");
+      result.current.form.register("title");
+      result.current.form.setValue("title", "Trip");
     });
 
     let isValid = false;
     await act(async () => {
-      isValid = await result.current.trigger();
+      isValid = await result.current.form.trigger();
     });
 
     expect(isValid).toBe(true);
@@ -89,12 +104,13 @@ describe("useZodForm", () => {
       context: "form",
       field: "title",
       message: "Title must be at least 3 characters",
+      timestamp: new Date(nowIso),
     });
 
     expect(result.current.validationState.validationErrors).toContain(
       "Title must be at least 3 characters"
     );
-    expect(result.current.validationState.lastValidation).toBeInstanceOf(Date);
+    expect(result.current.validationState.lastValidation).toEqual(new Date(nowIso));
   });
 
   it("handleSubmitSafe applies transformSubmitData and clears validation errors on success", async () => {
@@ -123,5 +139,6 @@ describe("useZodForm", () => {
 
     expect(onSubmit).toHaveBeenCalledWith({ title: "Trip" });
     expect(result.current.validationState.validationErrors).toHaveLength(0);
+    expect(result.current.validationState.lastValidation).toEqual(new Date(nowIso));
   });
 });

--- a/src/hooks/use-authenticated-api.ts
+++ b/src/hooks/use-authenticated-api.ts
@@ -20,7 +20,7 @@ import { ApiError } from "@/lib/api/error-types";
  * `makeAuthenticatedRequest` helper, and a `cancelRequests` function.
  */
 export function useAuthenticatedApi() {
-  const abortControllerRef = useRef<AbortController | null>(null);
+  const abortControllersRef = useRef<Set<AbortController>>(new Set());
 
   /**
    * Options for authenticated requests.
@@ -105,8 +105,8 @@ export function useAuthenticatedApi() {
       endpoint: string,
       options: AuthFetchOptions = {}
     ): Promise<T> => {
-      if (abortControllerRef.current) abortControllerRef.current.abort();
-      abortControllerRef.current = new AbortController();
+      const controller = new AbortController();
+      abortControllersRef.current.add(controller);
 
       try {
         const method = (options.method || "GET").toUpperCase() as
@@ -151,10 +151,18 @@ export function useAuthenticatedApi() {
           headers,
           params,
           data,
-          abortControllerRef.current.signal,
+          controller.signal,
           { retries: requestRetries, timeout: requestTimeout }
         );
       } catch (error) {
+        if (controller.signal.aborted) {
+          throw new ApiError({
+            code: "REQUEST_CANCELLED",
+            message: "Request was cancelled",
+            status: 499,
+          });
+        }
+
         // ApiClient handles abort signals and timeouts internally, returning
         // properly typed ApiError instances. Pass them through unchanged.
         if (error instanceof ApiError) {
@@ -179,6 +187,8 @@ export function useAuthenticatedApi() {
           message: error instanceof Error ? error.message : "Request failed",
           status: 500,
         });
+      } finally {
+        abortControllersRef.current.delete(controller);
       }
     },
     [normalizeEndpoint, dispatch]
@@ -242,10 +252,10 @@ export function useAuthenticatedApi() {
    * Cancels any in-flight API requests.
    */
   const cancelRequests = useCallback(() => {
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-      abortControllerRef.current = null;
+    for (const controller of abortControllersRef.current) {
+      controller.abort();
     }
+    abortControllersRef.current.clear();
   }, []);
 
   return {

--- a/src/hooks/use-budget.ts
+++ b/src/hooks/use-budget.ts
@@ -20,9 +20,10 @@ import { useShallow } from "zustand/react/shallow";
 import { useBudgetStore } from "@/features/budget/store/budget-store";
 import { useAuthenticatedApi } from "@/hooks/use-authenticated-api";
 import { useCurrentUserId } from "@/hooks/use-current-user-id";
-import { type AppError, handleApiError } from "@/lib/api/error-types";
+import { type ApiError, handleApiError } from "@/lib/api/error-types";
 import { keys } from "@/lib/keys";
 import { staleTimes } from "@/lib/query/config";
+import { nowIso } from "@/lib/security/random";
 
 /**
  * Hook for accessing budget store state.
@@ -146,7 +147,7 @@ export function useFetchBudgets() {
   const { makeAuthenticatedRequest } = useAuthenticatedApi();
   const userId = useCurrentUserId();
 
-  const query = useQuery<{ budgets: Budget[] }, AppError>({
+  const query = useQuery<{ budgets: Budget[] }, ApiError>({
     enabled: !!userId,
     queryFn: async () => {
       try {
@@ -188,7 +189,7 @@ export function useFetchBudget(id: string) {
   const { makeAuthenticatedRequest } = useAuthenticatedApi();
   const userId = useCurrentUserId();
 
-  const query = useQuery<Budget, AppError>({
+  const query = useQuery<Budget, ApiError>({
     enabled: !!id && !!userId,
     queryFn: async () => {
       try {
@@ -220,7 +221,7 @@ export function useCreateBudget() {
   const queryClient = useQueryClient();
   const userId = useCurrentUserId();
 
-  const mutation = useMutation<Budget, AppError, CreateBudgetRequest>({
+  const mutation = useMutation<Budget, ApiError, CreateBudgetRequest>({
     mutationFn: async (variables) => {
       try {
         return await makeAuthenticatedRequest<Budget>("/api/budgets", {
@@ -232,7 +233,8 @@ export function useCreateBudget() {
         throw handleApiError(error);
       }
     },
-    onSuccess: () => {
+    onSuccess: (data) => {
+      addBudget(data);
       if (userId) {
         queryClient.invalidateQueries({ queryKey: keys.budget.list(userId) });
       } else {
@@ -241,12 +243,6 @@ export function useCreateBudget() {
     },
     throwOnError: false,
   });
-
-  useEffect(() => {
-    if (mutation.data) {
-      addBudget(mutation.data);
-    }
-  }, [mutation.data, addBudget]);
 
   return mutation;
 }
@@ -260,7 +256,7 @@ export function useUpdateBudget() {
   const queryClient = useQueryClient();
   const userId = useCurrentUserId();
 
-  const mutation = useMutation<Budget, AppError, UpdateBudgetRequest>({
+  const mutation = useMutation<Budget, ApiError, UpdateBudgetRequest>({
     mutationFn: async (variables) => {
       try {
         return await makeAuthenticatedRequest<Budget>("/api/budgets", {
@@ -273,6 +269,7 @@ export function useUpdateBudget() {
       }
     },
     onSuccess: (data) => {
+      updateBudget(data.id, data);
       if (userId) {
         queryClient.invalidateQueries({
           queryKey: keys.budget.detail(userId, data.id),
@@ -285,12 +282,6 @@ export function useUpdateBudget() {
     },
     throwOnError: false,
   });
-
-  useEffect(() => {
-    if (mutation.data) {
-      updateBudget(mutation.data.id, mutation.data);
-    }
-  }, [mutation.data, updateBudget]);
 
   return mutation;
 }
@@ -304,7 +295,7 @@ export function useDeleteBudget() {
   const queryClient = useQueryClient();
   const userId = useCurrentUserId();
 
-  const mutation = useMutation<{ success: boolean; id: string }, AppError, string>({
+  const mutation = useMutation<{ success: boolean; id: string }, ApiError, string>({
     mutationFn: async (id) => {
       try {
         return await makeAuthenticatedRequest<{ success: boolean; id: string }>(
@@ -318,6 +309,10 @@ export function useDeleteBudget() {
       }
     },
     onSuccess: (data) => {
+      if (data.success) {
+        removeBudget(data.id);
+      }
+
       if (userId) {
         queryClient.invalidateQueries({
           queryKey: keys.budget.detail(userId, data.id),
@@ -330,12 +325,6 @@ export function useDeleteBudget() {
     },
     throwOnError: false,
   });
-
-  useEffect(() => {
-    if (mutation.data?.success) {
-      removeBudget(mutation.data.id);
-    }
-  }, [mutation.data, removeBudget]);
 
   return mutation;
 }
@@ -350,7 +339,7 @@ export function useFetchExpenses(budgetId: string) {
   const { makeAuthenticatedRequest } = useAuthenticatedApi();
   const userId = useCurrentUserId();
 
-  const query = useQuery<{ expenses: Expense[] }, AppError>({
+  const query = useQuery<{ expenses: Expense[] }, ApiError>({
     enabled: !!budgetId && !!userId,
     queryFn: async () => {
       try {
@@ -384,7 +373,7 @@ export function useAddExpense() {
   const queryClient = useQueryClient();
   const userId = useCurrentUserId();
 
-  const mutation = useMutation<Expense, AppError, AddExpenseRequest>({
+  const mutation = useMutation<Expense, ApiError, AddExpenseRequest>({
     mutationFn: async (variables) => {
       try {
         return await makeAuthenticatedRequest<Expense>("/api/expenses", {
@@ -397,6 +386,7 @@ export function useAddExpense() {
       }
     },
     onSuccess: (data) => {
+      addExpense(data);
       if (userId) {
         queryClient.invalidateQueries({
           queryKey: keys.budget.expenses(userId, data.budgetId),
@@ -407,12 +397,6 @@ export function useAddExpense() {
     },
     throwOnError: false,
   });
-
-  useEffect(() => {
-    if (mutation.data) {
-      addExpense(mutation.data);
-    }
-  }, [mutation.data, addExpense]);
 
   return mutation;
 }
@@ -426,7 +410,7 @@ export function useUpdateExpense() {
   const queryClient = useQueryClient();
   const userId = useCurrentUserId();
 
-  const mutation = useMutation<Expense, AppError, UpdateExpenseRequest>({
+  const mutation = useMutation<Expense, ApiError, UpdateExpenseRequest>({
     mutationFn: async (variables) => {
       try {
         return await makeAuthenticatedRequest<Expense>("/api/expenses", {
@@ -439,6 +423,7 @@ export function useUpdateExpense() {
       }
     },
     onSuccess: (data) => {
+      updateExpense(data.id, data.budgetId, data);
       if (userId) {
         queryClient.invalidateQueries({
           queryKey: keys.budget.expenses(userId, data.budgetId),
@@ -449,12 +434,6 @@ export function useUpdateExpense() {
     },
     throwOnError: false,
   });
-
-  useEffect(() => {
-    if (mutation.data) {
-      updateExpense(mutation.data.id, mutation.data.budgetId, mutation.data);
-    }
-  }, [mutation.data, updateExpense]);
 
   return mutation;
 }
@@ -470,7 +449,7 @@ export function useDeleteExpense() {
 
   const mutation = useMutation<
     { success: boolean; id: string; budgetId: string },
-    AppError,
+    ApiError,
     string
   >({
     mutationFn: async (id) => {
@@ -487,6 +466,10 @@ export function useDeleteExpense() {
       }
     },
     onSuccess: (data) => {
+      if (data.success) {
+        removeExpense(data.id, data.budgetId);
+      }
+
       if (userId) {
         queryClient.invalidateQueries({
           queryKey: keys.budget.expenses(userId, data.budgetId),
@@ -497,12 +480,6 @@ export function useDeleteExpense() {
     },
     throwOnError: false,
   });
-
-  useEffect(() => {
-    if (mutation.data?.success) {
-      removeExpense(mutation.data.id, mutation.data.budgetId);
-    }
-  }, [mutation.data, removeExpense]);
 
   return mutation;
 }
@@ -517,7 +494,7 @@ export function useFetchAlerts(budgetId: string) {
   const { makeAuthenticatedRequest } = useAuthenticatedApi();
   const userId = useCurrentUserId();
 
-  const query = useQuery<{ alerts: BudgetAlert[] }, AppError>({
+  const query = useQuery<{ alerts: BudgetAlert[] }, ApiError>({
     enabled: !!budgetId && !!userId,
     queryFn: async () => {
       try {
@@ -551,7 +528,7 @@ export function useCreateAlert() {
   const queryClient = useQueryClient();
   const userId = useCurrentUserId();
 
-  const mutation = useMutation<BudgetAlert, AppError, CreateBudgetAlertRequest>({
+  const mutation = useMutation<BudgetAlert, ApiError, CreateBudgetAlertRequest>({
     mutationFn: async (variables) => {
       try {
         return await makeAuthenticatedRequest<BudgetAlert>("/api/alerts", {
@@ -564,6 +541,7 @@ export function useCreateAlert() {
       }
     },
     onSuccess: (data) => {
+      addAlert(data);
       if (userId) {
         queryClient.invalidateQueries({
           queryKey: keys.budget.alerts(userId, data.budgetId),
@@ -574,12 +552,6 @@ export function useCreateAlert() {
     },
     throwOnError: false,
   });
-
-  useEffect(() => {
-    if (mutation.data) {
-      addAlert(mutation.data);
-    }
-  }, [mutation.data, addAlert]);
 
   return mutation;
 }
@@ -595,7 +567,7 @@ export function useMarkAlertAsRead() {
 
   const mutation = useMutation<
     { id: string; budgetId: string; isRead: boolean },
-    AppError,
+    ApiError,
     { id: string; budgetId: string }
   >({
     mutationFn: async (variables) => {
@@ -614,6 +586,7 @@ export function useMarkAlertAsRead() {
       }
     },
     onSuccess: (data) => {
+      markAlertAsRead(data.id, data.budgetId);
       if (userId) {
         queryClient.invalidateQueries({
           queryKey: keys.budget.alerts(userId, data.budgetId),
@@ -625,12 +598,6 @@ export function useMarkAlertAsRead() {
     throwOnError: false,
   });
 
-  useEffect(() => {
-    if (mutation.data) {
-      markAlertAsRead(mutation.data.id, mutation.data.budgetId);
-    }
-  }, [mutation.data, markAlertAsRead]);
-
   return mutation;
 }
 
@@ -641,7 +608,7 @@ export function useFetchCurrencyRates() {
   const setCurrencies = useBudgetStore((state) => state.setCurrencies);
   const { makeAuthenticatedRequest } = useAuthenticatedApi();
 
-  const query = useQuery<{ rates: Record<string, number> }, AppError>({
+  const query = useQuery<{ rates: Record<string, number> }, ApiError>({
     queryFn: async () => {
       try {
         return await makeAuthenticatedRequest<{ rates: Record<string, number> }>(
@@ -664,7 +631,7 @@ export function useFetchCurrencyRates() {
         (acc, [code, rate]) => {
           acc[code] = {
             code,
-            lastUpdated: new Date().toISOString(),
+            lastUpdated: nowIso(),
             rate,
           };
           return acc;

--- a/src/hooks/use-currency.ts
+++ b/src/hooks/use-currency.ts
@@ -15,7 +15,7 @@ import { useCallback, useEffect, useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useCurrencyStore } from "@/features/shared/store/currency-store";
 import { useAuthenticatedApi } from "@/hooks/use-authenticated-api";
-import { type AppError, handleApiError, isApiError } from "@/lib/api/error-types";
+import { type ApiError, handleApiError, isApiError } from "@/lib/api/error-types";
 import { keys } from "@/lib/keys";
 import { staleTimes } from "@/lib/query/config";
 import { recordClientErrorOnActiveSpan } from "@/lib/telemetry/client-errors";
@@ -29,7 +29,7 @@ const MAX_CURRENCY_QUERY_RETRIES = 2;
  * @param error - Normalized application error for the failed request.
  * @returns True when the query should be retried, otherwise false.
  */
-function shouldRetryCurrencyQuery(failureCount: number, error: AppError): boolean {
+function shouldRetryCurrencyQuery(failureCount: number, error: ApiError): boolean {
   if (isApiError(error) && (error.status === 401 || error.status === 403)) {
     return false;
   }
@@ -205,7 +205,7 @@ export function useFetchExchangeRates() {
   );
   const { makeAuthenticatedRequest } = useAuthenticatedApi();
 
-  const query = useQuery<UpdateExchangeRatesResponse, AppError>({
+  const query = useQuery<UpdateExchangeRatesResponse, ApiError>({
     queryFn: async () => {
       try {
         return await makeAuthenticatedRequest<UpdateExchangeRatesResponse>(
@@ -255,7 +255,7 @@ export function useFetchExchangeRate(targetCurrency: CurrencyCode) {
   );
   const { makeAuthenticatedRequest } = useAuthenticatedApi();
 
-  const query = useQuery<{ rate: number; timestamp: string }, AppError>({
+  const query = useQuery<{ rate: number; timestamp: string }, ApiError>({
     enabled: !!targetCurrency && targetCurrency !== baseCurrency,
     queryFn: async () => {
       try {

--- a/src/hooks/use-deals.ts
+++ b/src/hooks/use-deals.ts
@@ -9,6 +9,13 @@ import { useCallback, useEffect, useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useDealsStore } from "@/features/search/store/deals-store";
 import { groupBy, mapToUnique } from "@/lib/collection-utils";
+import { nowIso } from "@/lib/security/random";
+
+const SAVED_DEALS_EXPIRING_SOON_WINDOW_MS = 3 * 24 * 60 * 60 * 1000;
+
+function getCurrentDealTimestampMs(): number {
+  return Date.parse(nowIso());
+}
 
 /**
  * Hook for accessing and managing deals.
@@ -94,12 +101,9 @@ export function useDeals() {
   // Get all deals as array
   const allDeals = useMemo(() => Object.values(deals), [deals]);
 
-  // Get filtered deals based on current filters
-  // biome-ignore lint/correctness/useExhaustiveDependencies: ensure memo recomputes on state changes used inside store selectors.
-  const filteredDeals = useMemo(
-    () => getFilteredDeals(),
-    [getFilteredDeals, deals, filters]
-  );
+  // Get filtered deals based on current filters. The hook subscribes to deals and
+  // filters above, so render-time derivation stays in sync without hidden deps.
+  const filteredDeals = getFilteredDeals();
 
   // Get featured deals
   const featuredDeals = featuredDealItems;
@@ -110,9 +114,8 @@ export function useDeals() {
   // Get recently viewed deals
   const recentlyViewedDeals = recentlyViewedDealItems;
 
-  // Get deal statistics
-  // biome-ignore lint/correctness/useExhaustiveDependencies: ensure memo recomputes on state changes used inside store selectors.
-  const dealStats = useMemo(() => getDealsStats(), [getDealsStats, deals, filters]);
+  // Get deal statistics from the current store snapshot.
+  const dealStats = getDealsStats();
 
   // Convert IDs to Sets for O(1) membership checks.
   const savedDealIdSet = useMemo(() => new Set(savedDealIds), [savedDealIds]);
@@ -404,12 +407,18 @@ export function useSavedDeals() {
 
   // Get deals expiring soon (within 3 days)
   const expiringSoon = useMemo(() => {
-    const threeDaysFromNow = new Date();
-    threeDaysFromNow.setDate(threeDaysFromNow.getDate() + 3);
+    const currentTimestampMs = getCurrentDealTimestampMs();
+    const expiringSoonCutoffMs =
+      currentTimestampMs + SAVED_DEALS_EXPIRING_SOON_WINDOW_MS;
 
     return savedDeals.filter((deal) => {
-      const expiryDate = new Date(deal.expiryDate);
-      return expiryDate <= threeDaysFromNow && expiryDate >= new Date();
+      const expiryTimestampMs = Date.parse(deal.expiryDate);
+
+      return (
+        Number.isFinite(expiryTimestampMs) &&
+        expiryTimestampMs <= expiringSoonCutoffMs &&
+        expiryTimestampMs >= currentTimestampMs
+      );
     });
   }, [savedDeals]);
 

--- a/src/hooks/use-trip-collaborators.ts
+++ b/src/hooks/use-trip-collaborators.ts
@@ -12,7 +12,7 @@ import type {
 } from "@schemas/trips";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCurrentUserId } from "@/hooks/use-current-user-id";
-import { ApiError, type ApiErrorCode, type AppError } from "@/lib/api/error-types";
+import { ApiError, type ApiErrorCode } from "@/lib/api/error-types";
 import { keys } from "@/lib/keys";
 import { cacheTimes, staleTimes } from "@/lib/query/config";
 import type { Result, ResultError } from "@/lib/result";
@@ -92,7 +92,7 @@ export function useTripCollaborators(
   const userId = options?.userId ?? inferredUserId;
   const enabled = tripId !== null && !!userId;
 
-  return useQuery<TripCollaboratorsResponse, AppError>({
+  return useQuery<TripCollaboratorsResponse, ApiError>({
     enabled,
     gcTime: cacheTimes.medium,
     queryFn: async () => {
@@ -119,7 +119,7 @@ export function useInviteTripCollaborator(tripId: number) {
 
   return useMutation<
     InviteTripCollaboratorResponse,
-    AppError,
+    ApiError,
     TripCollaboratorInviteInput
   >({
     mutationFn: async (payload) => {
@@ -147,7 +147,7 @@ export function useUpdateTripCollaboratorRole(tripId: number) {
 
   return useMutation<
     UpdateTripCollaboratorRoleResponse,
-    AppError,
+    ApiError,
     { collaboratorUserId: string; payload: TripCollaboratorRoleUpdateInput }
   >({
     mutationFn: async ({ collaboratorUserId, payload }) => {
@@ -173,7 +173,7 @@ export function useRemoveTripCollaborator(tripId: number) {
   const queryClient = useQueryClient();
   const userId = useCurrentUserId();
 
-  return useMutation<void, AppError, { collaboratorUserId: string }>({
+  return useMutation<void, ApiError, { collaboratorUserId: string }>({
     mutationFn: async ({ collaboratorUserId }) => {
       const result = await removeCollaborator(tripId, collaboratorUserId);
       unwrapResult(result, "trips.collaborators.remove");

--- a/src/hooks/use-trips.ts
+++ b/src/hooks/use-trips.ts
@@ -18,7 +18,7 @@ import type { QueryKey } from "@tanstack/react-query";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuthenticatedApi } from "@/hooks/use-authenticated-api";
 import { useCurrentUserId } from "@/hooks/use-current-user-id";
-import { ApiError, type ApiErrorCode, type AppError } from "@/lib/api/error-types";
+import { ApiError, type ApiErrorCode } from "@/lib/api/error-types";
 import { keys } from "@/lib/keys";
 import { cacheTimes, staleTimes } from "@/lib/query/config";
 import type { Result, ResultError } from "@/lib/result";
@@ -139,7 +139,7 @@ export function useTripSuggestions(params?: TripSuggestionsParams) {
     normalizedParams.category = params.category;
   }
 
-  return useQuery<TripSuggestion[], AppError>({
+  return useQuery<TripSuggestion[], ApiError>({
     enabled: !!userId,
     gcTime: cacheTimes.medium,
     queryFn: async () => {
@@ -166,7 +166,7 @@ export function useCreateTrip() {
   const queryClient = useQueryClient();
   const userId = useCurrentUserId();
 
-  return useMutation<UiTrip, AppError, TripCreateInput>({
+  return useMutation<UiTrip, ApiError, TripCreateInput>({
     mutationFn: async (tripData: TripCreateInput) => {
       const result = await createTripAction(tripData);
       return unwrapResult(result, "trips.create");
@@ -203,7 +203,7 @@ export function useUpdateTrip(options?: { userId?: string | null }) {
 
   return useMutation<
     UiTrip,
-    AppError,
+    ApiError,
     { tripId: string | number; data: UpdateTripData },
     UpdateTripContext
   >({
@@ -307,7 +307,7 @@ export function useDeleteTrip(options?: { userId?: string | null }) {
   const inferredUserId = useCurrentUserId();
   const userId = options?.userId ?? inferredUserId;
 
-  return useMutation<void, AppError, string | number>({
+  return useMutation<void, ApiError, string | number>({
     mutationFn: async (tripId: string | number) => {
       const numericTripId = normalizeTripId(tripId);
       if (numericTripId === null) {
@@ -393,7 +393,7 @@ export function useTrips(filters?: TripFilters, options?: { userId?: string | nu
   const userId = options?.userId ?? inferredUserId;
   const apiParams = convertToApiParams(filters);
 
-  const query = useQuery<Trip[], AppError>({
+  const query = useQuery<Trip[], ApiError>({
     enabled: !!userId,
     gcTime: cacheTimes.medium,
     queryFn: async () => {
@@ -424,7 +424,7 @@ export function useTrip(
 
   const numericTripId = normalizeTripId(tripId);
 
-  const query = useQuery<Trip | null, AppError>({
+  const query = useQuery<Trip | null, ApiError>({
     enabled: numericTripId !== null && !!userId,
     gcTime: cacheTimes.medium,
     queryFn: async () => {
@@ -459,7 +459,7 @@ export function useTripItinerary(
       ? keys.trips.itinerary(userId, tripId)
       : keys.trips.itineraryDisabled();
 
-  return useQuery<ItineraryItem[], AppError>({
+  return useQuery<ItineraryItem[], ApiError>({
     enabled,
     gcTime: cacheTimes.medium,
     queryFn: async () => {
@@ -495,7 +495,7 @@ export function useUpsertTripItineraryItem(
 
   return useMutation<
     ItineraryItem,
-    AppError,
+    ApiError,
     ItineraryItemUpsertInput,
     UpsertItineraryContext
   >({
@@ -599,7 +599,7 @@ export function useDeleteTripItineraryItem(
 
   return useMutation<
     void,
-    AppError,
+    ApiError,
     { itemId: number },
     { previous?: ItineraryItem[] }
   >({
@@ -642,7 +642,7 @@ export function useSavedPlaces(tripId: number, options?: { userId?: string | nul
   const inferredUserId = useCurrentUserId();
   const userId = options?.userId ?? inferredUserId;
 
-  return useQuery<SavedPlaceSnapshot[], AppError>({
+  return useQuery<SavedPlaceSnapshot[], ApiError>({
     enabled: !!userId && Number.isFinite(tripId) && tripId > 0,
     gcTime: cacheTimes.short,
     queryFn: async () => {
@@ -664,7 +664,7 @@ export function useSavePlace(tripId: number, options?: { userId?: string | null 
 
   return useMutation<
     SavedPlaceSnapshot,
-    AppError,
+    ApiError,
     { place: PlaceSummary },
     { previous?: SavedPlaceSnapshot[] }
   >({
@@ -722,7 +722,7 @@ export function useRemoveSavedPlace(
 
   return useMutation<
     void,
-    AppError,
+    ApiError,
     { placeId: string },
     { previous?: SavedPlaceSnapshot[] }
   >({
@@ -824,7 +824,7 @@ export function useUpcomingFlights(params?: UpcomingFlightsParams) {
     limit: params?.limit ?? 10,
   };
 
-  return useQuery<UpcomingFlight[], AppError>({
+  return useQuery<UpcomingFlight[], ApiError>({
     gcTime: cacheTimes.short,
     queryFn: async () => {
       return await makeAuthenticatedRequest<UpcomingFlight[]>("/api/flights/upcoming", {

--- a/src/hooks/use-zod-form.ts
+++ b/src/hooks/use-zod-form.ts
@@ -13,6 +13,7 @@ import {
   useForm,
 } from "react-hook-form";
 import type { z } from "zod";
+import { nowIso } from "@/lib/security/random";
 import { recordClientErrorOnActiveSpan } from "@/lib/telemetry/client-errors";
 
 // Zod v4: `ZodType<Output, Input, Internals>` (Input defaults to `unknown`), so we pin
@@ -74,6 +75,10 @@ function isFieldErrorLike(value: unknown): value is FieldErrorLike {
 }
 
 const MAX_ERROR_DEPTH = 20;
+
+function getCurrentValidationDate(): Date {
+  return new Date(nowIso());
+}
 
 function collectRhfErrors(
   errors: unknown,
@@ -167,12 +172,14 @@ function validationResultFromFieldErrors<Data extends FieldValues>(
           code: "FORM_VALIDATION_ERROR",
           context: "form",
           message: "Validation failed",
-          timestamp: new Date(),
+          timestamp: getCurrentValidationDate(),
         },
       ],
       success: false,
     };
   }
+
+  const timestamp = getCurrentValidationDate();
 
   return {
     errors: flattened.map((error) => ({
@@ -181,7 +188,7 @@ function validationResultFromFieldErrors<Data extends FieldValues>(
       field: error.path,
       message: error.message,
       path: error.path ? error.path.split(".") : undefined,
-      timestamp: new Date(),
+      timestamp,
     })),
     success: false,
   };
@@ -230,7 +237,7 @@ export function useZodForm<Schema extends AnyFieldValuesSchema>(
           async (data) => {
             setValidationState({
               isValidating: false,
-              lastValidation: new Date(),
+              lastValidation: getCurrentValidationDate(),
               validationErrors: [],
             });
 
@@ -265,7 +272,7 @@ export function useZodForm<Schema extends AnyFieldValuesSchema>(
               setValidationState((prev) => ({
                 ...prev,
                 isValidating: false,
-                lastValidation: prev.lastValidation ?? new Date(),
+                lastValidation: prev.lastValidation ?? getCurrentValidationDate(),
               }));
             }
           },
@@ -275,7 +282,7 @@ export function useZodForm<Schema extends AnyFieldValuesSchema>(
 
             setValidationState({
               isValidating: false,
-              lastValidation: new Date(),
+              lastValidation: getCurrentValidationDate(),
               validationErrors: validationResult.errors?.map((e) => e.message) ?? [],
             });
 
@@ -296,19 +303,26 @@ export function useZodForm<Schema extends AnyFieldValuesSchema>(
     [form, onSubmitError, onSubmitSuccess, onValidationError, transformSubmitData]
   );
 
-  // Subscribe to form validity via RHF's formState Proxy.
-  const { isValid, isValidating } = form.formState;
-  const isFormComplete = isValid;
-
-  return {
+  const enhancedForm = {
     ...form,
     handleSubmitSafe,
-    isFormComplete,
-    validationState: {
-      ...validationState,
-      isValidating: validationState.isValidating || isValidating,
+  } as UseZodFormReturn<FormFieldValues<Schema>, FormSubmitValues<Schema>>;
+
+  Object.defineProperties(enhancedForm, {
+    isFormComplete: {
+      enumerable: false,
+      get: () => form.formState.isValid,
     },
-  };
+    validationState: {
+      enumerable: false,
+      get: () => ({
+        ...validationState,
+        isValidating: validationState.isValidating || form.formState.isValidating,
+      }),
+    },
+  });
+
+  return enhancedForm;
 }
 
 // Export types for external use

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Client instrumentation entrypoint (Next.js 15.3+) for BotID.
+ * @fileoverview Next.js client instrumentation entrypoint for BotID.
  */
 
 import { patchPerformanceMeasureForPrerender } from "@/lib/performance/patch-performance-measure";

--- a/src/lib/__tests__/error-service.test.ts
+++ b/src/lib/__tests__/error-service.test.ts
@@ -221,31 +221,6 @@ describe("ErrorService", () => {
     beforeEach(timers.setup);
     afterEach(timers.teardown);
 
-    it("simulates rejected fetches before returning a successful response", async () => {
-      const endpoint = config.endpoint ?? ERROR_REPORTING_ENDPOINT;
-      const flaky = createFlakyErrorReportingHandler({
-        endpoint,
-        failTimes: 1,
-      });
-      server.use(flaky.handler);
-
-      await expect(
-        fetch(endpoint, {
-          body: JSON.stringify(buildReport()),
-          method: "POST",
-        })
-      ).rejects.toThrow();
-
-      const response = await fetch(endpoint, {
-        body: JSON.stringify(buildReport()),
-        method: "POST",
-      });
-
-      expect(response.ok).toBe(true);
-      await expect(response.json()).resolves.toEqual({ success: true });
-      expect(flaky.callCount()).toBe(2);
-    });
-
     it("retries transient failures up to maxRetries", async () => {
       const flaky = createFlakyErrorReportingHandler({
         endpoint: config.endpoint,

--- a/src/lib/__tests__/error-service.test.ts
+++ b/src/lib/__tests__/error-service.test.ts
@@ -11,7 +11,7 @@ import {
   ERROR_REPORTING_ENDPOINT,
 } from "@/test/msw/handlers/error-reporting";
 import { server } from "@/test/msw/server";
-import { createFakeTimersContext } from "@/test/utils/with-fake-timers";
+import { createFakeTimersContext, withFakeTimers } from "@/test/utils/with-fake-timers";
 import { ErrorService } from "../error-service";
 
 type StorageMocks = {
@@ -107,30 +107,35 @@ describe("ErrorService", () => {
   });
 
   describe("createErrorReport", () => {
-    it("builds a report with runtime context and optional details", () => {
-      const error = new Error("Test error");
-      error.stack = "Error: Test error\n    at test (test.js:1:1)";
+    it(
+      "builds a report with helper-backed runtime timestamp and optional details",
+      withFakeTimers(() => {
+        vi.setSystemTime(new Date("2026-02-03T04:05:06.000Z"));
 
-      const report = errorService.createErrorReport(
-        error,
-        { componentStack: "Component.tsx:10:5" },
-        { sessionId: "session-1", userId: "user-1" }
-      );
+        const error = new Error("Test error");
+        error.stack = "Error: Test error\n    at test (test.js:1:1)";
 
-      expect(report.error).toMatchObject({
-        message: "Test error",
-        name: "Error",
-        stack: "Error: Test error\n    at test (test.js:1:1)",
-      });
-      expect(report.errorInfo).toEqual({
-        componentStack: "Component.tsx:10:5",
-      });
-      expect(report.sessionId).toBe("session-1");
-      expect(report.userId).toBe("user-1");
-      expect(report.url).toBe("https://example.com/");
-      expect(report.userAgent).toBe("Vitest");
-      expect(new Date(report.timestamp).toISOString()).toBe(report.timestamp);
-    });
+        const report = errorService.createErrorReport(
+          error,
+          { componentStack: "Component.tsx:10:5" },
+          { sessionId: "session-1", userId: "user-1" }
+        );
+
+        expect(report.error).toMatchObject({
+          message: "Test error",
+          name: "Error",
+          stack: "Error: Test error\n    at test (test.js:1:1)",
+        });
+        expect(report.errorInfo).toEqual({
+          componentStack: "Component.tsx:10:5",
+        });
+        expect(report.sessionId).toBe("session-1");
+        expect(report.userId).toBe("user-1");
+        expect(report.url).toBe("https://example.com/");
+        expect(report.userAgent).toBe("Vitest");
+        expect(report.timestamp).toBe("2026-02-03T04:05:06.000Z");
+      })
+    );
 
     it("includes error digests when present", () => {
       const error = new Error("Test error") as Error & { digest?: string };
@@ -171,19 +176,24 @@ describe("ErrorService", () => {
       expect(recorder.requests).toHaveLength(0);
     });
 
-    it("persists errors to localStorage when enabled", async () => {
-      const recorder = createErrorReportingRecorder(config.endpoint);
-      server.use(recorder.handler);
-      const errorReport = buildReport();
+    it(
+      "persists errors to localStorage with helper-backed keys when enabled",
+      withFakeTimers(async () => {
+        vi.setSystemTime(new Date("2026-02-03T04:05:06.000Z"));
 
-      await errorService.reportError(errorReport);
+        const recorder = createErrorReportingRecorder(config.endpoint);
+        server.use(recorder.handler);
+        const errorReport = buildReport();
 
-      const setItemMock = localStorageMock.setItem as ReturnType<typeof vi.fn>;
-      expect(setItemMock).toHaveBeenCalledTimes(1);
-      const [key, value] = setItemMock.mock.calls[0] as [string, string];
-      expect(key).toMatch(/^error_\d+_[a-z0-9]+$/);
-      expect(JSON.parse(value)).toEqual(errorReport);
-    });
+        await errorService.reportError(errorReport);
+
+        const setItemMock = localStorageMock.setItem as ReturnType<typeof vi.fn>;
+        expect(setItemMock).toHaveBeenCalledTimes(1);
+        const [key, value] = setItemMock.mock.calls[0] as [string, string];
+        expect(key).toMatch(/^error_2026-02-03T04:05:06\.000Z_[a-z0-9]+$/);
+        expect(JSON.parse(value)).toEqual(errorReport);
+      })
+    );
 
     it("silently handles invalid reports via Zod validation without crashing", async () => {
       const recorder = createErrorReportingRecorder(config.endpoint);
@@ -210,6 +220,31 @@ describe("ErrorService", () => {
     const timers = createFakeTimersContext();
     beforeEach(timers.setup);
     afterEach(timers.teardown);
+
+    it("simulates rejected fetches before returning a successful response", async () => {
+      const endpoint = config.endpoint ?? ERROR_REPORTING_ENDPOINT;
+      const flaky = createFlakyErrorReportingHandler({
+        endpoint,
+        failTimes: 1,
+      });
+      server.use(flaky.handler);
+
+      await expect(
+        fetch(endpoint, {
+          body: JSON.stringify(buildReport()),
+          method: "POST",
+        })
+      ).rejects.toThrow();
+
+      const response = await fetch(endpoint, {
+        body: JSON.stringify(buildReport()),
+        method: "POST",
+      });
+
+      expect(response.ok).toBe(true);
+      await expect(response.json()).resolves.toEqual({ success: true });
+      expect(flaky.callCount()).toBe(2);
+    });
 
     it("retries transient failures up to maxRetries", async () => {
       const flaky = createFlakyErrorReportingHandler({

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { clampProgress, fireAndForget } from "../utils";
+import { clampProgress, fireAndForget, throttle } from "../utils";
 
 const FLUSH_MICROTASKS = () => new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -61,5 +61,38 @@ describe("fireAndForget", () => {
     await FLUSH_MICROTASKS();
 
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("throttle", () => {
+  it("runs the first call even when the monotonic clock starts below the delay", () => {
+    const nowSpy = vi.spyOn(performance, "now").mockReturnValue(5);
+    const fn = vi.fn();
+    const throttled = throttle(fn, 100);
+
+    throttled("first");
+
+    expect(fn).toHaveBeenCalledOnce();
+    expect(fn).toHaveBeenCalledWith("first");
+    expect(nowSpy).toHaveBeenCalledOnce();
+  });
+
+  it("uses monotonic elapsed time to suppress calls within the delay", () => {
+    const nowSpy = vi
+      .spyOn(performance, "now")
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(40)
+      .mockReturnValueOnce(111);
+    const fn = vi.fn();
+    const throttled = throttle(fn, 100);
+
+    throttled("first");
+    throttled("suppressed");
+    throttled("second");
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenNthCalledWith(1, "first");
+    expect(fn).toHaveBeenNthCalledWith(2, "second");
+    expect(nowSpy).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/lib/agents/__tests__/version-id.test.ts
+++ b/src/lib/agents/__tests__/version-id.test.ts
@@ -1,0 +1,12 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+import { createAgentConfigVersionId } from "@/lib/agents/version-id";
+
+describe("createAgentConfigVersionId", () => {
+  it("keeps the existing epoch-second version id shape", () => {
+    expect(createAgentConfigVersionId("2026-02-03T04:05:06.000Z", "deadbeef")).toBe(
+      "v1770091506_deadbeef"
+    );
+  });
+});

--- a/src/lib/agents/version-id.ts
+++ b/src/lib/agents/version-id.ts
@@ -12,8 +12,9 @@ const VERSION_ID_RANDOM_LENGTH = 8;
  * Keeps the existing `v<epoch_seconds>_<token>` shape while deriving the
  * timestamp through the repo timestamp helper.
  *
- * @param currentIso - ISO timestamp used to derive the version epoch seconds.
- * @param token - Random token suffix for collision resistance.
+ * @param currentIso - ISO 8601 timestamp string; defaults to current time via
+ * `nowIso()`.
+ * @param token - Random token string; defaults to an 8-character secure ID.
  * @returns Agent configuration version identifier.
  */
 export function createAgentConfigVersionId(

--- a/src/lib/agents/version-id.ts
+++ b/src/lib/agents/version-id.ts
@@ -12,6 +12,8 @@ const VERSION_ID_RANDOM_LENGTH = 8;
  * Keeps the existing `v<epoch_seconds>_<token>` shape while deriving the
  * timestamp through the repo timestamp helper.
  *
+ * @param currentIso - ISO timestamp used to derive the version epoch seconds.
+ * @param token - Random token suffix for collision resistance.
  * @returns Agent configuration version identifier.
  */
 export function createAgentConfigVersionId(

--- a/src/lib/agents/version-id.ts
+++ b/src/lib/agents/version-id.ts
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview Agent configuration version identifier helpers.
+ */
+
+import { nowIso, secureId } from "@/lib/security/random";
+
+const VERSION_ID_RANDOM_LENGTH = 8;
+
+/**
+ * Creates a sortable agent configuration version identifier.
+ *
+ * Keeps the existing `v<epoch_seconds>_<token>` shape while deriving the
+ * timestamp through the repo timestamp helper.
+ *
+ * @returns Agent configuration version identifier.
+ */
+export function createAgentConfigVersionId(
+  currentIso: string = nowIso(),
+  token: string = secureId(VERSION_ID_RANDOM_LENGTH)
+): string {
+  const epochSeconds = Math.floor(Date.parse(currentIso) / 1000);
+  return `v${epochSeconds}_${token}`;
+}

--- a/src/lib/agents/version-id.ts
+++ b/src/lib/agents/version-id.ts
@@ -16,6 +16,7 @@ const VERSION_ID_RANDOM_LENGTH = 8;
  * `nowIso()`.
  * @param token - Random token string; defaults to an 8-character secure ID.
  * @returns Agent configuration version identifier.
+ * @see docs/architecture/decisions/adr-0052-agent-configuration-backend.md
  */
 export function createAgentConfigVersionId(
   currentIso: string = nowIso(),

--- a/src/lib/api/__tests__/api-client.test.ts
+++ b/src/lib/api/__tests__/api-client.test.ts
@@ -52,6 +52,7 @@ type PaginatedResponse = z.infer<typeof PAGINATED_RESPONSE_SCHEMA>;
 
 /** Dedicated API client instance for testing with absolute base URL. */
 const CLIENT = new ApiClient({ baseUrl: "http://localhost" });
+const FIXED_NOW_ISO = "2026-01-15T12:00:00.000Z";
 
 describe("API client with Zod Validation", () => {
   beforeEach(() => {
@@ -60,9 +61,8 @@ describe("API client with Zod Validation", () => {
 
   it("normalizes baseUrl without duplicating /api segments", () => {
     const client = new ApiClient({ baseUrl: "/api" });
-    // @ts-expect-error – accessing private for test verification
-    const baseUrl: string = client.config.baseUrl;
-    expect(baseUrl).toBe("http://localhost:3000/api/");
+    const clientInternals = unsafeCast<{ config: { baseUrl: string } }>(client);
+    expect(clientInternals.config.baseUrl).toBe("http://localhost:3000/api/");
   });
 
   describe("Request Validation", () => {
@@ -127,6 +127,35 @@ describe("API client with Zod Validation", () => {
       // Should not make HTTP request with invalid data - verify no handler was called
       // (MSW will warn if unhandled request, but validation happens before HTTP call)
     });
+
+    it(
+      "uses the shared timestamp helper for request validation errors",
+      withFakeTimers(async () => {
+        vi.setSystemTime(new Date(FIXED_NOW_ISO));
+        const invalidUserData = {
+          age: 15,
+          email: "invalid-email",
+          name: "",
+        };
+
+        await expect(
+          CLIENT.postValidated<UserCreateRequest, UserResponse>(
+            "/api/users",
+            invalidUserData,
+            USER_CREATE_REQUEST_SCHEMA,
+            USER_RESPONSE_SCHEMA
+          )
+        ).rejects.toMatchObject({
+          validationErrors: {
+            errors: expect.arrayContaining([
+              expect.objectContaining({
+                timestamp: new Date(FIXED_NOW_ISO),
+              }),
+            ]),
+          },
+        });
+      })
+    );
 
     it("handles nested validation errors", async () => {
       const invalidUserData = {
@@ -201,6 +230,42 @@ describe("API client with Zod Validation", () => {
         CLIENT.getValidated("/api/users/123", USER_RESPONSE_SCHEMA)
       ).rejects.toThrow();
     });
+
+    it(
+      "uses the shared timestamp helper for response validation errors",
+      withFakeTimers(async () => {
+        vi.setSystemTime(new Date(FIXED_NOW_ISO));
+        const invalidResponse = {
+          age: -5,
+          createdAt: "invalid-date",
+          email: "invalid-email",
+          id: "invalid-uuid",
+          isActive: "yes",
+          name: "",
+          updatedAt: "invalid-date",
+        };
+
+        server.use(
+          http.get("http://localhost/api/users/123", () =>
+            HttpResponse.json(invalidResponse, {
+              headers: { "content-type": "application/json" },
+            })
+          )
+        );
+
+        await expect(
+          CLIENT.getValidated("/api/users/123", USER_RESPONSE_SCHEMA)
+        ).rejects.toMatchObject({
+          validationErrors: {
+            errors: expect.arrayContaining([
+              expect.objectContaining({
+                timestamp: new Date(FIXED_NOW_ISO),
+              }),
+            ]),
+          },
+        });
+      })
+    );
 
     it("validates complex nested response structures", async () => {
       const validPaginatedResponse: PaginatedResponse = {
@@ -304,7 +369,7 @@ describe("API client with Zod Validation", () => {
       withFakeTimers(async () => {
         server.use(
           http.get("http://localhost/api/users", () => {
-            throw new Error("Network error");
+            return HttpResponse.error();
           })
         );
 
@@ -324,7 +389,26 @@ describe("API client with Zod Validation", () => {
 
         await vi.advanceTimersByTimeAsync(2000);
 
-        await expect(pendingRequest).rejects.toThrow("Network error");
+        await expect(pendingRequest).rejects.toThrow("Failed to fetch");
+      })
+    );
+
+    it(
+      "clears request timeout timers when fetch fails before the timeout",
+      withFakeTimers(async () => {
+        server.use(http.get("http://localhost/api/users", () => HttpResponse.error()));
+
+        const fastClient = new ApiClient({
+          baseUrl: "http://localhost",
+          retries: 0,
+          timeout: 1_000,
+        });
+
+        await expect(
+          fastClient.getValidated("/api/users", USER_RESPONSE_SCHEMA)
+        ).rejects.toThrow("Failed to fetch");
+
+        expect(vi.getTimerCount()).toBe(0);
       })
     );
   });

--- a/src/lib/api/api-client.ts
+++ b/src/lib/api/api-client.ts
@@ -7,6 +7,7 @@
 import type { ValidationResult } from "@schemas/validation";
 import type { z } from "zod";
 import { getClientEnvVarWithFallback } from "../env/client";
+import { nowIso } from "../security/random";
 import { getClientOrigin } from "../url/client-origin";
 import { ApiError, type ApiErrorCode } from "./error-types";
 
@@ -59,6 +60,10 @@ interface ApiClientConfig {
   authHeaderName: string;
   /** Default headers to include in all requests. */
   defaultHeaders: Record<string, string>;
+}
+
+function getCurrentValidationDate(): Date {
+  return new Date(nowIso());
 }
 
 /**
@@ -135,6 +140,7 @@ export class ApiClient {
       if (config.validateRequest ?? this.config.validateRequests) {
         const validationResult = config.requestSchema.safeParse(config.data);
         if (!validationResult.success) {
+          const timestamp = getCurrentValidationDate();
           const validationErrors: ValidationResult<unknown> = {
             errors: validationResult.error.issues.map((issue) => ({
               code: issue.code,
@@ -142,7 +148,7 @@ export class ApiClient {
               field: issue.path.join(".") || undefined,
               message: issue.message,
               path: issue.path.map(String),
-              timestamp: new Date(),
+              timestamp,
               value: issue.input,
             })),
             success: false,
@@ -207,6 +213,18 @@ export class ApiClient {
     for (let attempt = 0; attempt <= retries; attempt++) {
       // Track abort source to distinguish timeout vs external cancellation
       let abortedByTimeout = false;
+      let externalAbortHandler: (() => void) | null = null;
+      let timeoutId: ReturnType<typeof setTimeout> | null = null;
+      const cleanupAttempt = () => {
+        if (timeoutId !== null) {
+          clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        if (config.abortSignal && externalAbortHandler) {
+          config.abortSignal.removeEventListener("abort", externalAbortHandler);
+          externalAbortHandler = null;
+        }
+      };
 
       try {
         const controller = new AbortController();
@@ -215,12 +233,13 @@ export class ApiClient {
           if (config.abortSignal.aborted) {
             controller.abort();
           } else {
-            config.abortSignal.addEventListener("abort", () => controller.abort(), {
+            externalAbortHandler = () => controller.abort();
+            config.abortSignal.addEventListener("abort", externalAbortHandler, {
               once: true,
             });
           }
         }
-        const timeoutId = setTimeout(() => {
+        timeoutId = setTimeout(() => {
           abortedByTimeout = true;
           controller.abort();
         }, timeout);
@@ -229,8 +248,6 @@ export class ApiClient {
           ...requestOptions,
           signal: controller.signal,
         });
-
-        clearTimeout(timeoutId);
 
         // Handle HTTP errors
         if (!response.ok) {
@@ -260,6 +277,7 @@ export class ApiClient {
           if (config.validateResponse ?? this.config.validateResponses) {
             const zodResult = config.responseSchema.safeParse(responseData);
             if (!zodResult.success) {
+              const timestamp = getCurrentValidationDate();
               const validationResult: ValidationResult<unknown> = {
                 errors: zodResult.error.issues.map((issue) => ({
                   code: issue.code,
@@ -267,7 +285,7 @@ export class ApiClient {
                   field: issue.path.join(".") || undefined,
                   message: issue.message,
                   path: issue.path.map(String),
-                  timestamp: new Date(),
+                  timestamp,
                   value: issue.input,
                 })),
                 success: false,
@@ -324,9 +342,13 @@ export class ApiClient {
           break;
         }
 
+        cleanupAttempt();
+
         // Wait before retrying (exponential backoff)
         const delay = Math.min(1000 * 2 ** attempt, 10000);
         await new Promise((resolve) => setTimeout(resolve, delay));
+      } finally {
+        cleanupAttempt();
       }
     }
 

--- a/src/lib/api/error-types.ts
+++ b/src/lib/api/error-types.ts
@@ -2,6 +2,8 @@
  * @fileoverview Consolidated error types for API and React Query integration. Single ApiError class with error codes replaces separate error classes.
  */
 
+import { nowIso } from "@/lib/security/random";
+
 /** Standard error codes for API errors. */
 export type ApiErrorCode =
   | "NETWORK_ERROR"
@@ -99,7 +101,7 @@ export class ApiError extends Error {
     this.endpoint = options.endpoint;
     this.validationErrors = options.validationErrors;
     this.fieldErrors = options.fieldErrors;
-    this.timestamp = new Date().toISOString();
+    this.timestamp = nowIso();
 
     Object.setPrototypeOf(this, ApiError.prototype);
   }
@@ -297,9 +299,6 @@ export const isValidationError = (error: unknown): error is ApiError => {
   // Legacy support for Error with name "ValidationError"
   return error instanceof Error && error.name === "ValidationError";
 };
-
-/** Union type for app errors (now just ApiError). */
-export type AppError = ApiError;
 
 /** Error handler utility - normalizes all errors to ApiError. */
 export const handleApiError = (error: unknown): ApiError => {

--- a/src/lib/calendar/__tests__/ics.test.ts
+++ b/src/lib/calendar/__tests__/ics.test.ts
@@ -373,6 +373,24 @@ describe("generateIcsFromEvents", () => {
   });
 
   describe("edge cases", () => {
+    it("uses deterministic fallback start date when event start is missing", () => {
+      const event = calendarEventSchema.parse({
+        end: {},
+        start: {},
+        summary: "Missing Start Time",
+      });
+
+      const { icsString } = generateIcsFromEvents({
+        calendarName: "Test",
+        events: [event],
+        fallbackStartDate: new Date("2024-06-15T10:00:00Z"),
+      });
+
+      expect(icsString).toContain("SUMMARY:Missing Start Time");
+      expect(icsString).toContain("DTSTART:20240615T100000Z");
+      expect(icsString).toContain("DTEND:20240615T110000Z");
+    });
+
     it("should handle event without end date (defaults to 1 hour)", () => {
       // This tests the fallback behavior
       const event = calendarEventSchema.parse({

--- a/src/lib/calendar/ics.ts
+++ b/src/lib/calendar/ics.ts
@@ -9,6 +9,7 @@ import type { CalendarEvent } from "@schemas/calendar";
 import ical, { ICalAlarmType, ICalAttendeeStatus } from "ical-generator";
 import { RecurringDateGenerator } from "@/lib/dates/recurring-rules";
 import { DateUtils } from "@/lib/dates/unified-date-utils";
+import { nowIso } from "@/lib/security/random";
 import { createServerLogger } from "@/lib/telemetry/logger";
 
 /** Logger for ICS generation operations. */
@@ -22,6 +23,8 @@ export interface GenerateIcsOptions {
   calendarName: string;
   /** Events to include in the calendar. */
   events: CalendarEvent[];
+  /** Fallback start date for events missing start data. Defaults to now. */
+  fallbackStartDate?: Date;
   /** Timezone for the calendar (defaults to UTC). */
   timezone?: string;
 }
@@ -89,7 +92,7 @@ function reminderMethodToIcal(method: string): ICalAlarmType {
  * ```
  */
 export function generateIcsFromEvents(options: GenerateIcsOptions): GenerateIcsResult {
-  const { calendarName, events, timezone = "UTC" } = options;
+  const { calendarName, events, fallbackStartDate, timezone = "UTC" } = options;
 
   // Create calendar
   const calendar = ical({
@@ -105,11 +108,11 @@ export function generateIcsFromEvents(options: GenerateIcsOptions): GenerateIcsR
     } else if (event.start.date) {
       startDate = DateUtils.parse(event.start.date);
     } else {
-      logger.warn("Event missing start date, using current time", {
+      logger.warn("Event missing start date, using fallback start date", {
         eventId: event.id,
         eventSummary: event.summary,
       });
-      startDate = new Date();
+      startDate = fallbackStartDate ?? DateUtils.parse(nowIso());
     }
 
     const endDate =

--- a/src/lib/circuit-breaker/__tests__/index.test.ts
+++ b/src/lib/circuit-breaker/__tests__/index.test.ts
@@ -1,0 +1,114 @@
+/** @vitest-environment node */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
+
+const redisMock = vi.hoisted(() => ({
+  del: vi.fn(),
+  eval: vi.fn(),
+  get: vi.fn(),
+  set: vi.fn(),
+  ttl: vi.fn(),
+}));
+
+const recordTelemetryEventMock = vi.hoisted(() => vi.fn());
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/redis", () => ({
+  getRedis: () => redisMock,
+}));
+
+vi.mock("@/lib/telemetry/span", () => ({
+  recordTelemetryEvent: recordTelemetryEventMock,
+  withTelemetrySpan: vi.fn(
+    (
+      _name: string,
+      _opts: unknown,
+      fn: (span: {
+        recordException: ReturnType<typeof vi.fn>;
+        setAttribute: ReturnType<typeof vi.fn>;
+      }) => Promise<unknown>
+    ) =>
+      fn({
+        recordException: vi.fn(),
+        setAttribute: vi.fn(),
+      })
+  ),
+}));
+
+import { checkCircuit, getCircuitState } from "../index";
+
+describe("circuit breaker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redisMock.get.mockResolvedValue(null);
+    redisMock.set.mockResolvedValue("OK");
+  });
+
+  it(
+    "rejects open circuits with a deterministic helper-backed cooldown window",
+    withFakeTimers(async () => {
+      vi.setSystemTime(new Date("2026-02-03T04:05:06.000Z"));
+      redisMock.get.mockResolvedValueOnce(
+        Date.parse("2026-02-03T04:04:46.000Z").toString()
+      );
+
+      const result = await checkCircuit({
+        cooldownSeconds: 30,
+        name: "maps",
+      });
+
+      expect(result).toEqual({
+        allowed: false,
+        reason: "Circuit open for maps, cooldown remaining: 10s",
+        state: "open",
+      });
+    })
+  );
+
+  it(
+    "stores the deterministic opened-at timestamp when the failure threshold is reached",
+    withFakeTimers(async () => {
+      vi.setSystemTime(new Date("2026-02-03T04:05:06.000Z"));
+      redisMock.get.mockResolvedValueOnce(null).mockResolvedValueOnce("5");
+
+      const result = await checkCircuit({
+        cooldownSeconds: 30,
+        failureThreshold: 5,
+        name: "payments",
+      });
+
+      expect(result).toEqual({
+        allowed: false,
+        reason: "Circuit opened for payments after 5 failures",
+        state: "open",
+      });
+      expect(redisMock.set).toHaveBeenCalledWith(
+        "circuit:payments:opened_at",
+        Date.parse("2026-02-03T04:05:06.000Z").toString(),
+        { ex: 60 }
+      );
+      expect(recordTelemetryEventMock).toHaveBeenCalledWith("circuit_breaker.opened", {
+        attributes: {
+          "circuit.failure_count": 5,
+          "circuit.name": "payments",
+          "circuit.threshold": 5,
+        },
+        level: "error",
+      });
+    })
+  );
+
+  it(
+    "reports half-open state after the helper-backed cooldown has elapsed",
+    withFakeTimers(async () => {
+      vi.setSystemTime(new Date("2026-02-03T04:05:06.000Z"));
+      redisMock.get.mockResolvedValueOnce(
+        Date.parse("2026-02-03T04:04:30.000Z").toString()
+      );
+
+      await expect(getCircuitState("flights", 30)).resolves.toBe("half-open");
+    })
+  );
+});

--- a/src/lib/circuit-breaker/index.ts
+++ b/src/lib/circuit-breaker/index.ts
@@ -5,6 +5,7 @@
 import "server-only";
 
 import { getRedis } from "@/lib/redis";
+import { nowIso } from "@/lib/security/random";
 import { recordTelemetryEvent, withTelemetrySpan } from "@/lib/telemetry/span";
 
 // ===== TYPES =====
@@ -49,6 +50,7 @@ const DEFAULT_FAILURE_THRESHOLD = 5;
 const DEFAULT_COOLDOWN_SECONDS = 30;
 const DEFAULT_SUCCESS_THRESHOLD = 2;
 const DEFAULT_FAILURE_WINDOW_SECONDS = 60;
+const MS_PER_SECOND = 1000;
 
 // ===== HELPERS =====
 
@@ -62,6 +64,14 @@ function getOpenedAtKey(name: string): string {
 
 function getSuccessCountKey(name: string): string {
   return `${REDIS_PREFIX}${name}:successes`;
+}
+
+function getCurrentEpochMs(currentIso = nowIso()): number {
+  return Date.parse(currentIso);
+}
+
+function getElapsedSecondsSince(openedAtMs: number): number {
+  return (getCurrentEpochMs() - openedAtMs) / MS_PER_SECOND;
 }
 
 // ===== CIRCUIT BREAKER =====
@@ -95,7 +105,7 @@ export async function checkCircuit(
 
   if (openedAt) {
     const openedAtMs = parseInt(openedAt as string, 10);
-    const elapsedSeconds = (Date.now() - openedAtMs) / 1000;
+    const elapsedSeconds = getElapsedSecondsSince(openedAtMs);
 
     if (elapsedSeconds < cooldownSeconds) {
       // Circuit is open, reject request
@@ -118,7 +128,9 @@ export async function checkCircuit(
 
   if (failureCount >= failureThreshold) {
     // Threshold exceeded, open circuit
-    await redis.set(openedAtKey, Date.now().toString(), { ex: cooldownSeconds * 2 });
+    await redis.set(openedAtKey, getCurrentEpochMs().toString(), {
+      ex: cooldownSeconds * 2,
+    });
 
     recordTelemetryEvent("circuit_breaker.opened", {
       attributes: {
@@ -267,7 +279,7 @@ export async function getCircuitState(
 
   // Circuit was opened - check if cooldown has passed
   const openedAtMs = parseInt(openedAt as string, 10);
-  const elapsedSeconds = (Date.now() - openedAtMs) / 1000;
+  const elapsedSeconds = getElapsedSecondsSince(openedAtMs);
 
   // Use provided cooldown for read-only state check
   if (elapsedSeconds < cooldownSeconds) {

--- a/src/lib/dates/__tests__/unified-date-utils.test.ts
+++ b/src/lib/dates/__tests__/unified-date-utils.test.ts
@@ -2,7 +2,12 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createFakeTimersContext } from "@/test/utils/with-fake-timers";
-import { DATE_FORMATS, DateUtils } from "../unified-date-utils";
+import {
+  DATE_FORMATS,
+  DateUtils,
+  todayUtcIsoDate,
+  toUtcIsoDate,
+} from "../unified-date-utils";
 
 describe("DateUtils", () => {
   const timers = createFakeTimersContext();
@@ -29,6 +34,17 @@ describe("DateUtils", () => {
       expect(result.getFullYear()).toBe(2024);
       expect(result.getMonth()).toBe(0);
       expect(result.getDate()).toBe(15);
+    });
+
+    it("uses an explicit reference date for partial pattern parsing", () => {
+      const referenceDate = new Date(2030, 6, 4, 12, 0, 0);
+      const result = DateUtils.parse("15:45", "HH:mm", referenceDate);
+
+      expect(result.getFullYear()).toBe(2030);
+      expect(result.getMonth()).toBe(6);
+      expect(result.getDate()).toBe(4);
+      expect(result.getHours()).toBe(15);
+      expect(result.getMinutes()).toBe(45);
     });
 
     it("should throw error for empty string", () => {
@@ -99,6 +115,32 @@ describe("DateUtils", () => {
       expect(() => DateUtils.formatForApi(invalidDate)).toThrow(
         "Invalid date instance"
       );
+    });
+  });
+
+  describe("toUtcIsoDate", () => {
+    it("formats a date using the UTC calendar day", () => {
+      const date = new Date("2024-01-15T23:30:00-08:00");
+
+      expect(toUtcIsoDate(date)).toBe("2024-01-16");
+    });
+
+    it("throws for invalid dates", () => {
+      expect(() => toUtcIsoDate(new Date("invalid"))).toThrow("Invalid date instance");
+    });
+  });
+
+  describe("todayUtcIsoDate", () => {
+    it("formats the current UTC day", () => {
+      expect(todayUtcIsoDate()).toBe("2024-01-15");
+    });
+
+    it("accepts a deterministic timestamp", () => {
+      expect(todayUtcIsoDate(Date.parse("2024-02-29T23:59:59Z"))).toBe("2024-02-29");
+    });
+
+    it("accepts a deterministic ISO timestamp", () => {
+      expect(todayUtcIsoDate("2024-03-01T01:00:00+02:00")).toBe("2024-02-29");
     });
   });
 

--- a/src/lib/dates/unified-date-utils.ts
+++ b/src/lib/dates/unified-date-utils.ts
@@ -42,6 +42,7 @@ import {
   subWeeks,
   subYears,
 } from "date-fns";
+import { nowIso } from "@/lib/security/random";
 
 /**
  * Predefined date format patterns used throughout the application.
@@ -88,6 +89,38 @@ function ensureValidDate(date: Date): void {
 }
 
 /**
+ * Formats a Date as a UTC ISO date string (`YYYY-MM-DD`).
+ *
+ * @param date - The date to format.
+ * @returns UTC ISO date-only string.
+ */
+export function toUtcIsoDate(date: Date): string {
+  ensureValidDate(date);
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Returns the current UTC ISO date string (`YYYY-MM-DD`).
+ *
+ * @param currentTime - Optional epoch milliseconds or ISO timestamp for deterministic callers/tests.
+ * @returns UTC ISO date-only string.
+ */
+export function todayUtcIsoDate(currentTime?: number | string): string {
+  return toUtcIsoDate(new Date(currentTime ?? nowIso()));
+}
+
+type DateParseReference = Date | number | string;
+
+const getDateParseReferenceDate = (referenceDate?: DateParseReference): Date => {
+  const date =
+    referenceDate instanceof Date
+      ? new Date(referenceDate.getTime())
+      : new Date(referenceDate ?? nowIso());
+  ensureValidDate(date);
+  return date;
+};
+
+/**
  * Unified date utility class providing consistent date operations.
  *
  * Wraps date-fns v4 functionality with a stable API and error handling.
@@ -102,15 +135,20 @@ export class DateUtils {
    *
    * @param dateString - The date string to parse.
    * @param pattern - Optional pattern for parsing. Defaults to ISO parsing.
+   * @param referenceDate - Optional date-fns reference date for pattern parsing.
    * @returns A parsed Date object.
    * @throws Error if the date string is empty or invalid.
    */
-  static parse(dateString: string, pattern?: string): Date {
+  static parse(
+    dateString: string,
+    pattern?: string,
+    referenceDate?: DateParseReference
+  ): Date {
     if (!dateString) {
       throw new Error("Empty date string");
     }
     const parsed = pattern
-      ? parse(dateString, pattern, new Date())
+      ? parse(dateString, pattern, getDateParseReferenceDate(referenceDate))
       : parseISO(dateString);
     ensureValidDate(parsed);
     return parsed;

--- a/src/lib/error-service.ts
+++ b/src/lib/error-service.ts
@@ -10,7 +10,7 @@ import {
   errorReportSchema,
 } from "@schemas/errors";
 import { normalizeThrownError } from "@/lib/client/normalize-thrown-error";
-import { secureId } from "@/lib/security/random";
+import { nowIso, secureId } from "@/lib/security/random";
 import {
   type ErrorSpanMetadata,
   recordClientErrorOnActiveSpan,
@@ -144,7 +144,7 @@ class ErrorService {
    */
   private storeErrorLocally(report: ErrorReport): void {
     try {
-      const key = `error_${Date.now()}_${secureId(9)}`;
+      const key = `error_${nowIso()}_${secureId(9)}`;
       localStorage.setItem(key, JSON.stringify(report));
 
       // Clean up old errors (keep last 10)
@@ -195,7 +195,7 @@ class ErrorService {
             componentStack: errorInfo.componentStack || "",
           }
         : undefined,
-      timestamp: new Date().toISOString(),
+      timestamp: nowIso(),
       url: window.location.href,
       userAgent: navigator.userAgent,
       ...additionalInfo,

--- a/src/lib/google/__tests__/client.test.ts
+++ b/src/lib/google/__tests__/client.test.ts
@@ -3,6 +3,7 @@
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { server } from "@/test/msw/server";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
 import {
   getGeocode,
   getPlaceDetails,
@@ -223,6 +224,30 @@ describe("Google API Client", () => {
         timestamp: mockTimestamp,
       });
     });
+
+    it(
+      "defaults timestamp from the shared timestamp helper",
+      withFakeTimers(async () => {
+        vi.setSystemTime(new Date("2026-02-03T04:05:06.000Z"));
+        server.use(
+          http.get(
+            "https://maps.googleapis.com/maps/api/timezone/json",
+            ({ request }) => {
+              const url = new URL(request.url);
+              expect(url.searchParams.get("timestamp")).toBe("1770091506");
+
+              return HttpResponse.json({ status: "OK" });
+            }
+          )
+        );
+
+        await getTimezone({
+          apiKey: "test-key",
+          lat: 35.6762,
+          lng: 139.6503,
+        });
+      })
+    );
 
     it("should throw error for invalid coordinates", async () => {
       await expect(

--- a/src/lib/google/__tests__/places-activities.test.ts
+++ b/src/lib/google/__tests__/places-activities.test.ts
@@ -1,6 +1,7 @@
 /** @vitest-environment node */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
 
 vi.mock("@/lib/env/server", () => ({
   getGoogleMapsServerKey: vi.fn(() => "test-api-key"),
@@ -100,6 +101,21 @@ describe("places-activities", () => {
       expect(activity.price).toBe(2); // Default moderate
       expect(activity.type).toBe("activity");
     });
+
+    it(
+      "defaults missing dates to the current UTC ISO date",
+      withFakeTimers(() => {
+        vi.setSystemTime(new Date("2025-12-31T23:30:00Z"));
+
+        const activity = mapPlacesPlaceToActivity({
+          displayName: { text: "Test Activity" },
+          formattedAddress: "Test Address",
+          id: "places/1",
+        });
+
+        expect(activity.date).toBe("2025-12-31");
+      })
+    );
 
     it("should map price levels correctly", () => {
       const testCases = [

--- a/src/lib/google/client.ts
+++ b/src/lib/google/client.ts
@@ -5,6 +5,7 @@
 import "server-only";
 
 import { retryWithBackoff } from "@/lib/http/retry";
+import { nowIso } from "@/lib/security/random";
 import { GooglePlacesPhotoError } from "./errors";
 
 // === Coordinate Validation ===
@@ -358,7 +359,7 @@ export async function getTimezone(params: TimezoneParams): Promise<Response> {
   url.searchParams.set("location", `${params.lat},${params.lng}`);
   url.searchParams.set(
     "timestamp",
-    String(params.timestamp ?? Math.floor(Date.now() / 1000))
+    String(params.timestamp ?? getCurrentUnixTimestampSeconds())
   );
   url.searchParams.set("key", params.apiKey);
 
@@ -367,6 +368,10 @@ export async function getTimezone(params: TimezoneParams): Promise<Response> {
     baseDelayMs: 200,
     maxDelayMs: 1_000,
   });
+}
+
+function getCurrentUnixTimestampSeconds(): number {
+  return Math.floor(Date.parse(nowIso()) / 1000);
 }
 
 // === Places Photo API ===

--- a/src/lib/google/places-activities.ts
+++ b/src/lib/google/places-activities.ts
@@ -5,6 +5,7 @@
 import "server-only";
 
 import type { Activity } from "@schemas/search";
+import { todayUtcIsoDate } from "@/lib/dates/unified-date-utils";
 import { getGoogleMapsServerKey } from "@/lib/env/server";
 import { getPlaceDetails, postPlacesSearch } from "@/lib/google/client";
 import { normalizePlacesTextQuery } from "@/lib/google/places-utils";
@@ -174,7 +175,7 @@ function buildPhotoUrls(photos?: PlacesPhoto[]): string[] {
  */
 export function mapPlacesPlaceToActivity(
   place: PlacesPlace,
-  date: string = new Date().toISOString().split("T")[0]
+  date: string = todayUtcIsoDate()
 ): Activity {
   const name = place.displayName?.text ?? "Unknown Activity";
   const location = place.formattedAddress ?? "Unknown Location";

--- a/src/lib/http/__tests__/retry.test.ts
+++ b/src/lib/http/__tests__/retry.test.ts
@@ -3,6 +3,7 @@
 import { delay, HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { server } from "@/test/msw/server";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
 import { fetchWithRetry, type RetryOptions, retryWithBackoff } from "../retry";
 
 describe("retryWithBackoff", () => {
@@ -291,7 +292,7 @@ describe("fetchWithRetry", () => {
     expect(requests[0].headers.get("content-type")).toContain("application/json");
   });
 
-  it("handles caller abort signal", async () => {
+  it("handles caller abort signal distinctly from timeout", async () => {
     const controller = new AbortController();
     controller.abort();
 
@@ -300,7 +301,90 @@ describe("fetchWithRetry", () => {
         signal: controller.signal,
       })
     ).rejects.toMatchObject({
-      code: "fetch_timeout",
+      code: "fetch_aborted",
+      meta: {
+        attempt: 1,
+      },
+    });
+  });
+
+  it("does not retry caller-aborted requests", async () => {
+    let calls = 0;
+    const controller = new AbortController();
+    server.use(
+      http.get(ApiUrl, async () => {
+        calls += 1;
+        controller.abort();
+        await delay(50);
+        return HttpResponse.json({ data: "late" }, { status: 200 });
+      })
+    );
+
+    await expect(
+      fetchWithRetry(
+        ApiUrl,
+        {
+          signal: controller.signal,
+        },
+        { backoffMs: 1, retries: 3, timeoutMs: 1000 }
+      )
+    ).rejects.toMatchObject({
+      code: "fetch_aborted",
+      meta: {
+        attempt: 1,
+      },
+    });
+
+    expect(calls).toBe(1);
+  });
+
+  it(
+    "clears timeout and abort listener when caller aborts",
+    withFakeTimers(async () => {
+      const controller = new AbortController();
+      server.use(
+        http.get(ApiUrl, async () => {
+          controller.abort();
+          await delay(50);
+          return HttpResponse.json({ data: "late" }, { status: 200 });
+        })
+      );
+
+      const pendingRequest = fetchWithRetry(
+        ApiUrl,
+        {
+          signal: controller.signal,
+        },
+        { retries: 0, timeoutMs: 1000 }
+      );
+      pendingRequest.catch(() => undefined);
+
+      await vi.advanceTimersByTimeAsync(50);
+
+      await expect(pendingRequest).rejects.toMatchObject({
+        code: "fetch_aborted",
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    })
+  );
+
+  it("handles pre-aborted caller signals without retrying", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      fetchWithRetry(
+        ApiUrl,
+        {
+          signal: controller.signal,
+        },
+        { backoffMs: 1, retries: 3 }
+      )
+    ).rejects.toMatchObject({
+      code: "fetch_aborted",
+      meta: {
+        attempt: 1,
+      },
     });
   });
 });

--- a/src/lib/http/retry.ts
+++ b/src/lib/http/retry.ts
@@ -140,8 +140,9 @@ export type FetchRetryOptions = {
  * @param init - Fetch options (RequestInit).
  * @param options - Retry and timeout options.
  * @returns The Response object on success.
- * @throws {Error} Error with `code` property set to "fetch_timeout" or "fetch_failed",
- *   and `meta` property containing attempt details.
+ * @throws {Error} Error with `code` property set to "fetch_timeout",
+ *   "fetch_aborted", or "fetch_failed", and `meta` property containing attempt
+ *   details.
  */
 export function fetchWithRetry(
   url: string,
@@ -157,36 +158,47 @@ export function fetchWithRetry(
       const controller = new AbortController();
       // Propagate caller aborts to our controller
       let onCallerAbort: (() => void) | undefined;
+      let abortedByCaller = init.signal?.aborted ?? false;
+      let abortedByTimeout = false;
       if (init.signal) {
         if (init.signal.aborted) {
           controller.abort();
         } else {
-          onCallerAbort = () => controller.abort();
+          onCallerAbort = () => {
+            abortedByCaller = true;
+            controller.abort();
+          };
           init.signal.addEventListener("abort", onCallerAbort, { once: true });
         }
       }
-      const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+      const timeoutId = setTimeout(() => {
+        abortedByTimeout = true;
+        controller.abort();
+      }, timeoutMs);
       try {
-        const res = await fetch(url, {
+        return await fetch(url, {
           ...init,
           signal: controller.signal,
         });
-        clearTimeout(timeoutId);
-        if (init.signal && onCallerAbort) {
-          init.signal.removeEventListener("abort", onCallerAbort);
-        }
-        return res;
       } catch (err) {
-        clearTimeout(timeoutId);
-        if (init.signal && onCallerAbort) {
-          init.signal.removeEventListener("abort", onCallerAbort);
-        }
-        const isTimeout = err instanceof Error && err.name === "AbortError";
+        const isAbort = err instanceof Error && err.name === "AbortError";
+        const code = isAbort
+          ? abortedByTimeout
+            ? "fetch_timeout"
+            : abortedByCaller
+              ? "fetch_aborted"
+              : "fetch_failed"
+          : "fetch_failed";
         const error: Error & { code?: string; meta?: Record<string, unknown> } =
-          new Error(isTimeout ? "fetch_timeout" : "fetch_failed");
-        error.code = isTimeout ? "fetch_timeout" : "fetch_failed";
+          new Error(code);
+        error.code = code;
         error.meta = { attempt: attemptNumber, maxRetries: retries, url };
         throw error;
+      } finally {
+        clearTimeout(timeoutId);
+        if (init.signal && onCallerAbort) {
+          init.signal.removeEventListener("abort", onCallerAbort);
+        }
       }
     },
     {
@@ -196,7 +208,11 @@ export function fetchWithRetry(
         // Don't retry on timeout errors or abort errors
         if (error instanceof Error) {
           const errorCode = (error as { code?: string }).code;
-          if (error.name === "AbortError" || errorCode === "fetch_timeout") {
+          if (
+            error.name === "AbortError" ||
+            errorCode === "fetch_timeout" ||
+            errorCode === "fetch_aborted"
+          ) {
             return false;
           }
         }

--- a/src/lib/metrics/__tests__/aggregate.test.ts
+++ b/src/lib/metrics/__tests__/aggregate.test.ts
@@ -1,6 +1,7 @@
 /** @vitest-environment node */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
 
 // Mock dependencies before imports
 const mockRedisGet = vi.fn();
@@ -130,45 +131,50 @@ describe("aggregate", () => {
       expect(result.activeTrips).toBe(0);
     });
 
-    it("calculates metrics correctly with api_metrics data", async () => {
-      const { createServerSupabase } = await import("@/lib/supabase/server");
-      const userId = "user_123";
+    it(
+      "calculates metrics with a helper-backed api metrics window filter",
+      withFakeTimers(async () => {
+        vi.setSystemTime(new Date("2026-02-03T04:05:06.000Z"));
+        const { createServerSupabase } = await import("@/lib/supabase/server");
+        const userId = "user_123";
 
-      // Reset redis mock to not return cached
-      mockRedisGet.mockResolvedValue(null);
+        // Reset redis mock to not return cached
+        mockRedisGet.mockResolvedValue(null);
 
-      const mockSelect = vi.fn();
-      const mockGte = vi.fn().mockReturnValue({
-        limit: vi.fn().mockResolvedValue({
-          data: [
-            { duration_ms: 100, status_code: 200 },
-            { duration_ms: 200, status_code: 200 },
-            { duration_ms: 150, status_code: 500 },
-            { duration_ms: 250, status_code: 400 },
-          ],
-          error: null,
-        }),
-      });
+        const mockSelect = vi.fn();
+        const mockGte = vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue({
+            data: [
+              { duration_ms: 100, status_code: 200 },
+              { duration_ms: 200, status_code: 200 },
+              { duration_ms: 150, status_code: 500 },
+              { duration_ms: 250, status_code: 400 },
+            ],
+            error: null,
+          }),
+        });
 
-      // First call for trips, second for api_metrics
-      mockSelect
-        .mockResolvedValueOnce({ data: [], error: null }) // trips
-        .mockReturnValueOnce({ gte: mockGte }); // api_metrics
+        // First call for trips, second for api_metrics
+        mockSelect
+          .mockResolvedValueOnce({ data: [], error: null }) // trips
+          .mockReturnValueOnce({ gte: mockGte }); // api_metrics
 
-      (createServerSupabase as ReturnType<typeof vi.fn>).mockResolvedValue({
-        from: vi.fn().mockReturnValue({ select: mockSelect }),
-      });
+        (createServerSupabase as ReturnType<typeof vi.fn>).mockResolvedValue({
+          from: vi.fn().mockReturnValue({ select: mockSelect }),
+        });
 
-      const { aggregateDashboardMetrics } = await import("../aggregate");
+        const { aggregateDashboardMetrics } = await import("../aggregate");
 
-      const result = await aggregateDashboardMetrics(userId, 24);
+        const result = await aggregateDashboardMetrics(userId, 24);
 
-      expect(result.totalRequests).toBe(4);
-      // (100 + 200 + 150 + 250) / 4 = 175
-      expect(result.avgLatencyMs).toBe(175);
-      // 2 errors out of 4 = 50%
-      expect(result.errorRate).toBe(50);
-    });
+        expect(result.totalRequests).toBe(4);
+        // (100 + 200 + 150 + 250) / 4 = 175
+        expect(result.avgLatencyMs).toBe(175);
+        // 2 errors out of 4 = 50%
+        expect(result.errorRate).toBe(50);
+        expect(mockGte).toHaveBeenCalledWith("created_at", "2026-02-02T04:05:06.000Z");
+      })
+    );
   });
 
   describe("invalidateDashboardCache", () => {

--- a/src/lib/metrics/__tests__/api-metrics.test.ts
+++ b/src/lib/metrics/__tests__/api-metrics.test.ts
@@ -1,6 +1,7 @@
 /** @vitest-environment node */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
 
 // Mock dependencies before imports
 vi.mock("@/lib/redis", () => ({
@@ -32,43 +33,52 @@ describe("api-metrics", () => {
   });
 
   describe("recordApiMetric", () => {
-    it("records metric to Supabase and increments Redis counters", async () => {
-      const { getRedis, incrCounter } = await import("@/lib/redis");
-      const { createServerSupabase } = await import("@/lib/supabase/server");
+    it(
+      "records metric to Supabase and increments Redis counters",
+      withFakeTimers(async () => {
+        vi.setSystemTime(new Date("2024-06-07T23:30:00Z"));
 
-      const mockInsert = vi.fn().mockResolvedValue({ data: null, error: null });
-      const mockFrom = vi.fn().mockReturnValue({ insert: mockInsert });
-      (createServerSupabase as ReturnType<typeof vi.fn>).mockResolvedValue({
-        from: mockFrom,
-      });
+        const { getRedis, incrCounter } = await import("@/lib/redis");
+        const { createServerSupabase } = await import("@/lib/supabase/server");
 
-      (getRedis as ReturnType<typeof vi.fn>).mockReturnValue({ mock: true });
-      (incrCounter as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+        const mockInsert = vi.fn().mockResolvedValue({ data: null, error: null });
+        const mockFrom = vi.fn().mockReturnValue({ insert: mockInsert });
+        (createServerSupabase as ReturnType<typeof vi.fn>).mockResolvedValue({
+          from: mockFrom,
+        });
 
-      const { recordApiMetric } = await import("../api-metrics");
+        (getRedis as ReturnType<typeof vi.fn>).mockReturnValue({ mock: true });
+        (incrCounter as ReturnType<typeof vi.fn>).mockResolvedValue(1);
 
-      await recordApiMetric({
-        durationMs: 100,
-        endpoint: "/api/test",
-        method: "GET",
-        statusCode: 200,
-      });
+        const { recordApiMetric } = await import("../api-metrics");
 
-      // Verify Supabase insert was called
-      expect(mockFrom).toHaveBeenCalledWith("api_metrics");
-      expect(mockInsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          duration_ms: 100,
+        await recordApiMetric({
+          durationMs: 100,
           endpoint: "/api/test",
           method: "GET",
-          status_code: 200,
-          user_id: null,
-        })
-      );
+          statusCode: 200,
+        });
 
-      // Verify Redis counters were incremented
-      expect(incrCounter).toHaveBeenCalled();
-    });
+        // Verify Supabase insert was called
+        expect(mockFrom).toHaveBeenCalledWith("api_metrics");
+        expect(mockInsert).toHaveBeenCalledWith(
+          expect.objectContaining({
+            duration_ms: 100,
+            endpoint: "/api/test",
+            method: "GET",
+            status_code: 200,
+            user_id: null,
+          })
+        );
+
+        // Verify Redis counters were incremented
+        expect(incrCounter).toHaveBeenCalledWith("metrics:requests:2024-06-07", 604800);
+        expect(incrCounter).toHaveBeenCalledWith(
+          "metrics:endpoint:/api/test:2024-06-07",
+          86400
+        );
+      })
+    );
 
     it("handles missing Redis gracefully", async () => {
       const { getRedis } = await import("@/lib/redis");

--- a/src/lib/metrics/aggregate.ts
+++ b/src/lib/metrics/aggregate.ts
@@ -5,7 +5,9 @@
 import "server-only";
 
 import { type DashboardMetrics, dashboardMetricsSchema } from "@schemas/dashboard";
+import { DateUtils } from "@/lib/dates/unified-date-utils";
 import { getRedis } from "@/lib/redis";
+import { nowIso } from "@/lib/security/random";
 import type { Tables } from "@/lib/supabase/database.types";
 import { createServerSupabase } from "@/lib/supabase/server";
 import { getMany } from "@/lib/supabase/typed-helpers";
@@ -13,6 +15,16 @@ import { withTelemetrySpan } from "@/lib/telemetry/span";
 
 /** Metric row shape for api_metrics queries (subset of columns needed). */
 type ApiMetricRow = Pick<Tables<"api_metrics">, "duration_ms" | "status_code">;
+
+function getMetricsWindowSince(
+  windowHours: number,
+  currentIso: string = nowIso()
+): string | null {
+  if (windowHours <= 0) return null;
+  return DateUtils.formatForApi(
+    DateUtils.add(DateUtils.parse(currentIso), -windowHours, "hours")
+  );
+}
 
 /**
  * Aggregates dashboard metrics from Supabase with Redis caching.
@@ -66,10 +78,7 @@ export function aggregateDashboardMetrics(
       const supabase = await createServerSupabase();
 
       // Calculate time filter
-      const since =
-        windowHours > 0
-          ? new Date(Date.now() - windowHours * 3600000).toISOString()
-          : null;
+      const since = getMetricsWindowSince(windowHours);
 
       // Parallel queries for trips and API metrics
       const [tripsResult, metricsResult] = await Promise.all([

--- a/src/lib/metrics/api-metrics.ts
+++ b/src/lib/metrics/api-metrics.ts
@@ -5,6 +5,7 @@
 import "server-only";
 
 import type { HttpMethod } from "@schemas/supabase";
+import { todayUtcIsoDate } from "@/lib/dates/unified-date-utils";
 import { getRedis, incrCounter } from "@/lib/redis";
 import type { TablesInsert } from "@/lib/supabase/database.types";
 import { createServerSupabase } from "@/lib/supabase/server";
@@ -54,7 +55,7 @@ export async function recordApiMetric(metric: ApiMetric): Promise<void> {
       },
     },
     async (span) => {
-      const today = new Date().toISOString().split("T")[0];
+      const today = todayUtcIsoDate();
       const counterKey = `metrics:requests:${today}`;
       const errorCounterKey = `metrics:errors:${today}`;
 

--- a/src/lib/notifications/__tests__/collaborators.test.ts
+++ b/src/lib/notifications/__tests__/collaborators.test.ts
@@ -1,9 +1,10 @@
 /** @vitest-environment node */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { unsafeCast } from "@/test/helpers/unsafe-cast";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
 
-const envValues = vi.hoisted(() => ({
+const envValues = vi.hoisted<Record<string, string | undefined>>(() => ({
   COLLAB_WEBHOOK_URL: undefined,
   NEXT_PUBLIC_SUPABASE_URL: "https://supabase.test",
   RESEND_API_KEY: "resend-key",
@@ -74,10 +75,16 @@ const { sendCollaboratorNotifications } = await import(
 describe("sendCollaboratorNotifications", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    envValues.COLLAB_WEBHOOK_URL = undefined;
+    envValues.RESEND_API_KEY = "resend-key";
     mockAuthAdminGetUserById.mockReset();
     mockAuthAdminGetUserById.mockResolvedValue(
       createDefaultAuthAdminGetUserByIdResult()
     );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("returns empty result when table is not trip_collaborators", async () => {
@@ -108,4 +115,35 @@ describe("sendCollaboratorNotifications", () => {
     expect(mockAuthAdminGetUserById).toHaveBeenCalledTimes(1);
     expect(result.emailed).toBe(true);
   });
+
+  it(
+    "clears downstream webhook timeout when fetch fails before the timeout",
+    withFakeTimers(async () => {
+      envValues.COLLAB_WEBHOOK_URL = "https://downstream.test/webhook";
+      envValues.RESEND_API_KEY = "";
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(() => Promise.reject(new TypeError("network failed")))
+      );
+
+      const result = await sendCollaboratorNotifications(
+        {
+          oldRecord: null,
+          record: { trip_id: 1, user_id: "user-1" },
+          table: "trip_collaborators",
+          type: "INSERT",
+        },
+        "event-key-webhook"
+      );
+
+      expect(result).toEqual({ emailed: false, webhookPosted: false });
+      expect(fetch).toHaveBeenCalledWith(
+        "https://downstream.test/webhook",
+        expect.objectContaining({
+          method: "POST",
+        })
+      );
+      expect(vi.getTimerCount()).toBe(0);
+    })
+  );
 });

--- a/src/lib/notifications/collaborators.ts
+++ b/src/lib/notifications/collaborators.ts
@@ -118,16 +118,20 @@ export async function sendCollaboratorNotifications(
         try {
           const controller = new AbortController();
           const id = setTimeout(() => controller.abort(), 1500);
-          const resp = await fetch(downstreamUrl, {
-            body: JSON.stringify({ event, eventKey }),
-            headers: {
-              "content-type": "application/json",
-              "x-event-key": eventKey,
-            },
-            method: "POST",
-            signal: controller.signal,
-          });
-          clearTimeout(id);
+          let resp: Response;
+          try {
+            resp = await fetch(downstreamUrl, {
+              body: JSON.stringify({ event, eventKey }),
+              headers: {
+                "content-type": "application/json",
+                "x-event-key": eventKey,
+              },
+              method: "POST",
+              signal: controller.signal,
+            });
+          } finally {
+            clearTimeout(id);
+          }
           if (resp.ok) webhookPosted = true;
         } catch (err) {
           span.recordException(err as Error);

--- a/src/lib/qstash/__tests__/client.test.ts
+++ b/src/lib/qstash/__tests__/client.test.ts
@@ -14,6 +14,7 @@ const mockSpan = vi.hoisted(() => ({
 
 const GET_ENV_FALLBACK = vi.hoisted(() => vi.fn());
 const GET_REQUIRED_SERVER_ORIGIN = vi.hoisted(() => vi.fn(() => "https://example.com"));
+const RECORD_TELEMETRY_EVENT = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/env/server", () => ({
   getServerEnvVarWithFallback: (...args: unknown[]) => GET_ENV_FALLBACK(...args),
@@ -27,7 +28,7 @@ vi.mock("@/lib/telemetry/span", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/telemetry/span")>();
   return {
     ...actual,
-    recordTelemetryEvent: vi.fn(),
+    recordTelemetryEvent: RECORD_TELEMETRY_EVENT,
     withTelemetrySpan: vi.fn((_name: string, _opts: unknown, execute: unknown) =>
       (execute as (span: unknown) => unknown)(mockSpan)
     ),
@@ -47,6 +48,7 @@ describe("enqueueJob", () => {
     setQStashClientFactoryForTests(null);
     GET_ENV_FALLBACK.mockReset();
     GET_REQUIRED_SERVER_ORIGIN.mockReset();
+    RECORD_TELEMETRY_EVENT.mockReset();
     mockSpan.setAttribute.mockReset();
   });
 
@@ -77,6 +79,28 @@ describe("enqueueJob", () => {
     expect(messages[0]?.redact).toEqual({ body: true });
     expect(messages[0]?.timeout).toBe(30);
     expect(result?.messageId).toBe("qstash-mock-1");
+  });
+
+  it("records a scheduled telemetry event after successful publish", async () => {
+    const { enqueueJob, setQStashClientFactoryForTests } = await import(
+      "@/lib/qstash/client"
+    );
+    setQStashClientFactoryForTests(() => new qstash.Client({ token: "test" }));
+
+    const result = await enqueueJob("test-job", { ok: true }, "/api/jobs/test", {
+      deduplicationId: "test-job:telemetry",
+      label: QSTASH_JOB_LABELS.NOTIFY_COLLABORATORS,
+    });
+
+    expect(result?.messageId).toBe("qstash-mock-1");
+    expect(RECORD_TELEMETRY_EVENT).toHaveBeenCalledWith("qstash.enqueue.scheduled", {
+      attributes: {
+        jobType: "test-job",
+        label: QSTASH_JOB_LABELS.NOTIFY_COLLABORATORS,
+        messageId: "qstash-mock-1",
+        path: "/api/jobs/test",
+      },
+    });
   });
 
   it("records telemetry attributes for label, flow control, and failure callback", async () => {

--- a/src/lib/qstash/client.ts
+++ b/src/lib/qstash/client.ts
@@ -221,11 +221,7 @@ export interface EnqueueJobResult {
  *   }
  * );
  * if (result) {
- *   recordTelemetryEvent("qstash.enqueue.scheduled", {
- *     attributes: {
- *       messageId: result.messageId,
- *     },
- *   });
+ *   // Job scheduled successfully; inspect messageId for tracing if needed.
  * }
  * ```
  */

--- a/src/lib/qstash/client.ts
+++ b/src/lib/qstash/client.ts
@@ -221,7 +221,11 @@ export interface EnqueueJobResult {
  *   }
  * );
  * if (result) {
- *   console.log("Enqueued:", result.messageId);
+ *   recordTelemetryEvent("qstash.enqueue.scheduled", {
+ *     attributes: {
+ *       messageId: result.messageId,
+ *     },
+ *   });
  * }
  * ```
  */
@@ -334,6 +338,16 @@ export async function enqueueJob(
       if (deduplicated !== undefined) {
         span.setAttribute("qstash.deduplicated", deduplicated);
       }
+
+      recordTelemetryEvent("qstash.enqueue.scheduled", {
+        attributes: {
+          ...(deduplicated === undefined ? {} : { deduplicated }),
+          jobType,
+          label: options.label,
+          messageId,
+          path,
+        },
+      });
 
       return { deduplicated, messageId };
     }

--- a/src/lib/ratelimit/__tests__/headers.test.ts
+++ b/src/lib/ratelimit/__tests__/headers.test.ts
@@ -1,11 +1,12 @@
 /** @vitest-environment node */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   applyRateLimitHeaders,
   createRateLimitHeaders,
   normalizeRateLimitResetToMs,
 } from "@/lib/ratelimit/headers";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
 
 describe("ratelimit headers", () => {
   describe("normalizeRateLimitResetToMs", () => {
@@ -79,6 +80,20 @@ describe("ratelimit headers", () => {
         ]
       ).toBe("0");
     });
+
+    it(
+      "uses the helper-backed current time when no nowMs override is provided",
+      withFakeTimers(() => {
+        vi.setSystemTime(new Date("2026-02-03T04:05:06.000Z"));
+
+        expect(
+          createRateLimitHeaders({
+            reset: Date.parse("2026-02-03T04:06:36.000Z"),
+            success: false,
+          })["Retry-After"]
+        ).toBe("90");
+      })
+    );
   });
 
   describe("applyRateLimitHeaders", () => {

--- a/src/lib/ratelimit/headers.ts
+++ b/src/lib/ratelimit/headers.ts
@@ -32,6 +32,13 @@ function getCurrentEpochMs(currentIso = nowIso()): number {
   return Date.parse(currentIso);
 }
 
+/**
+ * Compute the Retry-After header value from reset and current timestamps.
+ *
+ * @param resetMs - Rate-limit reset timestamp in milliseconds.
+ * @param nowMs - Current timestamp in milliseconds.
+ * @returns Non-negative retry delay in seconds.
+ */
 export function computeRetryAfterSeconds(
   resetMs: number,
   nowMs: number = getCurrentEpochMs()

--- a/src/lib/ratelimit/headers.ts
+++ b/src/lib/ratelimit/headers.ts
@@ -33,11 +33,11 @@ function getCurrentEpochMs(currentIso = nowIso()): number {
 }
 
 /**
- * Compute the Retry-After header value from reset and current timestamps.
+ * Computes the `Retry-After` value in whole seconds.
  *
- * @param resetMs - Rate-limit reset timestamp in milliseconds.
- * @param nowMs - Current timestamp in milliseconds.
- * @returns Non-negative retry delay in seconds.
+ * @param resetMs - The reset timestamp in epoch milliseconds.
+ * @param nowMs - Optional current timestamp in epoch milliseconds.
+ * @returns The clamped number of seconds until reset.
  */
 export function computeRetryAfterSeconds(
   resetMs: number,

--- a/src/lib/ratelimit/headers.ts
+++ b/src/lib/ratelimit/headers.ts
@@ -2,12 +2,16 @@
  * @fileoverview Helpers for attaching standard rate limit response headers.
  */
 
+import { nowIso } from "@/lib/security/random";
+
 export type RateLimitHeaderMeta = {
   limit?: number;
   remaining?: number;
   reset?: number;
   success?: boolean;
 };
+
+const MS_PER_SECOND = 1000;
 
 /**
  * Normalize a Unix timestamp to milliseconds.
@@ -24,11 +28,15 @@ export function normalizeRateLimitResetToMs(reset: number): number {
   return reset;
 }
 
+function getCurrentEpochMs(currentIso = nowIso()): number {
+  return Date.parse(currentIso);
+}
+
 export function computeRetryAfterSeconds(
   resetMs: number,
-  nowMs: number = Date.now()
+  nowMs: number = getCurrentEpochMs()
 ): number {
-  return Math.max(0, Math.ceil((resetMs - nowMs) / 1000));
+  return Math.max(0, Math.ceil((resetMs - nowMs) / MS_PER_SECOND));
 }
 
 /**
@@ -51,9 +59,7 @@ export function createRateLimitHeaders(
   if (resetMs !== undefined) headers["X-RateLimit-Reset"] = String(resetMs);
 
   if (meta.success === false && resetMs !== undefined) {
-    headers["Retry-After"] = String(
-      computeRetryAfterSeconds(resetMs, options?.nowMs ?? Date.now())
-    );
+    headers["Retry-After"] = String(computeRetryAfterSeconds(resetMs, options?.nowMs));
   }
 
   return headers;

--- a/src/lib/security/__tests__/mfa.test.ts
+++ b/src/lib/security/__tests__/mfa.test.ts
@@ -5,12 +5,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createBackupCodes,
   InvalidBackupCodeError,
+  InvalidTotpError,
   resetMfaInitForTest,
   startTotpEnrollment,
   verifyBackupCode,
   verifyTotp,
 } from "@/lib/security/mfa";
 import { unsafeCast } from "@/test/helpers/unsafe-cast";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
 
 const mockIds = {
   challengeId: "22222222-2222-4222-8222-222222222222",
@@ -277,36 +279,89 @@ describe("mfa service", () => {
     vi.clearAllMocks();
   });
 
-  it("enrolls totp and returns challenge data", async () => {
-    const result = await startTotpEnrollment(mockSupabase, {
-      adminSupabase: mockAdmin,
-    });
-    expect(result.factorId).toBe(mockIds.factorId);
-    expect(result.challengeId).toBe(mockIds.challengeId);
-    expect(result.qrCode).toBe("qr");
-  });
+  it(
+    "enrolls totp with deterministic helper-backed timestamps",
+    withFakeTimers(async () => {
+      vi.setSystemTime(new Date("2026-02-03T04:05:06.000Z"));
 
-  it("verifies totp code during initial enrollment", async () => {
-    // Set up pending enrollment data
-    mfaEnrollmentRows.push({
-      challenge_id: mockIds.challengeId,
-      expires_at: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
-      factor_id: mockIds.factorId,
-      issued_at: new Date().toISOString(),
-      status: "pending",
-    });
+      const result = await startTotpEnrollment(mockSupabase, {
+        adminSupabase: mockAdmin,
+      });
 
-    const result = await verifyTotp(
-      mockSupabase,
-      {
+      expect(result).toMatchObject({
         challengeId: mockIds.challengeId,
-        code: "123456",
+        expiresAt: "2026-02-03T04:20:06.000Z",
         factorId: mockIds.factorId,
-      },
-      { adminSupabase: mockAdmin }
-    );
-    expect(result.isInitialEnrollment).toBe(true);
-  });
+        issuedAt: "2026-02-03T04:05:06.000Z",
+        qrCode: "qr",
+        ttlSeconds: 900,
+      });
+      expect(mfaEnrollmentRows.at(-1)).toMatchObject({
+        challenge_id: mockIds.challengeId,
+        expires_at: "2026-02-03T04:20:06.000Z",
+        factor_id: mockIds.factorId,
+        issued_at: "2026-02-03T04:05:06.000Z",
+        status: "pending",
+      });
+    })
+  );
+
+  it(
+    "verifies totp code during initial enrollment",
+    withFakeTimers(async () => {
+      vi.setSystemTime(new Date("2026-02-03T04:05:06.000Z"));
+
+      // Set up pending enrollment data
+      mfaEnrollmentRows.push({
+        challenge_id: mockIds.challengeId,
+        expires_at: "2026-02-03T04:20:06.000Z",
+        factor_id: mockIds.factorId,
+        issued_at: "2026-02-03T04:05:06.000Z",
+        status: "pending",
+      });
+
+      const result = await verifyTotp(
+        mockSupabase,
+        {
+          challengeId: mockIds.challengeId,
+          code: "123456",
+          factorId: mockIds.factorId,
+        },
+        { adminSupabase: mockAdmin }
+      );
+      expect(result.isInitialEnrollment).toBe(true);
+    })
+  );
+
+  it(
+    "expires stale pending enrollment using helper-backed current time",
+    withFakeTimers(async () => {
+      vi.setSystemTime(new Date("2026-02-03T04:05:06.000Z"));
+
+      // Set up pending enrollment data
+      mfaEnrollmentRows.push({
+        challenge_id: mockIds.challengeId,
+        expires_at: "2026-02-03T04:05:05.000Z",
+        factor_id: mockIds.factorId,
+        issued_at: "2026-02-03T03:50:06.000Z",
+        status: "pending",
+      });
+
+      await expect(
+        verifyTotp(
+          mockSupabase,
+          {
+            challengeId: mockIds.challengeId,
+            code: "123456",
+            factorId: mockIds.factorId,
+          },
+          { adminSupabase: mockAdmin }
+        )
+      ).rejects.toBeInstanceOf(InvalidTotpError);
+      expect(mfaEnrollmentRows[0]?.status).toBe("expired");
+      expect(mockSupabase.auth.mfa.verify).not.toHaveBeenCalled();
+    })
+  );
 
   it("verifies totp code during subsequent challenge (no enrollment)", async () => {
     // No pending enrollment - simulates regular MFA login challenge

--- a/src/lib/security/__tests__/random.test.ts
+++ b/src/lib/security/__tests__/random.test.ts
@@ -34,6 +34,20 @@ describe("security/random", () => {
     expect(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:.+Z$/.test(ts)).toBe(true);
   });
 
+  it("nowIso accepts deterministic timestamp references", () => {
+    expect(nowIso(Date.parse("2026-05-25T12:34:56.789Z"))).toBe(
+      "2026-05-25T12:34:56.789Z"
+    );
+    expect(nowIso("2026-05-25T12:34:56.789Z")).toBe("2026-05-25T12:34:56.789Z");
+    expect(nowIso(new Date("2026-05-25T12:34:56.789Z"))).toBe(
+      "2026-05-25T12:34:56.789Z"
+    );
+  });
+
+  it("nowIso rejects invalid timestamp references", () => {
+    expect(() => nowIso("not-a-date")).toThrow("Invalid timestamp reference");
+  });
+
   it("falls back when crypto is unavailable", () => {
     vi.stubGlobal("crypto", unsafeCast<Crypto>(undefined));
     try {

--- a/src/lib/security/__tests__/service.test.ts
+++ b/src/lib/security/__tests__/service.test.ts
@@ -1,0 +1,166 @@
+/** @vitest-environment node */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
+
+const getManyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/supabase/typed-helpers", () => ({
+  getMany: getManyMock,
+}));
+
+import { getUserSecurityMetrics, getUserSessions } from "../service";
+
+type QueryCall = {
+  column: string;
+  method: string;
+  value: unknown;
+};
+
+type QueryRecorder = {
+  eq: (column: string, value: unknown) => QueryRecorder;
+  gte: (column: string, value: unknown) => QueryRecorder;
+};
+
+function createQueryRecorder(): { calls: QueryCall[]; query: QueryRecorder } {
+  const calls: QueryCall[] = [];
+  const query: QueryRecorder = {
+    eq: (column, value) => {
+      calls.push({ column, method: "eq", value });
+      return query;
+    },
+    gte: (column, value) => {
+      calls.push({ column, method: "gte", value });
+      return query;
+    },
+  };
+  return { calls, query };
+}
+
+describe("security service session mapping", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("prefers refreshed, updated, and created timestamps in order", async () => {
+    getManyMock.mockResolvedValue({
+      data: [
+        {
+          created_at: "2026-01-01T00:00:00.000Z",
+          id: "session-1",
+          ip: "192.0.2.1",
+          refreshed_at: "2026-01-01T03:00:00.000Z",
+          updated_at: "2026-01-01T02:00:00.000Z",
+          user_agent: "Chrome",
+        },
+        {
+          created_at: "2026-01-02T00:00:00.000Z",
+          id: "session-2",
+          ip: null,
+          refreshed_at: null,
+          updated_at: "2026-01-02T02:00:00.000Z",
+          user_agent: null,
+        },
+        {
+          created_at: "2026-01-03T00:00:00.000Z",
+          id: "session-3",
+          ip: "203.0.113.1",
+          refreshed_at: null,
+          updated_at: null,
+          user_agent: "Firefox",
+        },
+      ],
+      error: null,
+    });
+
+    const sessions = await getUserSessions({} as never, "user-1");
+
+    expect(sessions.map((session) => session.lastActivity)).toEqual([
+      "2026-01-01T03:00:00.000Z",
+      "2026-01-02T02:00:00.000Z",
+      "2026-01-03T00:00:00.000Z",
+    ]);
+  });
+
+  it("uses Unknown instead of fabricating fresh activity for missing timestamps", async () => {
+    getManyMock.mockResolvedValue({
+      data: [
+        {
+          created_at: null,
+          id: "session-missing",
+          ip: null,
+          refreshed_at: null,
+          updated_at: null,
+          user_agent: null,
+        },
+      ],
+      error: null,
+    });
+
+    const sessions = await getUserSessions({} as never, "user-1");
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      browser: "Unknown",
+      device: "Unknown device",
+      id: "session-missing",
+      ipAddress: "Unknown",
+      isCurrent: false,
+      lastActivity: "Unknown",
+      location: "Unknown",
+    });
+  });
+});
+
+describe("security service metrics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it(
+    "derives failed-login cutoff from the shared timestamp helper",
+    withFakeTimers(async () => {
+      vi.setSystemTime(new Date("2026-02-03T04:05:06.000Z"));
+      getManyMock
+        .mockResolvedValueOnce({
+          data: [{ created_at: "2026-02-03T03:00:00.000Z" }],
+          error: null,
+        })
+        .mockResolvedValueOnce({ count: 2, data: [], error: null })
+        .mockResolvedValueOnce({ count: 1, data: [], error: null })
+        .mockResolvedValueOnce({ data: [{ id: "mfa-1" }], error: null })
+        .mockResolvedValueOnce({
+          data: [{ provider: "google" }],
+          error: null,
+        });
+
+      const metrics = await getUserSecurityMetrics({} as never, "user-1");
+
+      expect(metrics).toEqual({
+        activeSessions: 1,
+        failedLoginAttempts: 2,
+        lastLogin: "2026-02-03T03:00:00.000Z",
+        oauthConnections: ["google"],
+        securityScore: 90,
+        trustedDevices: 1,
+      });
+
+      const failedLoginFilter = getManyMock.mock.calls[1]?.[2] as
+        | ((query: QueryRecorder) => QueryRecorder)
+        | undefined;
+      expect(failedLoginFilter).toBeTypeOf("function");
+      if (!failedLoginFilter) {
+        throw new Error("missing_failed_login_filter");
+      }
+
+      const { calls, query } = createQueryRecorder();
+      failedLoginFilter(query);
+
+      expect(calls).toContainEqual({
+        column: "created_at",
+        method: "gte",
+        value: "2026-02-02T04:05:06.000Z",
+      });
+    })
+  );
+});

--- a/src/lib/security/mfa.ts
+++ b/src/lib/security/mfa.ts
@@ -38,6 +38,26 @@ type TypedSupabase = SupabaseClient<Database>;
 type BackupAuditMeta = { ip?: string; userAgent?: string };
 
 const auditLogger = createServerLogger("security.mfa.audit");
+const TOTP_ENROLLMENT_TTL_MS = 15 * 60 * 1000;
+const MS_PER_SECOND = 1000;
+
+function getCurrentEpochMs(currentIso = nowIso()): number {
+  return Date.parse(currentIso);
+}
+
+function createTotpEnrollmentWindow(currentIso = nowIso()): {
+  expiresAt: string;
+  issuedAt: string;
+  ttlSeconds: number;
+} {
+  const issuedAtMs = Date.parse(currentIso);
+  const expiresAt = new Date(issuedAtMs + TOTP_ENROLLMENT_TTL_MS).toISOString();
+  return {
+    expiresAt,
+    issuedAt: currentIso,
+    ttlSeconds: Math.floor(TOTP_ENROLLMENT_TTL_MS / MS_PER_SECOND),
+  };
+}
 
 /** Normalizes an unknown error into a standard Error object for telemetry recordException. */
 function toException(error: unknown): Error {
@@ -190,12 +210,7 @@ export async function startTotpEnrollment(
     "mfa.start_enrollment",
     { attributes: { factor: "totp", feature: "mfa" } },
     async (span) => {
-      const now = new Date();
-      const expiresAt = new Date(now.getTime() + 15 * 60 * 1000);
-      const ttlSeconds = Math.max(
-        0,
-        Math.floor((expiresAt.getTime() - now.getTime()) / 1000)
-      );
+      const enrollmentWindow = createTotpEnrollmentWindow();
 
       const userId = await getAuthenticatedUserId(supabase).catch((error) => {
         span.recordException(error as Error);
@@ -216,11 +231,11 @@ export async function startTotpEnrollment(
 
       const payload = {
         challengeId: challenge.data.id,
-        expiresAt: expiresAt.toISOString(),
+        expiresAt: enrollmentWindow.expiresAt,
         factorId: enrollResult.data.id,
-        issuedAt: now.toISOString(),
+        issuedAt: enrollmentWindow.issuedAt,
         qrCode: enrollResult.data.totp.qr_code ?? "",
-        ttlSeconds,
+        ttlSeconds: enrollmentWindow.ttlSeconds,
         uri: enrollResult.data.totp.uri ?? undefined,
       };
       const parsed = mfaEnrollmentSchema.parse(payload);
@@ -230,7 +245,10 @@ export async function startTotpEnrollment(
         "mfa_enrollments",
         { status: "expired" },
         (qb) =>
-          qb.eq("user_id", userId).eq("status", "pending").lt("expires_at", nowIso()),
+          qb
+            .eq("user_id", userId)
+            .eq("status", "pending")
+            .lt("expires_at", enrollmentWindow.issuedAt),
         { count: null }
       );
       if (expireError) {
@@ -382,7 +400,7 @@ export async function verifyTotp(
         if (Number.isNaN(expiresAtMs)) {
           throw new TotpVerificationInternalError("mfa_enrollment_expires_at_invalid");
         }
-        if (expiresAtMs < Date.now()) {
+        if (expiresAtMs < getCurrentEpochMs()) {
           const { error: expireError } = await updateMany(
             adminSupabase,
             "mfa_enrollments",

--- a/src/lib/security/random.ts
+++ b/src/lib/security/random.ts
@@ -86,10 +86,27 @@ export function secureRandomFloat(): number {
   return (fallbackPrngState >>> 0) / 2 ** 32;
 }
 
+type TimestampReference = Date | number | string;
+
+const getTimestampDate = (reference?: TimestampReference): Date => {
+  const date =
+    reference instanceof Date
+      ? new Date(reference.getTime())
+      : new Date(reference ?? Date.now());
+
+  if (!Number.isFinite(date.getTime())) {
+    throw new Error("Invalid timestamp reference");
+  }
+
+  return date;
+};
+
 /**
  * Get current timestamp in ISO 8601 format.
+ *
+ * @param reference - Optional timestamp reference for deterministic callers/tests.
  * @returns ISO timestamp string.
  */
-export function nowIso(): string {
-  return new Date().toISOString();
+export function nowIso(reference?: TimestampReference): string {
+  return getTimestampDate(reference).toISOString();
 }

--- a/src/lib/security/service.ts
+++ b/src/lib/security/service.ts
@@ -11,6 +11,7 @@ import {
   securityMetricsSchema,
 } from "@schemas/security";
 import { extractErrorMessage } from "@/lib/errors/error-message";
+import { nowIso } from "@/lib/security/random";
 import type { TypedAdminSupabase } from "@/lib/supabase/admin";
 import { getMany } from "@/lib/supabase/typed-helpers";
 
@@ -24,6 +25,10 @@ type AuditLogRow = {
 
 /** 24 hours in milliseconds. */
 const HOURS_24_MS = 24 * 60 * 60 * 1000;
+
+function getSecurityMetricsSince(currentIso: string = nowIso()): string {
+  return new Date(Date.parse(currentIso) - HOURS_24_MS).toISOString();
+}
 
 /**
  * Maps an audit log action to a security event type.
@@ -129,7 +134,7 @@ export async function getUserSecurityMetrics(
   adminSupabase: TypedAdminSupabase,
   userId: string
 ): Promise<SecurityMetrics> {
-  const since = new Date(Date.now() - HOURS_24_MS).toISOString();
+  const since = getSecurityMetricsSince();
 
   const [loginRowsRes, failedRes, sessionRes, mfaRes, identitiesRes] =
     await Promise.all([
@@ -312,7 +317,7 @@ export async function getUserSessions(
       id: record.id as string,
       ipAddress: (record.ip as string | null | undefined) ?? "Unknown",
       isCurrent: false,
-      lastActivity: refreshedAt ?? updatedAt ?? createdAt ?? new Date().toISOString(),
+      lastActivity: refreshedAt ?? updatedAt ?? createdAt ?? "Unknown",
       location: "Unknown",
     };
   });

--- a/src/lib/supabase/__tests__/client.dom.test.ts
+++ b/src/lib/supabase/__tests__/client.dom.test.ts
@@ -5,11 +5,23 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // Mock env module to prevent validation errors during tests
 vi.mock("@/lib/env/client", () => ({
   getClientEnv: () => ({
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "",
     NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY:
-      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? "",
+      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ||
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+      "",
     NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
   }),
-  getClientEnvVar: (key: string) => process.env[key] ?? "",
+  getClientEnvVar: (key: string) => {
+    if (key === "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY") {
+      return (
+        process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ||
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+        ""
+      );
+    }
+    return process.env[key] ?? "";
+  },
 }));
 
 describe("Supabase Browser Client", () => {
@@ -23,12 +35,18 @@ describe("Supabase Browser Client", () => {
     // Reset environment variables
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "");
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "");
   });
 
   // Dynamic import to get fresh module after resetModules
   async function getClient() {
     const module = await import("../client");
     return module.createClient;
+  }
+
+  async function getBrowserClient() {
+    const module = await import("../client");
+    return module.getBrowserClient;
   }
 
   it("should create a browser client with valid environment variables", async () => {
@@ -56,12 +74,45 @@ describe("Supabase Browser Client", () => {
     expect(() => createClient()).not.toThrow();
   });
 
+  it("should create a browser client with the legacy anon key fallback", async () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", mockSupabaseUrl);
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "legacy-anon-key");
+
+    const createClient = await getClient();
+    const client = createClient();
+    expect(client).toBeTruthy();
+  });
+
   it("should handle both environment variables missing gracefully in tests", async () => {
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "");
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "");
 
     const createClient = await getClient();
     expect(() => createClient()).not.toThrow();
+  });
+
+  it("should return null without logging when singleton env variables are missing", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const getBrowserSupabaseClient = await getBrowserClient();
+
+    expect(getBrowserSupabaseClient()).toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("should create the singleton browser client with the legacy anon key fallback", async () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", mockSupabaseUrl);
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY", "");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "legacy-anon-key");
+
+    const getBrowserSupabaseClient = await getBrowserClient();
+
+    expect(getBrowserSupabaseClient()).toBeTruthy();
   });
 
   it("should handle undefined environment variables gracefully in tests", async () => {

--- a/src/lib/supabase/__tests__/factory.spec.ts
+++ b/src/lib/supabase/__tests__/factory.spec.ts
@@ -245,10 +245,11 @@ describe("Supabase Factory", () => {
         }
       );
 
-      // @ts-expect-error - runtime should guard against missing cookie adapter
-      createServerSupabaseClient({
-        enableTracing: false,
-      });
+      createServerSupabaseClient(
+        unsafeCast<Parameters<typeof createServerSupabaseClient>[0]>({
+          enableTracing: false,
+        })
+      );
     });
   });
 

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -48,22 +48,14 @@ export function getBrowserClient(): TypedSupabaseClient | null {
   }
 
   const supabaseUrl = getClientEnvVar("NEXT_PUBLIC_SUPABASE_URL");
-  const supabasePublishableKey = getClientEnvVar(
-    "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY"
-  );
+  const supabasePublicKey = getClientEnvVar("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY");
 
   // Allow the app to boot in dev/build placeholder mode without crashing.
-  if (!supabaseUrl || !supabasePublishableKey) {
-    if (process.env.NODE_ENV === "development") {
-      console.warn(
-        "[supabase/client] Supabase env vars missing (NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY or NEXT_PUBLIC_SUPABASE_ANON_KEY). " +
-          "This is expected during development or build with placeholder mode enabled."
-      );
-    }
+  if (!supabaseUrl || !supabasePublicKey) {
     return null;
   }
 
-  client = createBrowserClient<Database>(supabaseUrl, supabasePublishableKey);
+  client = createBrowserClient<Database>(supabaseUrl, supabasePublicKey);
   return client;
 }
 
@@ -110,14 +102,12 @@ export function createClient(): TypedSupabaseClient | null {
   }
 
   const supabaseUrl = getClientEnvVar("NEXT_PUBLIC_SUPABASE_URL");
-  const supabasePublishableKey = getClientEnvVar(
-    "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY"
-  );
+  const supabasePublicKey = getClientEnvVar("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY");
 
-  if (!supabaseUrl || !supabasePublishableKey) {
+  if (!supabaseUrl || !supabasePublicKey) {
     return null;
   }
 
   // Intentionally create a fresh client (used by utility code that expects non-singleton behavior)
-  return createBrowserClient<Database>(supabaseUrl, supabasePublishableKey);
+  return createBrowserClient<Database>(supabaseUrl, supabasePublicKey);
 }

--- a/src/lib/telemetry/__tests__/client.dom.test.ts
+++ b/src/lib/telemetry/__tests__/client.dom.test.ts
@@ -47,6 +47,31 @@ const FETCH_INSTRUMENTATION = vi.hoisted(() => {
   return vi.fn(FetchInstrumentation);
 });
 const REGISTER_INSTRUMENTATIONS = vi.hoisted(() => vi.fn());
+const ORIGINAL_WINDOW_DESCRIPTOR = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "window"
+);
+const ORIGINAL_ZONE_DESCRIPTOR = Object.getOwnPropertyDescriptor(globalThis, "Zone");
+
+function setGlobalPropertyForTest(key: "window" | "Zone", value: unknown): void {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value,
+    writable: true,
+  });
+}
+
+function restoreGlobalPropertyForTest(
+  key: "window" | "Zone",
+  descriptor: PropertyDescriptor | undefined
+): void {
+  if (descriptor) {
+    Object.defineProperty(globalThis, key, descriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(globalThis, key);
+}
 
 // Mock OpenTelemetry modules
 vi.mock("@opentelemetry/sdk-trace-web", () => ({
@@ -102,9 +127,8 @@ describe("initTelemetry", () => {
     vi.restoreAllMocks();
     // Reset module cache to clear singleton state between tests
     vi.resetModules();
-
-    // @ts-expect-error - test-only cleanup for zone.js globals
-    globalThis.Zone = undefined;
+    restoreGlobalPropertyForTest("window", ORIGINAL_WINDOW_DESCRIPTOR);
+    restoreGlobalPropertyForTest("Zone", ORIGINAL_ZONE_DESCRIPTOR);
   });
 
   async function waitForInit(expectedExporterCalls = 1) {
@@ -125,19 +149,17 @@ describe("initTelemetry", () => {
 
     // First call initializes successfully in a browser-like environment
     // Provide Zone to exercise ZoneContextManager branch.
-    // @ts-expect-error - Zone is added by zone.js at runtime
-    globalThis.Zone = {};
+    setGlobalPropertyForTest("Zone", {});
     initTelemetry();
     await waitForInit(1);
 
     // Second call should be a no-op even if window is missing
     const originalWindow = globalThis.window;
-    // @ts-expect-error - intentionally setting window to undefined for test
-    globalThis.window = undefined;
+    setGlobalPropertyForTest("window", undefined);
 
     expect(() => initTelemetry()).not.toThrow();
 
-    globalThis.window = originalWindow;
+    setGlobalPropertyForTest("window", originalWindow);
 
     expect(OTLP_TRACE_EXPORTER).toHaveBeenCalledTimes(1);
   });
@@ -146,12 +168,11 @@ describe("initTelemetry", () => {
     const { initTelemetry } = await import("../client");
 
     const originalWindow = globalThis.window;
-    // @ts-expect-error - intentionally setting window to undefined for test
-    globalThis.window = undefined;
+    setGlobalPropertyForTest("window", undefined);
 
     expect(() => initTelemetry()).not.toThrow();
 
-    globalThis.window = originalWindow;
+    setGlobalPropertyForTest("window", originalWindow);
 
     expect(OTLP_TRACE_EXPORTER).not.toHaveBeenCalled();
     expect(WEB_TRACER_PROVIDER).not.toHaveBeenCalled();

--- a/src/lib/telemetry/__tests__/degraded-mode.test.ts
+++ b/src/lib/telemetry/__tests__/degraded-mode.test.ts
@@ -1,0 +1,57 @@
+/** @vitest-environment node */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
+
+const emitOperationalAlertMock = vi.hoisted(() => vi.fn());
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/telemetry/alerts", () => ({
+  emitOperationalAlert: emitOperationalAlertMock,
+}));
+
+import {
+  emitOperationalAlertOncePerWindow,
+  resetDegradedModeAlertStateForTests,
+} from "../degraded-mode";
+
+describe("emitOperationalAlertOncePerWindow", () => {
+  beforeEach(() => {
+    emitOperationalAlertMock.mockReset();
+    resetDegradedModeAlertStateForTests();
+  });
+
+  it(
+    "dedupes alerts using the helper-backed current time",
+    withFakeTimers(() => {
+      vi.setSystemTime(new Date("2026-02-03T04:05:06.000Z"));
+
+      emitOperationalAlertOncePerWindow({
+        attributes: { degradedMode: "fail_open", rateLimitKey: "trips:create" },
+        event: "ratelimit.degraded",
+        severity: "warning",
+        windowMs: 60_000,
+      });
+      emitOperationalAlertOncePerWindow({
+        attributes: { degradedMode: "fail_open", rateLimitKey: "trips:create" },
+        event: "ratelimit.degraded",
+        severity: "warning",
+        windowMs: 60_000,
+      });
+
+      expect(emitOperationalAlertMock).toHaveBeenCalledTimes(1);
+
+      vi.setSystemTime(new Date("2026-02-03T04:06:07.000Z"));
+
+      emitOperationalAlertOncePerWindow({
+        attributes: { degradedMode: "fail_open", rateLimitKey: "trips:create" },
+        event: "ratelimit.degraded",
+        severity: "warning",
+        windowMs: 60_000,
+      });
+
+      expect(emitOperationalAlertMock).toHaveBeenCalledTimes(2);
+    })
+  );
+});

--- a/src/lib/telemetry/alerts.ts
+++ b/src/lib/telemetry/alerts.ts
@@ -3,6 +3,7 @@
  */
 
 import "server-only";
+import { nowIso } from "@/lib/security/random";
 import { TELEMETRY_SERVICE_NAME } from "@/lib/telemetry/constants";
 import { recordTelemetryEvent } from "@/lib/telemetry/span";
 
@@ -39,7 +40,7 @@ export function emitOperationalAlert(
       }, {})
     : undefined;
 
-  const timestamp = new Date().toISOString();
+  const timestamp = nowIso();
 
   // Record to OTel for distributed tracing and monitoring integration
   recordTelemetryEvent(`alert.${event}`, {

--- a/src/lib/telemetry/degraded-mode.ts
+++ b/src/lib/telemetry/degraded-mode.ts
@@ -4,6 +4,7 @@
 
 import "server-only";
 
+import { nowIso } from "@/lib/security/random";
 import type { OperationalAlertOptions } from "@/lib/telemetry/alerts";
 import { emitOperationalAlert } from "@/lib/telemetry/alerts";
 import { isPlainObject } from "@/lib/utils/type-guards";
@@ -13,6 +14,10 @@ const MAX_DEDUPE_ENTRY_AGE_MS = 24 * 60 * 60 * 1000; // 24h
 const CLEANUP_INTERVAL_MS = 10 * 60 * 1000; // 10m
 const CLEANUP_SIZE_THRESHOLD = 1000;
 let lastCleanupAt = 0;
+
+function getCurrentEpochMs(currentIso = nowIso()): number {
+  return Date.parse(currentIso);
+}
 
 function normalizeForStableJson(value: unknown): unknown {
   if (value === null) return null;
@@ -70,7 +75,7 @@ export function emitOperationalAlertOncePerWindow(
 ): void {
   const { event, windowMs, ...options } = params;
 
-  const now = Date.now();
+  const now = getCurrentEpochMs();
   maybeCleanup(now);
   const dedupeKey = `${event}:${stableStringifyAttributes(options.attributes ?? {})}`;
   const last = lastEmittedAtByKey.get(dedupeKey);

--- a/src/lib/tokens/budget.ts
+++ b/src/lib/tokens/budget.ts
@@ -20,7 +20,7 @@ interface TiktokenWithFree extends Tiktoken {
 export type { ClampResult };
 export type ChatMessage = TokenChatMessage;
 
-/** Heuristic fallback ratio: ~4 characters per token (UNVERIFIED for non-OpenAI). */
+/** Approximate fallback ratio for models without first-party JS tokenizers; see ADR-027. */
 export const CHARS_PER_TOKEN_HEURISTIC = 4;
 
 /** Cache for tokenizer instances to avoid repeated WASM instantiation. */

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -114,12 +114,12 @@ export function throttle<T extends (...args: unknown[]) => unknown>(
   fn: T,
   delay: number
 ): (...args: Parameters<T>) => void {
-  let lastCall = 0;
+  let lastCall: number | null = null;
 
   return (...args: Parameters<T>) => {
-    const now = Date.now();
+    const now = performance.now();
 
-    if (now - lastCall < delay) {
+    if (lastCall !== null && now - lastCall < delay) {
       return;
     }
 

--- a/src/lib/utils/__tests__/deep-equal.test.ts
+++ b/src/lib/utils/__tests__/deep-equal.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { deepEqualJsonLike } from "@/lib/utils/deep-equal";
 
 describe("deepEqualJsonLike", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("compares primitives and arrays", () => {
     expect(deepEqualJsonLike(1, 1)).toBe(true);
     expect(deepEqualJsonLike(1, 2)).toBe(false);
@@ -68,6 +72,34 @@ describe("deepEqualJsonLike", () => {
     expect(warnings.some((w) => w.message === "Slow dirty-check comparison")).toBe(
       true
     );
+  });
+
+  it("uses monotonic time for default slow-comparison timing", () => {
+    const dateNowSpy = vi.spyOn(Date, "now");
+    const performanceNowSpy = vi
+      .spyOn(performance, "now")
+      .mockReturnValueOnce(100)
+      .mockReturnValueOnce(103);
+    const warnings: Array<{ message: string; meta?: Record<string, unknown> }> = [];
+    const logger = {
+      warn: (message: string, meta?: Record<string, unknown>) => {
+        warnings.push({ message, meta });
+      },
+    };
+
+    const result = deepEqualJsonLike(
+      { a: 1 },
+      { a: 1 },
+      { logger, slowThresholdMs: 0 }
+    );
+
+    expect(result).toBe(true);
+    expect(performanceNowSpy).toHaveBeenCalledTimes(2);
+    expect(dateNowSpy).not.toHaveBeenCalled();
+    expect(warnings).toContainEqual({
+      message: "Slow dirty-check comparison",
+      meta: expect.objectContaining({ durationMs: 3 }),
+    });
   });
 
   it("handles large arrays", () => {

--- a/src/lib/utils/deep-equal.ts
+++ b/src/lib/utils/deep-equal.ts
@@ -30,8 +30,7 @@ export interface DeepEqualJsonLikeOptions {
   slowThresholdMs?: number;
 }
 
-const defaultNowMs = (): number =>
-  typeof performance === "undefined" ? Date.now() : performance.now();
+const defaultNowMs = (): number => globalThis.performance?.now() ?? 0;
 
 const sizeOf = (value: unknown): number => {
   if (Array.isArray(value)) return value.length;

--- a/src/scripts/__tests__/check-coverage-critical.test.ts
+++ b/src/scripts/__tests__/check-coverage-critical.test.ts
@@ -1,0 +1,196 @@
+/** @vitest-environment node */
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const scriptPath = join(process.cwd(), "scripts/check-coverage-critical.mjs");
+
+const criticalFiles = [
+  "src/app/auth/page.ts",
+  "src/lib/auth/server.ts",
+  "src/lib/payments/checkout.ts",
+  "src/app/api/keys/route.ts",
+  "src/lib/webhooks/handler.ts",
+  "src/app/api/hooks/cache/route.ts",
+  "src/lib/qstash/client.ts",
+  "src/ai/agents/router.ts",
+  "src/ai/tools/flights.ts",
+  "src/ai/lib/tool-factory.ts",
+  "src/app/api/chat/route.ts",
+];
+
+type CoverageCounts = {
+  branch?: number;
+  function?: number;
+  statement?: number;
+};
+
+function writeFixtureFiles(root: string, files: readonly string[]) {
+  for (const filePath of files) {
+    const absolutePath = join(root, filePath);
+    mkdirSync(dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, "export const covered = true;\n");
+  }
+}
+
+function coverageEntry(counts: CoverageCounts = {}) {
+  return {
+    b: {
+      "0": [counts.branch ?? 1],
+    },
+    branchMap: {
+      "0": {
+        line: 1,
+        locations: [{ line: 1 }],
+        type: "if",
+      },
+    },
+    f: {
+      "0": counts.function ?? 1,
+    },
+    fnMap: {
+      "0": {
+        decl: { line: 1 },
+        line: 1,
+        loc: { line: 1 },
+        name: "covered",
+      },
+    },
+    s: {
+      "0": counts.statement ?? 1,
+    },
+    statementMap: {
+      "0": {
+        start: { line: 1 },
+      },
+    },
+  };
+}
+
+function coverageForFiles(root: string, files: readonly string[]) {
+  return Object.fromEntries(
+    files.map((filePath) => [join(root, filePath), coverageEntry()])
+  );
+}
+
+function runCoverageCheck({
+  coverage,
+  sourceFiles = criticalFiles,
+}: {
+  coverage: Record<string, unknown>;
+  sourceFiles?: readonly string[];
+}) {
+  const tempDir = mkdtempSync(join(tmpdir(), "tripsage-critical-coverage-"));
+
+  try {
+    writeFixtureFiles(tempDir, sourceFiles);
+    const coveragePath = join(tempDir, "coverage-final.json");
+    writeFileSync(coveragePath, `${JSON.stringify(coverage, null, 2)}\n`);
+
+    return spawnSync(process.execPath, [scriptPath, coveragePath], {
+      cwd: tempDir,
+      encoding: "utf8",
+    });
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
+describe("check-coverage-critical", () => {
+  it("accepts coverage that includes every critical file above thresholds", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "tripsage-critical-coverage-ok-"));
+
+    try {
+      writeFixtureFiles(tempDir, criticalFiles);
+      const coveragePath = join(tempDir, "coverage-final.json");
+      writeFileSync(
+        coveragePath,
+        `${JSON.stringify(coverageForFiles(tempDir, criticalFiles), null, 2)}\n`
+      );
+
+      const result = spawnSync(process.execPath, [scriptPath, coveragePath], {
+        cwd: tempDir,
+        encoding: "utf8",
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("auth");
+      expect(result.stdout).toContain("OK: critical coverage thresholds satisfied");
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  it("fails when a critical surface falls below its configured threshold", () => {
+    const tempDir = mkdtempSync(
+      join(tmpdir(), "tripsage-critical-coverage-threshold-")
+    );
+
+    try {
+      writeFixtureFiles(tempDir, criticalFiles);
+      const coverage = coverageForFiles(tempDir, criticalFiles);
+      coverage[join(tempDir, "src/app/api/keys/route.ts")] = coverageEntry({
+        branch: 0,
+        function: 0,
+        statement: 0,
+      });
+
+      const coveragePath = join(tempDir, "coverage-final.json");
+      writeFileSync(coveragePath, `${JSON.stringify(coverage, null, 2)}\n`);
+
+      const result = spawnSync(process.execPath, [scriptPath, coveragePath], {
+        cwd: tempDir,
+        encoding: "utf8",
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("Coverage below critical thresholds");
+      expect(result.stderr).toContain("keys.functions");
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  it("fails when a critical source file is missing from coverage output", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "tripsage-critical-coverage-missing-"));
+
+    try {
+      writeFixtureFiles(tempDir, criticalFiles);
+      const coveredFiles = criticalFiles.filter(
+        (filePath) => filePath !== "src/lib/auth/server.ts"
+      );
+      const coveragePath = join(tempDir, "coverage-final.json");
+      writeFileSync(
+        coveragePath,
+        `${JSON.stringify(coverageForFiles(tempDir, coveredFiles), null, 2)}\n`
+      );
+
+      const result = spawnSync(process.execPath, [scriptPath, coveragePath], {
+        cwd: tempDir,
+        encoding: "utf8",
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("auth.missing_files");
+      expect(result.stderr).toContain("src/lib/auth/server.ts");
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  it("fails loudly when a configured critical root was moved or removed", () => {
+    const result = runCoverageCheck({
+      coverage: coverageForFiles(tmpdir(), criticalFiles),
+      sourceFiles: criticalFiles.filter(
+        (filePath) => !filePath.startsWith("src/lib/payments/")
+      ),
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Critical surface root directory not found");
+    expect(result.stderr).toContain("src/lib/payments");
+  });
+});

--- a/src/scripts/__tests__/check-doc-links.test.ts
+++ b/src/scripts/__tests__/check-doc-links.test.ts
@@ -1,0 +1,134 @@
+/** @vitest-environment node */
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const scriptPath = join(process.cwd(), "scripts/check-doc-links.mjs");
+
+function writeFiles(root: string, files: Record<string, string>) {
+  for (const [filePath, contents] of Object.entries(files)) {
+    const absolutePath = join(root, filePath);
+    mkdirSync(dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, contents);
+  }
+}
+
+function runDocsCheck(files: Record<string, string>, targets: string[] = []) {
+  const tempDir = mkdtempSync(join(tmpdir(), "tripsage-doc-links-"));
+
+  try {
+    writeFiles(tempDir, files);
+    return spawnSync(process.execPath, [scriptPath, ...targets], {
+      cwd: tempDir,
+      encoding: "utf8",
+    });
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
+describe("check-doc-links", () => {
+  it("accepts valid relative links, anchors, reference links, and directory indexes", () => {
+    const result = runDocsCheck({
+      "docs/guide.md": `# Quick Start
+
+## Explicit Section {#explicit-id}
+`,
+      "docs/runbook/README.md": "# Operations\n",
+      "README.md": `# TripSage
+
+See [Guide](docs/guide.md#quick-start), [Directory](docs/runbook/),
+[Extensionless](docs/guide#explicit-id), and [Reference][runbook].
+
+[runbook]: docs/runbook/README.md#operations
+`,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Checked 3 active Markdown file(s)");
+  });
+
+  it("reports missing relative link targets", () => {
+    const result = runDocsCheck({
+      "README.md": `# TripSage
+
+See [Missing](docs/missing.md).
+`,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Found 1 broken active doc link");
+    expect(result.stderr).toContain("README.md: missing docs/missing.md");
+  });
+
+  it("reports missing heading anchors after normalizing generated markdown anchors", () => {
+    const result = runDocsCheck({
+      "docs/guide.md": "# Quick `Start`!\n",
+      "README.md": `# TripSage
+
+See [Wrong Anchor](docs/guide.md#missing-anchor).
+`,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "README.md: missing anchor docs/guide.md#missing-anchor"
+    );
+  });
+
+  it("ignores links in code fences and skippable external schemes", () => {
+    const result = runDocsCheck({
+      "README.md": `# TripSage
+
+[External](https://example.com)
+[Mail](mailto:hello@example.com)
+[App](app://local)
+
+\`\`\`md
+[Ignored](docs/missing.md)
+\`\`\`
+`,
+    });
+
+    expect(result.status).toBe(0);
+  });
+
+  it("excludes archive and review documentation from active link checks", () => {
+    const result = runDocsCheck({
+      "docs/plans/archive/old-plan.md": `# Archived Plan
+
+[Historical broken link](../missing.md)
+`,
+      "docs/reviews/2026-01-01/report.md": `# Review
+
+[Historical broken link](../missing.md)
+`,
+      "README.md": "# TripSage\n",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Checked 1 active Markdown file");
+  });
+
+  it("checks explicit target arguments instead of the default README and docs set", () => {
+    const result = runDocsCheck(
+      {
+        "notes/custom.md": `# Custom
+
+[Self](#custom)
+`,
+        "README.md": `# TripSage
+
+[Broken](docs/missing.md)
+`,
+      },
+      ["notes"]
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Checked 1 active Markdown file");
+  });
+});

--- a/src/scripts/__tests__/check-fileoverviews.test.ts
+++ b/src/scripts/__tests__/check-fileoverviews.test.ts
@@ -1,0 +1,198 @@
+/** @vitest-environment node */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const scriptPath = join(process.cwd(), "scripts/check-fileoverviews.mjs");
+
+function writeFiles(root: string, files: Record<string, string>) {
+  for (const [filePath, contents] of Object.entries(files)) {
+    const absolutePath = join(root, filePath);
+    mkdirSync(dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, contents);
+  }
+}
+
+function initRepo(tempDir: string) {
+  execFileSync("git", ["init", "--initial-branch=main"], {
+    cwd: tempDir,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["config", "user.email", "test@example.com"], {
+    cwd: tempDir,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["config", "user.name", "TripSage Test"], {
+    cwd: tempDir,
+    stdio: "ignore",
+  });
+}
+
+function runFullScannerInTempRepo(files: Record<string, string>) {
+  const tempDir = mkdtempSync(join(tmpdir(), "tripsage-fileoverview-full-scan-"));
+
+  try {
+    initRepo(tempDir);
+    writeFiles(tempDir, files);
+    execFileSync("git", ["add", "."], { cwd: tempDir, stdio: "ignore" });
+
+    return spawnSync(process.execPath, [scriptPath, "--full"], {
+      cwd: tempDir,
+      encoding: "utf8",
+    });
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
+function runDiffScannerInTempRepo(
+  before: Record<string, string>,
+  after: Record<string, string>,
+  deletedFiles: string[] = []
+) {
+  const tempDir = mkdtempSync(join(tmpdir(), "tripsage-fileoverview-diff-scan-"));
+
+  try {
+    initRepo(tempDir);
+    writeFiles(tempDir, before);
+    execFileSync("git", ["add", "."], { cwd: tempDir, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "baseline"], {
+      cwd: tempDir,
+      stdio: "ignore",
+    });
+    execFileSync("git", ["checkout", "-b", "feature"], {
+      cwd: tempDir,
+      stdio: "ignore",
+    });
+
+    for (const filePath of deletedFiles) {
+      unlinkSync(join(tempDir, filePath));
+    }
+    writeFiles(tempDir, after);
+    execFileSync("git", ["add", "-A"], { cwd: tempDir, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "feature"], {
+      cwd: tempDir,
+      stdio: "ignore",
+    });
+
+    return spawnSync(process.execPath, [scriptPath], {
+      cwd: tempDir,
+      encoding: "utf8",
+    });
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
+describe("check-fileoverviews", () => {
+  it("detects multi-line @fileoverview blocks in production source files", () => {
+    const result = runFullScannerInTempRepo({
+      "src/lib/example.ts": `
+        /**
+         * @fileoverview Describes the module.
+         *
+         * Extra implementation detail belongs in docs.
+         */
+        export const example = true;
+      `,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("src/lib/example.ts");
+    expect(result.stderr).toContain("Multi-line @fileoverview block detected");
+  });
+
+  it("allows one-line descriptions, documented exceptions, tests, and mocks", () => {
+    const result = runFullScannerInTempRepo({
+      "src/lib/__mocks__/fixture.ts": `
+        /**
+         * @fileoverview Mock-only module.
+         *
+         * Mocks are excluded from this production-code guard.
+         */
+        export const mockOnly = true;
+      `,
+      "src/lib/example.test.ts": `
+        /**
+         * @fileoverview Test-only module.
+         *
+         * Tests are excluded from this production-code guard.
+         */
+        export const testOnly = true;
+      `,
+      "src/lib/example.ts": `
+        /**
+         * @fileoverview Describes the module.
+         */
+        export const example = true;
+      `,
+      "src/lib/legacy.ts": `
+        /**
+         * @fileoverview fileoverview-ok: generated compatibility wrapper.
+         *
+         * Extra generated detail is preserved here.
+         */
+        export const legacy = true;
+      `,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("OK: no @fileoverview drift detected");
+  });
+
+  it("rejects @fileoverview blocks without descriptions", () => {
+    const result = runFullScannerInTempRepo({
+      "src/lib/example.ts": `
+        /**
+         * @fileoverview
+         */
+        export const example = true;
+      `,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("@fileoverview must include a short description");
+  });
+
+  it("checks committed branch diffs and skips deleted files", () => {
+    const result = runDiffScannerInTempRepo(
+      {
+        "src/lib/deleted.ts": `
+          /**
+           * @fileoverview Deleted module.
+           *
+           * Existing drift should not matter after deletion.
+           */
+          export const deleted = true;
+        `,
+        "src/lib/unchanged.ts": `
+          /**
+           * @fileoverview Existing unchanged drift.
+           *
+           * Diff mode should not scan unchanged files.
+           */
+          export const unchanged = true;
+        `,
+      },
+      {
+        "src/lib/changed.ts": `
+          /**
+           * @fileoverview Changed module.
+           *
+           * New drift should be reported.
+           */
+          export const changed = true;
+        `,
+      },
+      ["src/lib/deleted.ts"]
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("src/lib/changed.ts");
+    expect(result.stderr).not.toContain("src/lib/deleted.ts");
+    expect(result.stderr).not.toContain("src/lib/unchanged.ts");
+  });
+});

--- a/src/scripts/__tests__/check-no-new-domain-infra-imports.test.ts
+++ b/src/scripts/__tests__/check-no-new-domain-infra-imports.test.ts
@@ -1,0 +1,162 @@
+/** @vitest-environment node */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const scriptPath = join(process.cwd(), "scripts/check-no-new-domain-infra-imports.mjs");
+
+function writeFiles(root: string, files: Record<string, string>) {
+  for (const [filePath, contents] of Object.entries(files)) {
+    const absolutePath = join(root, filePath);
+    mkdirSync(dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, contents);
+  }
+}
+
+function initRepo(tempDir: string) {
+  execFileSync("git", ["init", "--initial-branch=main"], {
+    cwd: tempDir,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["config", "user.email", "test@example.com"], {
+    cwd: tempDir,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["config", "user.name", "TripSage Test"], {
+    cwd: tempDir,
+    stdio: "ignore",
+  });
+}
+
+function runGuardInTempRepo(
+  before: Record<string, string>,
+  after: Record<string, string>
+) {
+  const tempDir = mkdtempSync(join(tmpdir(), "tripsage-domain-infra-guard-"));
+
+  try {
+    initRepo(tempDir);
+    writeFiles(tempDir, before);
+    execFileSync("git", ["add", "."], { cwd: tempDir, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "baseline"], {
+      cwd: tempDir,
+      stdio: "ignore",
+    });
+    execFileSync("git", ["checkout", "-b", "feature"], {
+      cwd: tempDir,
+      stdio: "ignore",
+    });
+
+    writeFiles(tempDir, after);
+    execFileSync("git", ["add", "-A"], { cwd: tempDir, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "feature"], {
+      cwd: tempDir,
+      stdio: "ignore",
+    });
+
+    return spawnSync(process.execPath, [scriptPath], {
+      cwd: tempDir,
+      encoding: "utf8",
+    });
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
+describe("check-no-new-domain-infra-imports", () => {
+  it("detects newly added domain imports from lib infrastructure", () => {
+    const result = runGuardInTempRepo(
+      {
+        "src/domain/trips/service.ts": "export const existing = true;\n",
+      },
+      {
+        "src/domain/trips/service.ts": `
+          import { createServerSupabase } from "@/lib/supabase/server";
+
+          export const existing = true;
+        `,
+      }
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Found new Domain");
+    expect(result.stderr).toContain("src/domain/trips/service.ts");
+    expect(result.stderr).toContain("@/lib/supabase/server");
+  });
+
+  it("detects export and dynamic import forms", () => {
+    const result = runGuardInTempRepo(
+      {
+        "src/domain/activities/service.ts": "export const existing = true;\n",
+      },
+      {
+        "src/domain/activities/service.ts": `
+          export { createServerLogger } from "@/lib/telemetry/logger";
+
+          export async function loadLimiter() {
+            return import("@/lib/ratelimit/server");
+          }
+        `,
+      }
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("@/lib/telemetry/logger");
+    expect(result.stderr).toContain("@/lib/ratelimit/server");
+  });
+
+  it("allows legacy baseline imports when no new infra import is added", () => {
+    const result = runGuardInTempRepo(
+      {
+        "src/domain/flights/service.ts": `
+          import { redis } from "@/lib/redis";
+
+          export const existing = true;
+        `,
+      },
+      {
+        "src/domain/flights/service.ts": `
+          import { redis } from "@/lib/redis";
+
+          export const existing = true;
+          export const changed = true;
+        `,
+      }
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("OK: no new Domain");
+  });
+
+  it("ignores excluded files, comments, string literals, and allowlisted imports", () => {
+    const result = runGuardInTempRepo(
+      {
+        "src/domain/profile/service.ts": "export const existing = true;\n",
+      },
+      {
+        "src/domain/profile/__mocks__/fixture.ts": `
+          import { redis } from "@/lib/redis";
+          export const mockOnly = true;
+        `,
+        "src/domain/profile/__tests__/service.test.ts": `
+          import { createServerSupabase } from "@/lib/supabase/server";
+          export const testOnly = true;
+        `,
+        "src/domain/profile/service.ts": `
+          // import { redis } from "@/lib/redis";
+          const text = "import('@/lib/qstash/client')";
+          import { logger } from "@/lib/telemetry/logger"; // domain-infra-ok: migration seam under active refactor
+
+          export const existing = true;
+          export const changed = text.length + String(logger).length;
+        `,
+      }
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("OK: no new Domain");
+  });
+});

--- a/src/scripts/__tests__/check-no-new-unknown-casts.test.ts
+++ b/src/scripts/__tests__/check-no-new-unknown-casts.test.ts
@@ -1,0 +1,130 @@
+/** @vitest-environment node */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const scriptPath = join(process.cwd(), "scripts/check-no-new-unknown-casts.mjs");
+
+type RepoFixture = {
+  after?: Record<string, string>;
+  before: Record<string, string>;
+};
+
+function writeFiles(root: string, files: Record<string, string>) {
+  for (const [filePath, contents] of Object.entries(files)) {
+    const absolutePath = join(root, filePath);
+    mkdirSync(dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, contents);
+  }
+}
+
+function runScannerInTempRepo({ after = {}, before }: RepoFixture) {
+  const tempDir = mkdtempSync(join(tmpdir(), "tripsage-new-unknown-cast-scan-"));
+
+  try {
+    execFileSync("git", ["init", "--initial-branch=main"], {
+      cwd: tempDir,
+      stdio: "ignore",
+    });
+    execFileSync("git", ["config", "user.email", "test@example.com"], {
+      cwd: tempDir,
+      stdio: "ignore",
+    });
+    execFileSync("git", ["config", "user.name", "TripSage Test"], {
+      cwd: tempDir,
+      stdio: "ignore",
+    });
+
+    writeFiles(tempDir, before);
+    execFileSync("git", ["add", "."], { cwd: tempDir, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "baseline"], {
+      cwd: tempDir,
+      stdio: "ignore",
+    });
+    execFileSync("git", ["checkout", "-b", "feature"], {
+      cwd: tempDir,
+      stdio: "ignore",
+    });
+
+    writeFiles(tempDir, after);
+    execFileSync("git", ["add", "."], { cwd: tempDir, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "feature"], {
+      cwd: tempDir,
+      stdio: "ignore",
+    });
+
+    return spawnSync(process.execPath, [scriptPath], {
+      cwd: tempDir,
+      encoding: "utf8",
+    });
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
+describe("check-no-new-unknown-casts", () => {
+  it("detects newly added unsafe unknown casts in production src files", () => {
+    const result = runScannerInTempRepo({
+      after: {
+        "src/lib/example.ts": `
+          export function coerce(value: unknown) {
+            return value as unknown as { id: string };
+          }
+        `,
+      },
+      before: {
+        "src/lib/example.ts": "export const ok = 1;\n",
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Found new 'as unknown as' casts");
+    expect(result.stderr).toContain("src/lib/example.ts");
+    expect(result.stderr).toContain("as unknown as");
+  });
+
+  it("allows existing baseline casts when the branch does not add new ones", () => {
+    const result = runScannerInTempRepo({
+      after: {
+        "src/lib/example.ts": `
+          export const existing = value as unknown as { id: string };
+          export const newValue = 1;
+        `,
+      },
+      before: {
+        "src/lib/example.ts": `
+          export const existing = value as unknown as { id: string };
+        `,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("OK: no new 'as unknown as' casts detected");
+  });
+
+  it("ignores excluded files, comments, and explicit inline allowlist markers", () => {
+    const result = runScannerInTempRepo({
+      after: {
+        "src/lib/__mocks__/fixture.ts": `
+          export const mocked = value as unknown as { id: string };
+        `,
+        "src/lib/example.test.ts": `
+          export const tested = value as unknown as { id: string };
+        `,
+        "src/lib/example.ts": `
+          // value as unknown as { id: string }
+          export const justified = value as unknown as { id: string }; // cast-ok: fixture documents an intentional legacy exception
+        `,
+      },
+      before: {
+        "src/lib/example.ts": "export const ok = 1;\n",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("OK: no new 'as unknown as' casts detected");
+  });
+});

--- a/src/scripts/__tests__/check-no-unknown-casts.test.ts
+++ b/src/scripts/__tests__/check-no-unknown-casts.test.ts
@@ -1,0 +1,91 @@
+/** @vitest-environment node */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const scriptPath = join(process.cwd(), "scripts/check-no-unknown-casts.mjs");
+
+function runScannerInTempRepo(
+  files: Record<string, string>,
+  deletedFiles: string[] = []
+) {
+  const tempDir = mkdtempSync(join(tmpdir(), "tripsage-unknown-cast-scan-"));
+
+  try {
+    execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore" });
+
+    for (const [filePath, contents] of Object.entries(files)) {
+      const absolutePath = join(tempDir, filePath);
+      mkdirSync(dirname(absolutePath), { recursive: true });
+      writeFileSync(absolutePath, contents);
+    }
+
+    execFileSync("git", ["add", "."], { cwd: tempDir, stdio: "ignore" });
+
+    for (const filePath of deletedFiles) {
+      unlinkSync(join(tempDir, filePath));
+    }
+
+    return spawnSync(process.execPath, [scriptPath], {
+      cwd: tempDir,
+      encoding: "utf8",
+    });
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
+describe("check-no-unknown-casts", () => {
+  it("detects unsafe unknown casts in tracked src production files", () => {
+    const result = runScannerInTempRepo({
+      "src/lib/example.ts": `
+        export function coerce(value: unknown) {
+          return value as unknown as { id: string };
+        }
+      `,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("src/lib/example.ts:3");
+    expect(result.stderr).toContain("as unknown as");
+  });
+
+  it("ignores tests, mocks, and comment-only mentions", () => {
+    const result = runScannerInTempRepo({
+      "src/lib/__mocks__/fixture.ts": `
+        export const mockValue = value as unknown as { id: string };
+      `,
+      "src/lib/example.test.ts": `
+        export const testValue = value as unknown as { id: string };
+      `,
+      "src/lib/example.ts": `
+        // value as unknown as { id: string }
+        /*
+         * value as unknown as { id: string }
+         */
+        export const ok = 1;
+      `,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("OK: no 'as unknown as' casts found");
+  });
+
+  it("skips tracked files that no longer exist in the working tree", () => {
+    const result = runScannerInTempRepo(
+      {
+        "src/lib/deleted.ts": `
+          export const deletedValue = value as unknown as { id: string };
+        `,
+        "src/lib/kept.ts": "export const kept = 1;\n",
+      },
+      ["src/lib/deleted.ts"]
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("OK: no 'as unknown as' casts found");
+  });
+});

--- a/src/scripts/__tests__/check-otel-convergence.test.ts
+++ b/src/scripts/__tests__/check-otel-convergence.test.ts
@@ -1,0 +1,156 @@
+/** @vitest-environment node */
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const sourceScriptPath = join(process.cwd(), "scripts/check-otel-convergence.mjs");
+const sourceScript = readFileSync(sourceScriptPath, "utf8");
+
+const baseDependencies: Record<string, string> = {
+  "@opentelemetry/context-zone": "2.7.1",
+  "@opentelemetry/exporter-trace-otlp-http": "0.218.0",
+  "@opentelemetry/instrumentation": "0.218.0",
+  "@opentelemetry/instrumentation-fetch": "0.218.0",
+  "@opentelemetry/resources": "2.7.1",
+  "@opentelemetry/sdk-trace-base": "2.7.1",
+  "@opentelemetry/sdk-trace-web": "2.7.1",
+  "import-in-the-middle": "3.0.1",
+  "require-in-the-middle": "8.0.1",
+};
+
+function createLockfile(entries: readonly string[]) {
+  return `lockfileVersion: '9.0'
+
+packages:
+${entries.map((entry) => `  '${entry}':\n    resolution: {integrity: sha512-test}`).join("\n")}
+`;
+}
+
+function convergedLockfile() {
+  return createLockfile([
+    "@opentelemetry/context-zone@2.7.1",
+    "@opentelemetry/core@2.7.1",
+    "@opentelemetry/exporter-trace-otlp-http@0.218.0",
+    "@opentelemetry/instrumentation-fetch@0.218.0",
+    "@opentelemetry/instrumentation@0.218.0",
+    "@opentelemetry/resources@2.7.1",
+    "@opentelemetry/sdk-trace-base@2.7.1",
+    "@opentelemetry/sdk-trace-web@2.7.1",
+    "import-in-the-middle@3.0.1",
+    "require-in-the-middle@8.0.1",
+  ]);
+}
+
+function runGuardInTempProject(
+  dependencies: Record<string, string>,
+  lockfileText = convergedLockfile()
+) {
+  const tempDir = mkdtempSync(join(tmpdir(), "tripsage-otel-convergence-"));
+
+  try {
+    const scriptsDir = join(tempDir, "scripts");
+    mkdirSync(scriptsDir, { recursive: true });
+    writeFileSync(join(scriptsDir, "check-otel-convergence.mjs"), sourceScript);
+    writeFileSync(
+      join(tempDir, "package.json"),
+      `${JSON.stringify({ dependencies }, null, 2)}\n`
+    );
+    writeFileSync(join(tempDir, "pnpm-lock.yaml"), lockfileText);
+
+    return spawnSync(
+      process.execPath,
+      [join(scriptsDir, "check-otel-convergence.mjs")],
+      {
+        cwd: tempDir,
+        encoding: "utf8",
+      }
+    );
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
+describe("check-otel-convergence", () => {
+  it("accepts converged direct dependencies and resolved lockfile entries", () => {
+    const result = runGuardInTempProject(baseDependencies);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      "OK: OpenTelemetry/runtime dependency convergence verified"
+    );
+  });
+
+  it("detects direct OpenTelemetry core dependency version drift", () => {
+    const result = runGuardInTempProject({
+      ...baseDependencies,
+      "@opentelemetry/resources": "2.7.2",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("OTEL dependency convergence check failed");
+    expect(result.stderr).toContain(
+      "OpenTelemetry core runtime dependencies must share one declared version"
+    );
+    expect(result.stderr).toContain("@opentelemetry/resources@2.7.2");
+  });
+
+  it("detects multiple resolved versions for monitored lockfile packages", () => {
+    const result = runGuardInTempProject(
+      baseDependencies,
+      createLockfile([
+        "@opentelemetry/context-zone@2.7.1",
+        "@opentelemetry/core@2.7.1",
+        "@opentelemetry/core@2.7.2",
+        "@opentelemetry/exporter-trace-otlp-http@0.218.0",
+        "@opentelemetry/instrumentation-fetch@0.218.0",
+        "@opentelemetry/instrumentation@0.218.0",
+        "@opentelemetry/resources@2.7.1",
+        "@opentelemetry/sdk-trace-base@2.7.1",
+        "@opentelemetry/sdk-trace-web@2.7.1",
+        "import-in-the-middle@3.0.1",
+        "require-in-the-middle@8.0.1",
+      ])
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "@opentelemetry/core resolves to multiple versions in lockfile: 2.7.1, 2.7.2"
+    );
+  });
+
+  it("detects missing runtime shim dependencies", () => {
+    const { "import-in-the-middle": _removed, ...dependencies } = baseDependencies;
+    const result = runGuardInTempProject(dependencies);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Missing required dependency `import-in-the-middle` in package.json"
+    );
+  });
+
+  it("detects mismatched resolved versions", () => {
+    const result = runGuardInTempProject(
+      baseDependencies,
+      createLockfile([
+        "@opentelemetry/context-zone@2.7.1",
+        "@opentelemetry/core@2.7.1",
+        "@opentelemetry/exporter-trace-otlp-http@0.218.0",
+        "@opentelemetry/instrumentation-fetch@0.218.0",
+        "@opentelemetry/instrumentation@0.218.0",
+        "@opentelemetry/resources@2.7.1",
+        "@opentelemetry/sdk-trace-base@2.7.1",
+        "@opentelemetry/sdk-trace-web@2.7.1",
+        "import-in-the-middle@3.0.2",
+        "require-in-the-middle@8.0.1",
+      ])
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "import-in-the-middle resolves to 3.0.2 but package.json expects 3.0.1"
+    );
+  });
+});

--- a/src/scripts/__tests__/check-otel-convergence.test.ts
+++ b/src/scripts/__tests__/check-otel-convergence.test.ts
@@ -122,7 +122,11 @@ describe("check-otel-convergence", () => {
   });
 
   it("detects missing runtime shim dependencies", () => {
-    const { "import-in-the-middle": _removed, ...dependencies } = baseDependencies;
+    const dependencies = Object.fromEntries(
+      Object.entries(baseDependencies).filter(
+        ([name]) => name !== "import-in-the-middle"
+      )
+    );
     const result = runGuardInTempProject(dependencies);
 
     expect(result.status).toBe(1);

--- a/src/scripts/__tests__/check-zod-v4-usage.test.ts
+++ b/src/scripts/__tests__/check-zod-v4-usage.test.ts
@@ -1,0 +1,161 @@
+/** @vitest-environment node */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const scriptPath = join(process.cwd(), "scripts/check-zod-v4-usage.mjs");
+
+function writeFiles(root: string, files: Record<string, string>) {
+  for (const [filePath, contents] of Object.entries(files)) {
+    const absolutePath = join(root, filePath);
+    mkdirSync(dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, contents);
+  }
+}
+
+function initRepo(tempDir: string) {
+  execFileSync("git", ["init", "--initial-branch=main"], {
+    cwd: tempDir,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["config", "user.email", "test@example.com"], {
+    cwd: tempDir,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["config", "user.name", "TripSage Test"], {
+    cwd: tempDir,
+    stdio: "ignore",
+  });
+}
+
+function runFullScannerInTempRepo(files: Record<string, string>) {
+  const tempDir = mkdtempSync(join(tmpdir(), "tripsage-zod-v4-full-scan-"));
+
+  try {
+    initRepo(tempDir);
+    writeFiles(tempDir, files);
+    execFileSync("git", ["add", "."], { cwd: tempDir, stdio: "ignore" });
+
+    return spawnSync(process.execPath, [scriptPath, "--full"], {
+      cwd: tempDir,
+      encoding: "utf8",
+    });
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
+function runDiffScannerInTempRepo(
+  before: Record<string, string>,
+  after: Record<string, string>
+) {
+  const tempDir = mkdtempSync(join(tmpdir(), "tripsage-zod-v4-diff-scan-"));
+
+  try {
+    initRepo(tempDir);
+    writeFiles(tempDir, before);
+    execFileSync("git", ["add", "."], { cwd: tempDir, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "baseline"], {
+      cwd: tempDir,
+      stdio: "ignore",
+    });
+    execFileSync("git", ["checkout", "-b", "feature"], {
+      cwd: tempDir,
+      stdio: "ignore",
+    });
+
+    writeFiles(tempDir, after);
+    execFileSync("git", ["add", "-A"], { cwd: tempDir, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "feature"], {
+      cwd: tempDir,
+      stdio: "ignore",
+    });
+
+    return spawnSync(process.execPath, [scriptPath], {
+      cwd: tempDir,
+      encoding: "utf8",
+    });
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
+describe("check-zod-v4-usage", () => {
+  it("detects deprecated Zod string helper method chains in production files", () => {
+    const result = runFullScannerInTempRepo({
+      "src/domain/schemas/example.ts": `
+        import { z } from "zod";
+
+        export const Example = z.object({
+          email: z.string().email(),
+          id: z.string().uuid(),
+          homepage: z.string().url(),
+          createdAt: z.string().datetime(),
+        });
+      `,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("zod-string-email");
+    expect(result.stderr).toContain("zod-string-uuid");
+    expect(result.stderr).toContain("zod-string-url");
+    expect(result.stderr).toContain("zod-string-datetime");
+  });
+
+  it("allows Zod v4 top-level helpers and documented exceptions", () => {
+    const result = runFullScannerInTempRepo({
+      "src/domain/schemas/__mocks__/fixture.ts": `
+        export const mocked = z.string().email();
+      `,
+      "src/domain/schemas/example.test.ts": `
+        export const tested = z.string().email();
+      `,
+      "src/domain/schemas/example.ts": `
+        import { z } from "zod";
+
+        // z.string().email()
+        /*
+         * z.string().uuid()
+         */
+        export const Example = z.object({
+          email: z.email(),
+          id: z.uuid(),
+          homepage: z.url(),
+          createdAt: z.iso.datetime(),
+          legacy: z.string().email(), // zod-v4-ok: legacy provider demands method-chain schema metadata
+        });
+      `,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("OK: no Zod v4 style violations detected");
+  });
+
+  it("checks committed branch diffs and ignores deleted files", () => {
+    const result = runDiffScannerInTempRepo(
+      {
+        "src/domain/schemas/deleted.ts": `
+          import { z } from "zod";
+          export const Deleted = z.string().email();
+        `,
+        "src/domain/schemas/example.ts": `
+          import { z } from "zod";
+          export const Example = z.email();
+        `,
+      },
+      {
+        "src/domain/schemas/example.ts": `
+          import { z } from "zod";
+          export const Example = z.string().email();
+        `,
+      }
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("src/domain/schemas/example.ts");
+    expect(result.stderr).not.toContain("src/domain/schemas/deleted.ts");
+  });
+});

--- a/src/stores/__tests__/agent-status-store.test.ts
+++ b/src/stores/__tests__/agent-status-store.test.ts
@@ -3,6 +3,7 @@
 import type { Agent } from "@schemas/agent-status";
 import { act, renderHook } from "@testing-library/react";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { withFakeTimers } from "@/test/utils/with-fake-timers";
 
 const storeLogger = vi.hoisted(() => ({
   error: vi.fn(),
@@ -316,21 +317,31 @@ describe("useAgentStatusStore", () => {
     expect(typeof result.current.registerAgents).toBe("function");
   });
 
-  it("removes agents older than the provided ttl", () => {
-    const { result } = renderHook(() => useAgentStatusStore());
-    const nowMs = Date.now();
+  it(
+    "removes agents older than the provided ttl",
+    withFakeTimers(() => {
+      const { result } = renderHook(() => useAgentStatusStore());
+      const nowMs = Date.parse("2026-02-03T04:05:06.000Z");
+      vi.setSystemTime(nowMs);
 
-    act(() => {
-      result.current.registerAgents([
-        mockAgent({ id: "fresh", updatedAt: new Date(nowMs - 5_000).toISOString() }),
-        mockAgent({ id: "stale", updatedAt: new Date(nowMs - 60_000).toISOString() }),
-      ]);
-      result.current.removeStaleAgents(30_000);
-    });
+      act(() => {
+        result.current.registerAgents([
+          mockAgent({
+            id: "fresh",
+            updatedAt: new Date(nowMs - 5_000).toISOString(),
+          }),
+          mockAgent({
+            id: "stale",
+            updatedAt: new Date(nowMs - 60_000).toISOString(),
+          }),
+        ]);
+        result.current.removeStaleAgents(30_000);
+      });
 
-    expect(result.current.agentsById.fresh).toBeDefined();
-    expect(result.current.agentsById.stale).toBeUndefined();
-  });
+      expect(result.current.agentsById.fresh).toBeDefined();
+      expect(result.current.agentsById.stale).toBeUndefined();
+    })
+  );
 
   it("treats invalid updatedAt timestamps as stale and logs an error", () => {
     const { result } = renderHook(() => useAgentStatusStore());

--- a/src/stores/__tests__/realtime-connection-store.test.ts
+++ b/src/stores/__tests__/realtime-connection-store.test.ts
@@ -5,6 +5,9 @@ import { DEFAULT_BACKOFF_CONFIG } from "@/lib/realtime/backoff";
 import { unsafeCast } from "@/test/helpers/unsafe-cast";
 import { createFakeTimersContext } from "@/test/utils/with-fake-timers";
 
+const BASE_NOW_MS = Date.UTC(2026, 0, 15, 12, 0, 0);
+const BASE_NOW_ISO = new Date(BASE_NOW_MS).toISOString();
+
 describe("realtime connection store", () => {
   // Use createFakeTimersContext for safe timer handling across all tests
   // shouldAdvanceTime: true allows async operations to work with fake timers
@@ -12,6 +15,7 @@ describe("realtime connection store", () => {
 
   beforeEach(() => {
     timers.setup();
+    vi.setSystemTime(BASE_NOW_MS);
     useRealtimeConnectionStore.setState({
       connections: {},
       isReconnecting: false,
@@ -43,7 +47,7 @@ describe("realtime connection store", () => {
 
     const entry = useRealtimeConnectionStore.getState().connections[channel.topic];
     expect(entry?.lastActivity).toBeInstanceOf(Date);
-    expect(entry?.lastActivity?.getTime()).toBeGreaterThan(Date.now() - 5_000);
+    expect(entry?.lastActivity?.toISOString()).toBe(BASE_NOW_ISO);
   });
 
   it("ignores updates for unknown channels without throwing", () => {
@@ -90,7 +94,13 @@ describe("realtime connection store", () => {
     expect(
       useRealtimeConnectionStore.getState().connections[channel.topic]?.lastError
     ).toBe(failure);
+    expect(
+      useRealtimeConnectionStore.getState().connections[channel.topic]?.lastErrorAt
+    ).toEqual(new Date(BASE_NOW_ISO));
     expect(useRealtimeConnectionStore.getState().summary().lastError).toBe(failure);
+    expect(useRealtimeConnectionStore.getState().summary().lastErrorAt).toEqual(
+      new Date(BASE_NOW_ISO)
+    );
 
     store.updateStatus(channel.topic, "subscribed", false, null);
 
@@ -122,6 +132,9 @@ describe("realtime connection store", () => {
 
     const updated = useRealtimeConnectionStore.getState();
     expect(updated.reconnectAttempts).toBeGreaterThan(0);
+    expect(updated.lastReconnectAt?.toISOString()).toBe(
+      new Date(BASE_NOW_MS + delay).toISOString()
+    );
     expect(channel.unsubscribe).toHaveBeenCalled();
     expect(channel.subscribe).toHaveBeenCalled();
 

--- a/src/stores/__tests__/ui/ui-state.test.ts
+++ b/src/stores/__tests__/ui/ui-state.test.ts
@@ -2,6 +2,7 @@
 
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { unsafeCast } from "@/test/helpers/unsafe-cast";
 import { withFakeTimers } from "@/test/utils/with-fake-timers";
 
 // Ensure matchMedia is mocked before importing the store
@@ -20,7 +21,7 @@ Object.defineProperty(window, "matchMedia", {
   writable: true,
 });
 
-import type { Theme } from "@schemas/stores";
+import type { LoadingState, Notification, Theme } from "@schemas/stores";
 import { useUiStore } from "@/stores/ui";
 
 describe("UI Store - UI State Management", () => {
@@ -113,8 +114,7 @@ describe("UI Store - UI State Management", () => {
       const previousTheme = result.current.theme;
 
       act(() => {
-        // @ts-expect-error Testing invalid theme
-        result.current.setTheme("invalid-theme");
+        result.current.setTheme(unsafeCast<Theme>("invalid-theme"));
       });
 
       // Store now uses OTEL-based store logger instead of console.error
@@ -303,8 +303,10 @@ describe("UI Store - UI State Management", () => {
       const { result } = renderHook(() => useUiStore());
 
       act(() => {
-        // @ts-expect-error Testing invalid loading state
-        result.current.setLoadingState("test", "invalid-state");
+        result.current.setLoadingState(
+          "test",
+          unsafeCast<LoadingState>("invalid-state")
+        );
       });
 
       // Store now uses OTEL-based store logger instead of console.error
@@ -511,12 +513,13 @@ describe("UI Store - UI State Management", () => {
       const { result } = renderHook(() => useUiStore());
 
       act(() => {
-        result.current.addNotification({
-          isRead: false,
-          title: "Invalid",
-          // @ts-expect-error - intentionally testing invalid type
-          type: "invalid-type",
-        });
+        result.current.addNotification(
+          unsafeCast<Omit<Notification, "createdAt" | "id">>({
+            isRead: false,
+            title: "Invalid",
+            type: "invalid-type",
+          })
+        );
       });
 
       // Store now uses OTEL-based store logger instead of console.error

--- a/src/stores/ui/command-palette.ts
+++ b/src/stores/ui/command-palette.ts
@@ -3,7 +3,6 @@
  */
 
 import type { StateCreator } from "zustand";
-import { useUiStore } from "./index";
 import type { CommandPaletteSlice, CommandPaletteState, UiState } from "./types";
 
 export const DEFAULT_COMMAND_PALETTE_STATE: CommandPaletteState = {
@@ -57,15 +56,3 @@ export const createCommandPaletteSlice: StateCreator<
     }));
   },
 });
-
-// ===== SELECTOR HOOKS =====
-
-/** Select whether the command palette is open */
-export const useCommandPaletteOpen = () => useUiStore((s) => s.commandPalette.isOpen);
-
-/** Select the command palette query */
-export const useCommandPaletteQuery = () => useUiStore((s) => s.commandPalette.query);
-
-/** Select the command palette results */
-export const useCommandPaletteResults = () =>
-  useUiStore((s) => s.commandPalette.results);

--- a/src/stores/ui/modal.ts
+++ b/src/stores/ui/modal.ts
@@ -3,7 +3,6 @@
  */
 
 import type { StateCreator } from "zustand";
-import { useUiStore } from "./index";
 import type { ModalSlice, ModalState, UiState } from "./types";
 
 export const DEFAULT_MODAL_STATE: ModalState = {
@@ -44,17 +43,3 @@ export const createModalSlice: StateCreator<UiState, [], [], ModalSlice> = (set)
     }));
   },
 });
-
-// ===== SELECTOR HOOKS =====
-
-/** Select whether the modal is open */
-export const useModalOpen = () => useUiStore((s) => s.modal.isOpen);
-
-/** Select the modal component */
-export const useModalComponent = () => useUiStore((s) => s.modal.component);
-
-/** Select the modal props */
-export const useModalProps = () => useUiStore((s) => s.modal.props);
-
-/** Select the modal size */
-export const useModalSize = () => useUiStore((s) => s.modal.size);

--- a/src/test/msw/handlers/__tests__/error-reporting.test.ts
+++ b/src/test/msw/handlers/__tests__/error-reporting.test.ts
@@ -1,0 +1,45 @@
+/** @vitest-environment node */
+
+import type { ErrorReport } from "@schemas/errors";
+import { describe, expect, it } from "vitest";
+import {
+  createFlakyErrorReportingHandler,
+  ERROR_REPORTING_ENDPOINT,
+} from "@/test/msw/handlers/error-reporting";
+import { server } from "@/test/msw/server";
+
+const buildReport = (): ErrorReport => ({
+  error: {
+    message: "Test error",
+    name: "Error",
+  },
+  timestamp: new Date().toISOString(),
+  url: "https://example.com/",
+  userAgent: "Vitest",
+});
+
+describe("error reporting MSW handlers", () => {
+  it("simulates rejected fetches before returning a successful response", async () => {
+    const flaky = createFlakyErrorReportingHandler({
+      endpoint: ERROR_REPORTING_ENDPOINT,
+      failTimes: 1,
+    });
+    server.use(flaky.handler);
+
+    await expect(
+      fetch(ERROR_REPORTING_ENDPOINT, {
+        body: JSON.stringify(buildReport()),
+        method: "POST",
+      })
+    ).rejects.toThrow();
+
+    const response = await fetch(ERROR_REPORTING_ENDPOINT, {
+      body: JSON.stringify(buildReport()),
+      method: "POST",
+    });
+
+    expect(response.ok).toBe(true);
+    await expect(response.json()).resolves.toEqual({ success: true });
+    expect(flaky.callCount()).toBe(2);
+  });
+});

--- a/src/test/msw/handlers/error-reporting.ts
+++ b/src/test/msw/handlers/error-reporting.ts
@@ -45,7 +45,7 @@ export function createErrorReportingRecorder(endpoint = ERROR_REPORTING_ENDPOINT
  *
  * Useful for exercising retry logic without duplicating inline handlers.
  *
- * @param options.failTimes - Number of initial calls that should throw.
+ * @param options.failTimes - Number of initial calls that should fail.
  * @param options.endpoint - Endpoint to intercept.
  * @returns MSW handler plus a getter for total call count.
  */
@@ -62,7 +62,7 @@ export function createFlakyErrorReportingHandler(options?: {
     handler: http.post(endpoint, () => {
       calls += 1;
       if (calls <= failTimes) {
-        throw new Error("Network error");
+        return HttpResponse.error();
       }
       return HttpResponse.json({ success: true });
     }),


### PR DESCRIPTION
## Summary

- Add injectable `nowIso(reference?)` and propagate through security, schemas, lib, hooks, domain, and UI for deterministic tests.
- Harden HTTP retry abort vs timeout semantics; remove deprecated `AppError` alias; extract `createAgentConfigVersionId`.
- Improve realtime optimistic updates, expand guardrail script tests, and align e2e/docs/dev Docker corepack pin.

## Commit stack

1. `feat(security): add injectable nowIso reference`
2. `refactor(security): deterministic MFA enrollment windows`
3. `refactor(schemas): factory-based future local date validation`
4. `fix(http): distinguish caller abort from fetch timeout`
5. `refactor(lib): propagate nowIso and remove AppError alias`
6. `refactor(hooks): simplify React Query typing and store selectors`
7. `refactor(app): deterministic timestamps in features and routes`
8. `refactor(ai): align tool timestamps and expand guardrail coverage`

## Test plan

- [x] `pnpm biome:fix && pnpm type-check`
- [x] `vitest related` against `main...HEAD` (315 files, 2813 tests)
- [x] `pnpm check:zod-v4`, `pnpm check:api-route-errors`, `pnpm check:no-new-unknown-casts`
- [ ] Optional smoke: `pnpm test:e2e:chromium --grep critical`