### PR TITLE
fix(ci): restore release provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,30 +3,6 @@ name: CI
 on:
   push:
     branches: [main, develop]
-    paths:
-      - 'src/**'
-      - 'e2e/**'
-      - 'public/**'
-      - 'scripts/**'
-      - 'docs/**'
-      - '.github/workflows/**'
-      - '.pre-commit-config.yaml'
-      # Root config files (post-flattening)
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - 'tsconfig.json'
-      - 'vitest.config.ts'
-      - 'biome.json'
-      - 'next.config.ts'
-      - 'tailwind.config.mjs'
-      - 'postcss.config.mjs'
-      - 'playwright.config.ts'
-      - 'vercel.json'
-      - 'components.json'
-      - '.nvmrc'
-      - 'Dockerfile*'
-      - 'README.md'
   pull_request:
     branches: [main, develop]
     paths:
@@ -53,6 +29,7 @@ on:
       - '.nvmrc'
       - 'Dockerfile*'
       - 'README.md'
+      - 'CHANGELOG.md'
   workflow_dispatch: {}
 
 permissions:
@@ -353,7 +330,7 @@ jobs:
 
       - name: Merge reports
         run: |
-          pnpm exec vitest run --merge-reports .vitest-reports --coverage
+          pnpm exec vitest run --merge-reports .vitest-reports --coverage --passWithNoTests
           node scripts/check-coverage-critical.mjs
 
       - name: Upload coverage report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,30 +1,37 @@
 name: Release
 
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [main]
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 env:
   COREPACK_VERSION: "0.35.0"
 
 jobs:
   release:
-    if: ${{ !startsWith(github.event.head_commit.message || '', 'chore(release):') }}
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        !startsWith(github.event.workflow_run.head_commit.message || '', 'chore(release):')
+      }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Validate release tag ancestry
         shell: bash
@@ -59,5 +66,11 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || github.token }}
-        run: pnpm exec semantic-release --extends ./release.config.mjs
+          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+        shell: bash
+        run: |
+          if [[ -z "${GITHUB_TOKEN}" ]]; then
+            echo "::error::RELEASE_BOT_TOKEN is required so release commits trigger CI."
+            exit 1
+          fi
+          pnpm exec semantic-release --extends ./release.config.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   release:
+    name: Publish release
     if: >-
       ${{
         github.event.workflow_run.conclusion == 'success' &&
@@ -27,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/docs/development/backend/release-automation.md
+++ b/docs/development/backend/release-automation.md
@@ -8,7 +8,7 @@ This repository uses semantic-release to automate versioning, changelog updates,
 - Action: `.github/workflows/release.yml`.
 - Steps: checkout the tested CI head without persisted credentials (full
   history) → validate tag ancestry → set up Node from `.nvmrc` → install pnpm
-  and dependencies → run `pnpm exec semantic-release --extends release.config.mjs`.
+  and dependencies → run `pnpm exec semantic-release --extends ./release.config.mjs`.
 - Secret: `RELEASE_BOT_TOKEN`. Only the semantic-release step receives this
   token so the generated release commit triggers CI. The workflow fails closed
   when the secret is absent; `github.token` is intentionally not a fallback.

--- a/docs/development/backend/release-automation.md
+++ b/docs/development/backend/release-automation.md
@@ -1,25 +1,36 @@
 # Release Automation (semantic-release)
 
-This repository uses semantic-release to automate versioning, changelog updates, tags, and GitHub Releases on pushes to `main`.
+This repository uses semantic-release to automate versioning, changelog updates, tags, and GitHub Releases after CI succeeds for a push to `main`.
 
 ## Workflow
 
-- Trigger: push to `main`.
+- Trigger: successful `CI` workflow completion for a push to `main`.
 - Action: `.github/workflows/release.yml`.
-- Steps: checkout (full history) → set up Node from `.nvmrc` → install pnpm and dependencies → run `pnpm exec semantic-release --extends release.config.mjs`.
-- Env: `GITHUB_TOKEN`.
-- Permissions: `contents`, `issues`, and `pull-requests` (write) to create tags and release notes.
+- Steps: checkout the tested CI head without persisted credentials (full
+  history) → validate tag ancestry → set up Node from `.nvmrc` → install pnpm
+  and dependencies → run `pnpm exec semantic-release --extends release.config.mjs`.
+- Secret: `RELEASE_BOT_TOKEN`. Only the semantic-release step receives this
+  token so the generated release commit triggers CI. The workflow fails closed
+  when the secret is absent; `github.token` is intentionally not a fallback.
+- Permissions: the built-in workflow token has read-only repository contents
+  access. `RELEASE_BOT_TOKEN` supplies the narrowly scoped Git and GitHub API
+  write access needed by semantic-release.
 
 ## Configuration
 
 File: `release.config.mjs` (root).
 
 - semantic-release runs from repo root.
+- Git tags and GitHub Releases are the canonical application version. The
+  private root package intentionally omits a separate `package.json#version`.
 - Plugins:
   - `@semantic-release/commit-analyzer` with temporary rule `{ breaking: true, release: 'minor' }`.
   - `@semantic-release/release-notes-generator` (conventional commits preset).
   - `@semantic-release/changelog` updates `CHANGELOG.md` (repo root).
-  - `@semantic-release/git` commits `CHANGELOG.md` with `chore(release): <version> [skip ci]`.
+  - `@semantic-release/git` commits `CHANGELOG.md` with `chore(release): <version>`.
+    That commit runs CI so the exact tagged head receives a deployable provenance
+    receipt. The release workflow ignores the successful CI completion for
+    `chore(release):` commits to prevent a second semantic-release run.
   - `@semantic-release/github` creates the GitHub Release.
 
 ## Temporary major suppression
@@ -39,7 +50,7 @@ When ready to ship the first stable major (e.g., `v2.0.0`):
    git push origin v2.0.0
    ```
 
-3. Push to `main` to run the release workflow.
+3. Push to `main`; the release workflow runs after CI succeeds.
 4. Update release docs to state majors are enabled.
 
 ## Commit conventions (recap)
@@ -58,7 +69,11 @@ If a release is incorrect:
 ## Troubleshooting
 
 - **No release produced**: ensure the commit history since the last tag contains a `feat` or `fix` (or `breaking` with the temporary rule). Non-releasing prefixes are ignored.
-- **Permissions error**: confirm workflow permissions include `contents: write`.
-- **Branch protection blocks release commit**: allow GitHub Actions (`GITHUB_TOKEN`) to push to `main`, or add a bypass rule for the release job so `@semantic-release/git` can commit `chore(release): …` and update `CHANGELOG.md`.
+- **Permissions error**: confirm `RELEASE_BOT_TOKEN` is present, valid, and has
+  the repository contents, issues, and pull-request write access required by
+  the configured semantic-release plugins.
+- **Branch protection blocks release commit**: grant the identity behind
+  `RELEASE_BOT_TOKEN` the narrow ruleset bypass needed for the release job to
+  commit `chore(release): …` and update `CHANGELOG.md`.
 - **Unexpected major**: verify the `releaseRules` still map `breaking` to `minor`.
 - **Changelog not updating**: check that `@semantic-release/changelog` and `@semantic-release/git` are installed and present in the config.

--- a/docs/development/core/troubleshooting.md
+++ b/docs/development/core/troubleshooting.md
@@ -66,7 +66,7 @@ git push origin feat/new-feature
 # Create PR to develop, then PR from develop -> main when ready
 
 # Release process (automated)
-# Merge to main triggers semantic-release:
+# A successful push CI run on main triggers semantic-release:
 # - computes next version (feat/minor, fix/patch, breaking->minor while pre-stable)
 # - updates CHANGELOG.md
 # - tags and publishes a GitHub Release

--- a/docs/runbooks/deployment-vercel.md
+++ b/docs/runbooks/deployment-vercel.md
@@ -35,9 +35,11 @@ before promotion. If main advances while a candidate builds or is tested, the
 second check fails closed and the stale candidate is not promoted.
 
 Configure the GitHub `Production` environment deployment branch policy for
-selected branches with `main` as the only allowed branch. If a release-only
-commit becomes the new main head without a CI run, dispatch CI on that exact
-main SHA before retrying production deployment.
+selected branches with `main` as the only allowed branch. Release-only
+`CHANGELOG.md` commits do not use a skip marker, and every push to `main` runs
+CI, so the exact tagged head receives a CI run automatically. Do not deploy a
+historical or imported main head that lacks a qualifying push CI run; advance
+`main` through the normal reviewed change flow so the new head receives one.
 
 ## Required GitHub Environment Secrets
 

--- a/docs/specs/active/0109-spec-testing-quality-and-ci.md
+++ b/docs/specs/active/0109-spec-testing-quality-and-ci.md
@@ -31,6 +31,8 @@ Coverage:
   change.
 - Production deploy validation runs separately through the Vercel CLI deploy
   workflow and `scripts/vercel-deploy-smoke.mjs`.
+- Release automation runs only after CI succeeds for a push to `main`; its
+  generated changelog commit must then receive its own successful push CI run.
 - The active workflows are:
   - CI (`.github/workflows/ci.yml`)
   - Deploy (`.github/workflows/deploy.yml`)
@@ -66,7 +68,8 @@ Recommended stages:
   - run `pnpm check:zod-v4` (diff-based)
   - run `pnpm check:api-route-errors` (diff-based)
   - run `pnpm deps:audit`
-- Main branch / merge CI:
+- Main branch / merge CI (runs for every push so release eligibility never
+  depends on a path filter):
   - run the full suite (`pnpm test:ci`) + E2E (`pnpm test:e2e` or `pnpm test:e2e:chromium`)
 - Deployment smoke:
   - run `pnpm deploy:check-env`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "tripsage-ai-frontend",
-  "version": "1.32.2",
   "private": true,
   "packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8",
   "scripts": {

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -27,7 +27,7 @@ export default {
       {
         assets: ["CHANGELOG.md"],
         // biome-ignore lint/suspicious/noTemplateCurlyInString: semantic-release interpolates this placeholder.
-        message: "chore(release): ${nextRelease.version} [skip ci]",
+        message: "chore(release): ${nextRelease.version}",
       },
     ],
     [

--- a/src/ai/agents/__tests__/destination-agent.test.ts
+++ b/src/ai/agents/__tests__/destination-agent.test.ts
@@ -3,6 +3,7 @@
 import type { DestinationResearchRequest } from "@schemas/agents";
 import type { AgentConfig } from "@schemas/configuration";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { unsafeCast } from "@/test/helpers/unsafe-cast";
 
 const mockCreateTripSageAgent = vi.hoisted(() => vi.fn());
 const mockClampMaxTokens = vi.hoisted(() => vi.fn());
@@ -36,7 +37,7 @@ import { createDestinationAgent } from "../destination-agent";
 import type { AgentDependencies } from "../types";
 
 const mockDeps: AgentDependencies = {
-  model: { modelId: "gpt-5.4-mini" } as AgentDependencies["model"],
+  model: unsafeCast<AgentDependencies["model"]>({ modelId: "gpt-5.4-mini" }),
   modelId: "gpt-5.4-mini",
   userId: "user-456",
 };

--- a/src/ai/agents/__tests__/destination-agent.test.ts
+++ b/src/ai/agents/__tests__/destination-agent.test.ts
@@ -1,0 +1,168 @@
+/** @vitest-environment node */
+
+import type { DestinationResearchRequest } from "@schemas/agents";
+import type { AgentConfig } from "@schemas/configuration";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCreateTripSageAgent = vi.hoisted(() => vi.fn());
+const mockClampMaxTokens = vi.hoisted(() => vi.fn());
+const mockBuildDestinationPrompt = vi.hoisted(() => vi.fn());
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("../agent-factory", () => ({
+  createTripSageAgent: mockCreateTripSageAgent,
+}));
+
+vi.mock("@/lib/tokens/budget", () => ({
+  clampMaxTokens: mockClampMaxTokens,
+}));
+
+vi.mock("@/prompts/agents", () => ({
+  buildDestinationPrompt: mockBuildDestinationPrompt,
+}));
+
+vi.mock("@ai/tools", () => ({
+  crawlSite: { description: "crawl" },
+  getCurrentWeather: { description: "weather" },
+  getTravelAdvisory: { description: "advisory" },
+  placeDetails: { description: "place details" },
+  searchPlaces: { description: "places" },
+  webSearch: { description: "search" },
+  webSearchBatch: { description: "batch search" },
+}));
+
+import { createDestinationAgent } from "../destination-agent";
+import type { AgentDependencies } from "../types";
+
+const mockDeps: AgentDependencies = {
+  model: { modelId: "gpt-5.4-mini" } as AgentDependencies["model"],
+  modelId: "gpt-5.4-mini",
+  userId: "user-456",
+};
+
+const baseConfig: AgentConfig = {
+  agentType: "destinationResearchAgent",
+  createdAt: "2026-07-16T00:00:00.000Z",
+  id: "v1784160000_deadbeef",
+  model: "gpt-5.4-mini",
+  parameters: {
+    maxOutputTokens: 2048,
+    stepLimit: 10,
+    temperature: 0.7,
+    topP: 0.9,
+  },
+  scope: "global",
+  updatedAt: "2026-07-16T00:00:00.000Z",
+};
+
+const mockInput: DestinationResearchRequest = {
+  destination: "Kyoto, Japan",
+  specificInterests: ["temples", "food"],
+  travelDates: "2027-04-01 to 2027-04-07",
+};
+
+function createdAgentConfig(): Record<string, unknown> {
+  const call = mockCreateTripSageAgent.mock.calls.at(-1);
+  expect(call).toBeDefined();
+  return call?.[1] as Record<string, unknown>;
+}
+
+describe("createDestinationAgent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBuildDestinationPrompt.mockReturnValue("Trusted destination instructions");
+    mockClampMaxTokens.mockReturnValue({ maxOutputTokens: 1024, reasons: [] });
+    mockCreateTripSageAgent.mockReturnValue({ agent: {}, uiMessages: [] });
+  });
+
+  it("creates a bounded agent while keeping request data out of instructions", () => {
+    createDestinationAgent(mockDeps, baseConfig, mockInput);
+
+    expect(mockBuildDestinationPrompt).toHaveBeenCalledWith();
+    expect(mockCreateTripSageAgent).toHaveBeenCalledWith(
+      mockDeps,
+      expect.objectContaining({
+        agentType: "destinationResearch",
+        instructions: "Trusted destination instructions",
+        maxOutputTokens: 1024,
+        name: "Destination Research Agent",
+        stepLimit: 15,
+        temperature: 0.7,
+        tools: expect.objectContaining({
+          crawlSite: expect.anything(),
+          getCurrentWeather: expect.anything(),
+          getTravelAdvisory: expect.anything(),
+          searchPlaceDetails: expect.anything(),
+          searchPlaces: expect.anything(),
+          webSearch: expect.anything(),
+          webSearchBatch: expect.anything(),
+        }),
+        topP: 0.9,
+      })
+    );
+
+    const config = createdAgentConfig();
+    expect(config.instructions).not.toContain(mockInput.destination);
+    expect(config.uiMessages).toEqual([
+      expect.objectContaining({
+        parts: [
+          expect.objectContaining({
+            text: expect.stringContaining('schemaVersion="dest.v1"'),
+          }),
+        ],
+        role: "user",
+      }),
+    ]);
+    const uiMessages = config.uiMessages as Array<{
+      parts: Array<{ text: string }>;
+    }>;
+    expect(uiMessages[0]?.parts[0]?.text).toContain(JSON.stringify(mockInput));
+  });
+
+  it("selects the search, crawl, and safety tools at each phase boundary", () => {
+    createDestinationAgent(mockDeps, baseConfig, mockInput);
+
+    const prepareStep = createdAgentConfig().prepareStep as (input: {
+      stepNumber: number;
+    }) => { activeTools: string[] };
+
+    expect(prepareStep({ stepNumber: 4 }).activeTools).toEqual([
+      "webSearch",
+      "webSearchBatch",
+      "searchPlaces",
+    ]);
+    expect(prepareStep({ stepNumber: 5 }).activeTools).toEqual([
+      "crawlSite",
+      "webSearchBatch",
+      "searchPlaces",
+      "searchPlaceDetails",
+    ]);
+    expect(prepareStep({ stepNumber: 10 }).activeTools).toEqual([
+      "getCurrentWeather",
+      "getTravelAdvisory",
+      "searchPlaceDetails",
+    ]);
+  });
+
+  it("honors a configured step limit when it exceeds the workflow minimum", () => {
+    createDestinationAgent(
+      mockDeps,
+      {
+        ...baseConfig,
+        parameters: { ...baseConfig.parameters, stepLimit: 50 },
+      },
+      mockInput
+    );
+
+    const config = createdAgentConfig();
+    const prepareStep = config.prepareStep as (input: { stepNumber: number }) => {
+      activeTools: string[];
+    };
+    expect(config.stepLimit).toBe(50);
+    expect(prepareStep({ stepNumber: 16 }).activeTools).toContain("webSearch");
+    expect(prepareStep({ stepNumber: 17 }).activeTools).toContain("crawlSite");
+    expect(prepareStep({ stepNumber: 32 }).activeTools).toContain("crawlSite");
+    expect(prepareStep({ stepNumber: 33 }).activeTools).toContain("getTravelAdvisory");
+  });
+});

--- a/src/ai/agents/__tests__/itinerary-agent.test.ts
+++ b/src/ai/agents/__tests__/itinerary-agent.test.ts
@@ -1,0 +1,191 @@
+/** @vitest-environment node */
+
+import type { ItineraryPlanRequest } from "@schemas/agents";
+import type { AgentConfig } from "@schemas/configuration";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCreateTripSageAgent = vi.hoisted(() => vi.fn());
+const mockClampMaxTokens = vi.hoisted(() => vi.fn());
+const mockBuildItineraryPrompt = vi.hoisted(() => vi.fn());
+const mockWrapToolsWithUserId = vi.hoisted(() => vi.fn());
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("../agent-factory", () => ({
+  createTripSageAgent: mockCreateTripSageAgent,
+}));
+
+vi.mock("@/lib/tokens/budget", () => ({
+  clampMaxTokens: mockClampMaxTokens,
+}));
+
+vi.mock("@/prompts/agents", () => ({
+  buildItineraryPrompt: mockBuildItineraryPrompt,
+}));
+
+vi.mock("@ai/tools/server/injection", () => ({
+  wrapToolsWithUserId: mockWrapToolsWithUserId,
+}));
+
+vi.mock("@ai/tools", () => ({
+  createTravelPlan: { description: "create plan" },
+  placeDetails: { description: "place details" },
+  saveTravelPlan: { description: "save plan" },
+  searchPlaces: { description: "places" },
+  webSearch: { description: "search" },
+  webSearchBatch: { description: "batch search" },
+}));
+
+import { createItineraryAgent } from "../itinerary-agent";
+import type { AgentDependencies } from "../types";
+
+const mockDeps: AgentDependencies = {
+  model: { modelId: "gpt-5.4-mini" } as AgentDependencies["model"],
+  modelId: "gpt-5.4-mini",
+  userId: "user-456",
+};
+
+const baseConfig: AgentConfig = {
+  agentType: "itineraryAgent",
+  createdAt: "2026-07-16T00:00:00.000Z",
+  id: "v1784160000_deadbeef",
+  model: "gpt-5.4-mini",
+  parameters: {
+    maxOutputTokens: 3072,
+    stepLimit: 10,
+    temperature: 0.6,
+    topP: 0.85,
+  },
+  scope: "global",
+  updatedAt: "2026-07-16T00:00:00.000Z",
+};
+
+const mockInput: ItineraryPlanRequest = {
+  destination: "Rome, Italy",
+  durationDays: 5,
+  interests: ["history", "food"],
+  partySize: 2,
+};
+
+function createdAgentConfig(): Record<string, unknown> {
+  const call = mockCreateTripSageAgent.mock.calls.at(-1);
+  expect(call).toBeDefined();
+  return call?.[1] as Record<string, unknown>;
+}
+
+describe("createItineraryAgent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBuildItineraryPrompt.mockReturnValue("Trusted itinerary instructions");
+    mockClampMaxTokens.mockReturnValue({ maxOutputTokens: 1536, reasons: [] });
+    mockWrapToolsWithUserId.mockImplementation((tools: Record<string, unknown>) => ({
+      ...tools,
+      createTravelPlan: { description: "wrapped create plan" },
+      saveTravelPlan: { description: "wrapped save plan" },
+    }));
+    mockCreateTripSageAgent.mockReturnValue({ agent: {}, uiMessages: [] });
+  });
+
+  it("requires a user before preparing user-scoped tools", () => {
+    expect(() =>
+      createItineraryAgent({ ...mockDeps, userId: undefined }, baseConfig, mockInput)
+    ).toThrow("Itinerary agent requires a valid userId");
+    expect(mockWrapToolsWithUserId).not.toHaveBeenCalled();
+    expect(mockCreateTripSageAgent).not.toHaveBeenCalled();
+  });
+
+  it("injects user ownership and keeps request data out of instructions", () => {
+    createItineraryAgent(mockDeps, baseConfig, mockInput);
+
+    expect(mockBuildItineraryPrompt).toHaveBeenCalledWith();
+    expect(mockWrapToolsWithUserId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        createTravelPlan: expect.anything(),
+        saveTravelPlan: expect.anything(),
+      }),
+      "user-456",
+      ["createTravelPlan", "saveTravelPlan"]
+    );
+    expect(mockCreateTripSageAgent).toHaveBeenCalledWith(
+      mockDeps,
+      expect.objectContaining({
+        agentType: "itineraryPlanning",
+        instructions: "Trusted itinerary instructions",
+        maxOutputTokens: 1536,
+        name: "Itinerary Planning Agent",
+        stepLimit: 15,
+        temperature: 0.6,
+        tools: expect.objectContaining({
+          createTravelPlan: { description: "wrapped create plan" },
+          saveTravelPlan: { description: "wrapped save plan" },
+        }),
+        topP: 0.85,
+      })
+    );
+
+    const config = createdAgentConfig();
+    expect(config.instructions).not.toContain(mockInput.destination);
+    expect(config.uiMessages).toEqual([
+      expect.objectContaining({
+        parts: [
+          expect.objectContaining({
+            text: expect.stringContaining('schemaVersion="itin.v1"'),
+          }),
+        ],
+        role: "user",
+      }),
+    ]);
+    const uiMessages = config.uiMessages as Array<{
+      parts: Array<{ text: string }>;
+    }>;
+    expect(uiMessages[0]?.parts[0]?.text).toContain(JSON.stringify(mockInput));
+  });
+
+  it("selects research, planning, and persistence tools at each phase boundary", () => {
+    createItineraryAgent(mockDeps, baseConfig, mockInput);
+
+    const prepareStep = createdAgentConfig().prepareStep as (input: {
+      stepNumber: number;
+    }) => { activeTools: string[] };
+
+    expect(prepareStep({ stepNumber: 5 }).activeTools).toEqual([
+      "webSearch",
+      "webSearchBatch",
+      "searchPlaces",
+      "searchPlaceDetails",
+    ]);
+    expect(prepareStep({ stepNumber: 6 }).activeTools).toEqual([
+      "createTravelPlan",
+      "searchPlaces",
+    ]);
+    expect(prepareStep({ stepNumber: 10 }).activeTools).toEqual([
+      "createTravelPlan",
+      "searchPlaces",
+    ]);
+    expect(prepareStep({ stepNumber: 11 }).activeTools).toEqual([
+      "saveTravelPlan",
+      "createTravelPlan",
+    ]);
+  });
+
+  it("honors a configured step limit when it exceeds the workflow minimum", () => {
+    createItineraryAgent(
+      mockDeps,
+      {
+        ...baseConfig,
+        parameters: { ...baseConfig.parameters, stepLimit: 20 },
+      },
+      mockInput
+    );
+
+    const config = createdAgentConfig();
+    const prepareStep = config.prepareStep as (input: { stepNumber: number }) => {
+      activeTools: string[];
+    };
+    expect(config.stepLimit).toBe(20);
+    expect(prepareStep({ stepNumber: 7 }).activeTools).toContain("webSearch");
+    expect(prepareStep({ stepNumber: 8 }).activeTools).toContain("createTravelPlan");
+    expect(prepareStep({ stepNumber: 14 }).activeTools).toContain("createTravelPlan");
+    expect(prepareStep({ stepNumber: 15 }).activeTools).toContain("saveTravelPlan");
+  });
+});

--- a/src/ai/agents/__tests__/itinerary-agent.test.ts
+++ b/src/ai/agents/__tests__/itinerary-agent.test.ts
@@ -3,6 +3,7 @@
 import type { ItineraryPlanRequest } from "@schemas/agents";
 import type { AgentConfig } from "@schemas/configuration";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { unsafeCast } from "@/test/helpers/unsafe-cast";
 
 const mockCreateTripSageAgent = vi.hoisted(() => vi.fn());
 const mockClampMaxTokens = vi.hoisted(() => vi.fn());
@@ -40,7 +41,7 @@ import { createItineraryAgent } from "../itinerary-agent";
 import type { AgentDependencies } from "../types";
 
 const mockDeps: AgentDependencies = {
-  model: { modelId: "gpt-5.4-mini" } as AgentDependencies["model"],
+  model: unsafeCast<AgentDependencies["model"]>({ modelId: "gpt-5.4-mini" }),
   modelId: "gpt-5.4-mini",
   userId: "user-456",
 };

--- a/src/ai/agents/destination-agent.ts
+++ b/src/ai/agents/destination-agent.ts
@@ -48,6 +48,7 @@ const DESTINATION_TOOLS = {
  * @param config - Agent configuration from database.
  * @param input - Validated destination research request.
  * @returns Configured agent and canonical UI messages for destination research.
+ * @see docs/specs/active/0103-spec-chat-and-agents.md
  *
  * @example
  * ```typescript

--- a/src/ai/agents/destination-agent.ts
+++ b/src/ai/agents/destination-agent.ts
@@ -78,8 +78,10 @@ export function createDestinationAgent(
 
   // Destination research may need more steps for gathering
   const stepLimit = Math.max(params.stepLimit, 15);
-  const phase1End = Math.max(4, Math.floor(stepLimit * 0.33));
-  const phase2End = Math.max(phase1End + 1, Math.floor(stepLimit * 0.66));
+  // AI SDK stepNumber is zero-based. Convert cumulative phase counts to
+  // inclusive end indices so exact percentage boundaries do not gain a step.
+  const phase1End = Math.max(4, Math.ceil(stepLimit * 0.33) - 1);
+  const phase2End = Math.max(phase1End + 1, Math.ceil(stepLimit * 0.66) - 1);
 
   return createTripSageAgent<typeof DESTINATION_TOOLS>(deps, {
     agentType: "destinationResearch",

--- a/src/ai/agents/itinerary-agent.ts
+++ b/src/ai/agents/itinerary-agent.ts
@@ -93,8 +93,11 @@ export function createItineraryAgent(
   const SaveTools: ToolName[] = ["saveTravelPlan", "createTravelPlan"];
 
   // Compute phase boundaries from stepLimit (40% research, 33% planning, 27% save)
-  const phase1End = Math.floor(stepLimit * 0.4);
-  const phase2End = Math.floor(stepLimit * 0.73);
+  // AI SDK stepNumber is zero-based, so convert cumulative phase counts to
+  // inclusive end indices. Ceil keeps each phase from receiving less than its
+  // intended share when stepLimit does not divide cleanly.
+  const phase1End = Math.ceil(stepLimit * 0.4) - 1;
+  const phase2End = Math.ceil(stepLimit * 0.73) - 1;
 
   if (!deps.userId) {
     throw new Error(

--- a/src/ai/agents/itinerary-agent.ts
+++ b/src/ai/agents/itinerary-agent.ts
@@ -50,6 +50,7 @@ const BASE_ITINERARY_TOOLS = {
  * @param config - Agent configuration from database.
  * @param input - Validated itinerary plan request.
  * @returns Configured agent and canonical UI messages for itinerary planning.
+ * @see docs/specs/active/0103-spec-chat-and-agents.md
  *
  * @example
  * ```typescript


### PR DESCRIPTION
## Summary

- fix the zero-based phase boundaries for destination and itinerary agents and add focused factory/tool-routing coverage
- repair the four-shard Vitest coverage merge without suppressing threshold failures
- run CI for every main push and start semantic-release only after successful push CI for the exact tested SHA
- keep the release bot token scoped to semantic-release, ensure generated release commits receive CI, and remove the stale private manifest version
- align release, testing, and deployment documentation with the fail-closed provenance contract

## Verification

- `pnpm test:coverage`
- `pnpm exec vitest run src/ai/agents/__tests__/destination-agent.test.ts src/ai/agents/__tests__/itinerary-agent.test.ts`
- `pnpm type-check`
- `pnpm exec biome check src e2e scripts`
- `pnpm docs:check`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `pnpm install --frozen-lockfile`
- diff-based file overview, unknown-cast, secret, API error, and Zod checks
- replayed all four report artifacts from failed CI run 29464677927; merge exits 0 with the fix and still exits 1 under forced failing thresholds

## Notes

A broad local affected run passed 3,827 tests and hit one unrelated 3-second setup-hook timeout under concurrent validation load; the isolated BotID route suite immediately passed 3/3, and the full coverage suite is green.
