### PR TITLE
deps-dev: upgrade Biome to 2.5.4

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
 
   "assist": {
     "actions": {
@@ -127,7 +127,7 @@
         "noAccumulatingSpread": "warn",
         "noDelete": "error"
       },
-      "recommended": true,
+      "preset": "recommended",
 
       "security": {
         "noDangerouslySetInnerHtml": "error",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "zustand": "^5.0.14"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.2",
+    "@biomejs/biome": "^2.5.4",
     "@playwright/test": "^1.61.1",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^13.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,8 +266,8 @@ importers:
         version: 5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.2
-        version: 2.5.2
+        specifier: ^2.5.4
+        version: 2.5.4
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1
@@ -540,59 +540,59 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@biomejs/biome@2.5.2':
-    resolution: {integrity: sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA==}
+  '@biomejs/biome@2.5.4':
+    resolution: {integrity: sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.5.2':
-    resolution: {integrity: sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg==}
+  '@biomejs/cli-darwin-arm64@2.5.4':
+    resolution: {integrity: sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.5.2':
-    resolution: {integrity: sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g==}
+  '@biomejs/cli-darwin-x64@2.5.4':
+    resolution: {integrity: sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.5.2':
-    resolution: {integrity: sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw==}
+  '@biomejs/cli-linux-arm64-musl@2.5.4':
+    resolution: {integrity: sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.5.2':
-    resolution: {integrity: sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ==}
+  '@biomejs/cli-linux-arm64@2.5.4':
+    resolution: {integrity: sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.5.2':
-    resolution: {integrity: sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw==}
+  '@biomejs/cli-linux-x64-musl@2.5.4':
+    resolution: {integrity: sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.5.2':
-    resolution: {integrity: sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA==}
+  '@biomejs/cli-linux-x64@2.5.4':
+    resolution: {integrity: sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.5.2':
-    resolution: {integrity: sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww==}
+  '@biomejs/cli-win32-arm64@2.5.4':
+    resolution: {integrity: sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.5.2':
-    resolution: {integrity: sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A==}
+  '@biomejs/cli-win32-x64@2.5.4':
+    resolution: {integrity: sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -6350,39 +6350,39 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@biomejs/biome@2.5.2':
+  '@biomejs/biome@2.5.4':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.5.2
-      '@biomejs/cli-darwin-x64': 2.5.2
-      '@biomejs/cli-linux-arm64': 2.5.2
-      '@biomejs/cli-linux-arm64-musl': 2.5.2
-      '@biomejs/cli-linux-x64': 2.5.2
-      '@biomejs/cli-linux-x64-musl': 2.5.2
-      '@biomejs/cli-win32-arm64': 2.5.2
-      '@biomejs/cli-win32-x64': 2.5.2
+      '@biomejs/cli-darwin-arm64': 2.5.4
+      '@biomejs/cli-darwin-x64': 2.5.4
+      '@biomejs/cli-linux-arm64': 2.5.4
+      '@biomejs/cli-linux-arm64-musl': 2.5.4
+      '@biomejs/cli-linux-x64': 2.5.4
+      '@biomejs/cli-linux-x64-musl': 2.5.4
+      '@biomejs/cli-win32-arm64': 2.5.4
+      '@biomejs/cli-win32-x64': 2.5.4
 
-  '@biomejs/cli-darwin-arm64@2.5.2':
+  '@biomejs/cli-darwin-arm64@2.5.4':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.5.2':
+  '@biomejs/cli-darwin-x64@2.5.4':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.5.2':
+  '@biomejs/cli-linux-arm64-musl@2.5.4':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.5.2':
+  '@biomejs/cli-linux-arm64@2.5.4':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.5.2':
+  '@biomejs/cli-linux-x64-musl@2.5.4':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.5.2':
+  '@biomejs/cli-linux-x64@2.5.4':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.5.2':
+  '@biomejs/cli-win32-arm64@2.5.4':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.5.2':
+  '@biomejs/cli-win32-x64@2.5.4':
     optional: true
 
   '@braintree/sanitize-url@7.1.1': {}

--- a/src/app/api/keys/validate/__tests__/route.test.ts
+++ b/src/app/api/keys/validate/__tests__/route.test.ts
@@ -406,31 +406,34 @@ describe("/api/keys/validate route", () => {
   it.each([
     ["TimeoutError", new DOMException("Timeout", "TimeoutError")],
     ["AbortError", Object.assign(new Error("Abort"), { name: "AbortError" })],
-  ] as const)("returns REQUEST_TIMEOUT when provider validation times out (%s)", async (_label, error) => {
-    const fetchMock = vi.fn<FetchLike>().mockRejectedValue(error);
-    mockCreateOpenAI.mockImplementation(() => buildProvider(fetchMock));
+  ] as const)(
+    "returns REQUEST_TIMEOUT when provider validation times out (%s)",
+    async (_label, error) => {
+      const fetchMock = vi.fn<FetchLike>().mockRejectedValue(error);
+      mockCreateOpenAI.mockImplementation(() => buildProvider(fetchMock));
 
-    const { POST } = await import("../route");
-    const req = createMockNextRequest({
-      body: { apiKey: "sk-test", service: "openai" },
-      method: "POST",
-      url: "http://localhost/api/keys/validate",
-    });
+      const { POST } = await import("../route");
+      const req = createMockNextRequest({
+        body: { apiKey: "sk-test", service: "openai" },
+        method: "POST",
+        url: "http://localhost/api/keys/validate",
+      });
 
-    const res = await POST(req, createRouteParamsContext());
-    const body = await res.json();
+      const res = await POST(req, createRouteParamsContext());
+      const body = await res.json();
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://provider.test/models",
-      expect.objectContaining({
-        headers: { Authorization: "Bearer test" },
-        method: "GET",
-        signal: expect.any(AbortSignal),
-      })
-    );
-    expect(body).toEqual({ isValid: false, reason: "REQUEST_TIMEOUT" });
-    expect(res.status).toBe(200);
-  });
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://provider.test/models",
+        expect.objectContaining({
+          headers: { Authorization: "Bearer test" },
+          method: "GET",
+          signal: expect.any(AbortSignal),
+        })
+      );
+      expect(body).toEqual({ isValid: false, reason: "REQUEST_TIMEOUT" });
+      expect(res.status).toBe(200);
+    }
+  );
 
   it("returns INVALID_KEY for non-429 provider 4xx responses", async () => {
     const fetchMock = vi

--- a/src/domain/flights/__tests__/service.test.ts
+++ b/src/domain/flights/__tests__/service.test.ts
@@ -156,25 +156,23 @@ describe("searchFlightsService", () => {
   });
 
   describe("cabin class options", () => {
-    it.each([
-      "economy",
-      "premium_economy",
-      "business",
-      "first",
-    ] as const)("accepts %s cabin class", async (cabinClass) => {
-      const request = {
-        ...validRequest,
-        cabinClass,
-      };
-
-      await searchFlightsService(request);
-
-      expect(mockFetchDuffelOffers).toHaveBeenCalledWith(
-        expect.objectContaining({
+    it.each(["economy", "premium_economy", "business", "first"] as const)(
+      "accepts %s cabin class",
+      async (cabinClass) => {
+        const request = {
+          ...validRequest,
           cabinClass,
-        })
-      );
-    });
+        };
+
+        await searchFlightsService(request);
+
+        expect(mockFetchDuffelOffers).toHaveBeenCalledWith(
+          expect.objectContaining({
+            cabinClass,
+          })
+        );
+      }
+    );
   });
 
   describe("input validation", () => {

--- a/src/domain/schemas/__tests__/budget.test.ts
+++ b/src/domain/schemas/__tests__/budget.test.ts
@@ -371,22 +371,21 @@ describe("budget schemas", () => {
       expect(result.success).toBe(true);
     });
 
-    it.concurrent.each([
-      "threshold",
-      "category",
-      "daily",
-    ])("validates alert type: %s", (type) => {
-      const result = budgetAlertSchema.safeParse({
-        budgetId: "123e4567-e89b-12d3-a456-426614174001",
-        createdAt: "2024-01-01T00:00:00Z",
-        id: "123e4567-e89b-12d3-a456-426614174000",
-        isRead: false,
-        message: "Budget alert",
-        threshold: 80,
-        type,
-      });
-      expect(result.success).toBe(true);
-    });
+    it.concurrent.each(["threshold", "category", "daily"])(
+      "validates alert type: %s",
+      (type) => {
+        const result = budgetAlertSchema.safeParse({
+          budgetId: "123e4567-e89b-12d3-a456-426614174001",
+          createdAt: "2024-01-01T00:00:00Z",
+          id: "123e4567-e89b-12d3-a456-426614174000",
+          isRead: false,
+          message: "Budget alert",
+          threshold: 80,
+          type,
+        });
+        expect(result.success).toBe(true);
+      }
+    );
   });
 
   describe("createBudgetRequestSchema", () => {

--- a/src/features/search/components/cards/__tests__/flight-card.test.tsx
+++ b/src/features/search/components/cards/__tests__/flight-card.test.tsx
@@ -237,14 +237,15 @@ describe("PredictionBadge", () => {
     { confidence: 85, expectedText: "Book Now (85%)", priceAlert: "buy_now" as const },
     { confidence: 70, expectedText: "Wait (70%)", priceAlert: "wait" as const },
     { confidence: 50, expectedText: "Monitor (50%)", priceAlert: "neutral" as const },
-  ])("renders $expectedText for $priceAlert alert", ({
-    priceAlert,
-    confidence,
-    expectedText,
-  }) => {
-    render(<PredictionBadge prediction={{ confidence, priceAlert, reason: "test" }} />);
-    expect(screen.getByText(expectedText)).toBeInTheDocument();
-  });
+  ])(
+    "renders $expectedText for $priceAlert alert",
+    ({ priceAlert, confidence, expectedText }) => {
+      render(
+        <PredictionBadge prediction={{ confidence, priceAlert, reason: "test" }} />
+      );
+      expect(screen.getByText(expectedText)).toBeInTheDocument();
+    }
+  );
 });
 
 describe("FLIGHT_COLORS", () => {

--- a/src/lib/env/__tests__/server.test.ts
+++ b/src/lib/env/__tests__/server.test.ts
@@ -77,16 +77,17 @@ describe("env/server", () => {
       expect(() => getServerEnv()).toThrow("Environment validation failed");
     });
 
-    it.each(
-      exactBooleanEnvFlags
-    )("parses %s only from exact boolean strings", (flag) => {
-      vi.stubEnv(flag, "true");
-      expect(getServerEnv()[flag]).toBe(true);
+    it.each(exactBooleanEnvFlags)(
+      "parses %s only from exact boolean strings",
+      (flag) => {
+        vi.stubEnv(flag, "true");
+        expect(getServerEnv()[flag]).toBe(true);
 
-      vi.stubEnv(flag, "false");
-      __resetServerEnvCacheForTest();
-      expect(getServerEnv()[flag]).toBe(false);
-    });
+        vi.stubEnv(flag, "false");
+        __resetServerEnvCacheForTest();
+        expect(getServerEnv()[flag]).toBe(false);
+      }
+    );
 
     it.each(exactBooleanEnvFlags)("rejects invalid %s values", (flag) => {
       vi.stubEnv(flag, "yes");
@@ -100,16 +101,14 @@ describe("env/server", () => {
       expect(getServerEnv()[flag]).toBe(false);
     });
 
-    it.each([
-      " false ",
-      "FALSE",
-      "1",
-      "*",
-    ])("rejects non-canonical ENABLE_AI_DEMO=%j", (value) => {
-      vi.stubEnv("ENABLE_AI_DEMO", value);
+    it.each([" false ", "FALSE", "1", "*"])(
+      "rejects non-canonical ENABLE_AI_DEMO=%j",
+      (value) => {
+        vi.stubEnv("ENABLE_AI_DEMO", value);
 
-      expect(() => getServerEnv()).toThrow("Environment validation failed");
-    });
+        expect(() => getServerEnv()).toThrow("Environment validation failed");
+      }
+    );
 
     it("requires a dedicated MFA backup-code pepper in production", () => {
       stubRequiredProductionEnv();

--- a/src/lib/qstash/__tests__/client.test.ts
+++ b/src/lib/qstash/__tests__/client.test.ts
@@ -183,25 +183,25 @@ describe("enqueueJob", () => {
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("qstash.missing_origin", true);
   });
 
-  it.each([
-    "https://evil.example/api/jobs/test",
-    "//evil.example/api/jobs/test",
-  ])("rejects off-origin job path %s", async (path) => {
-    const { enqueueJob, setQStashClientFactoryForTests } = await import(
-      "@/lib/qstash/client"
-    );
-    setQStashClientFactoryForTests(() => new qstash.Client({ token: "test" }));
+  it.each(["https://evil.example/api/jobs/test", "//evil.example/api/jobs/test"])(
+    "rejects off-origin job path %s",
+    async (path) => {
+      const { enqueueJob, setQStashClientFactoryForTests } = await import(
+        "@/lib/qstash/client"
+      );
+      setQStashClientFactoryForTests(() => new qstash.Client({ token: "test" }));
 
-    await expect(
-      enqueueJob("test-job", { ok: true }, path, {
-        deduplicationId: "test-job:invalid-path",
-        label: QSTASH_JOB_LABELS.NOTIFY_COLLABORATORS,
-      })
-    ).rejects.toThrow("QStash job path must be a same-origin absolute path");
+      await expect(
+        enqueueJob("test-job", { ok: true }, path, {
+          deduplicationId: "test-job:invalid-path",
+          label: QSTASH_JOB_LABELS.NOTIFY_COLLABORATORS,
+        })
+      ).rejects.toThrow("QStash job path must be a same-origin absolute path");
 
-    expect(qstash.__getMessages()).toHaveLength(0);
-    expect(mockSpan.setAttribute).toHaveBeenCalledWith("qstash.invalid_path", true);
-  });
+      expect(qstash.__getMessages()).toHaveLength(0);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith("qstash.invalid_path", true);
+    }
+  );
 
   it("rejects publishes without a deterministic deduplication id", async () => {
     const { enqueueJob, setQStashClientFactoryForTests } = await import(

--- a/src/lib/security/__tests__/botid-enable.test.ts
+++ b/src/lib/security/__tests__/botid-enable.test.ts
@@ -13,18 +13,17 @@ describe("isBotIdEnabledForCurrentEnvironment", () => {
     { expected: true, nodeEnv: "production", vercelEnv: undefined },
     { expected: true, nodeEnv: "production", vercelEnv: "preview" },
     { expected: true, nodeEnv: "test", vercelEnv: undefined },
-  ])("defaults for NODE_ENV=$nodeEnv, VERCEL_ENV=$vercelEnv", ({
-    nodeEnv,
-    vercelEnv,
-    expected,
-  }) => {
-    it(`returns ${expected}`, () => {
-      vi.stubEnv("BOTID_ENABLE", undefined);
-      vi.stubEnv("NODE_ENV", nodeEnv);
-      vi.stubEnv("VERCEL_ENV", vercelEnv);
-      expect(isBotIdEnabledForCurrentEnvironment()).toBe(expected);
-    });
-  });
+  ])(
+    "defaults for NODE_ENV=$nodeEnv, VERCEL_ENV=$vercelEnv",
+    ({ nodeEnv, vercelEnv, expected }) => {
+      it(`returns ${expected}`, () => {
+        vi.stubEnv("BOTID_ENABLE", undefined);
+        vi.stubEnv("NODE_ENV", nodeEnv);
+        vi.stubEnv("VERCEL_ENV", vercelEnv);
+        expect(isBotIdEnabledForCurrentEnvironment()).toBe(expected);
+      });
+    }
+  );
 
   it("can be enabled for development via BOTID_ENABLE", () => {
     vi.stubEnv("BOTID_ENABLE", "production,preview,development");

--- a/src/scripts/__tests__/verify-deploy-provenance.test.ts
+++ b/src/scripts/__tests__/verify-deploy-provenance.test.ts
@@ -72,20 +72,20 @@ function productionInput(fetchImpl: typeof fetch) {
 }
 
 describe("verify-deploy-provenance", () => {
-  it.each([
-    "development",
-    "staging",
-  ])("skips GitHub reads for %s deployments", async (environment) => {
-    const { fetchImpl, requests } = createGithubFetch();
+  it.each(["development", "staging"])(
+    "skips GitHub reads for %s deployments",
+    async (environment) => {
+      const { fetchImpl, requests } = createGithubFetch();
 
-    const result = await verifyDeployProvenance({
-      ...productionInput(fetchImpl),
-      environment,
-    });
+      const result = await verifyDeployProvenance({
+        ...productionInput(fetchImpl),
+        environment,
+      });
 
-    expect(result).toMatchObject({ environment, status: "skipped" });
-    expect(requests).toEqual([]);
-  });
+      expect(result).toMatchObject({ environment, status: "skipped" });
+      expect(requests).toEqual([]);
+    }
+  );
 
   it("requires the production workflow ref to be main", async () => {
     const { fetchImpl, requests } = createGithubFetch();

--- a/src/scripts/__tests__/verify-production-env.test.ts
+++ b/src/scripts/__tests__/verify-production-env.test.ts
@@ -296,25 +296,23 @@ describe("verify-production-env", () => {
     );
   });
 
-  it.each([
-    " false ",
-    "FALSE",
-    "1",
-    "*",
-  ])("rejects non-canonical AI demo flag %j", (value) => {
-    const result = runVerifier({ ENABLE_AI_DEMO: value });
+  it.each([" false ", "FALSE", "1", "*"])(
+    "rejects non-canonical AI demo flag %j",
+    (value) => {
+      const result = runVerifier({ ENABLE_AI_DEMO: value });
 
-    expect(result.status).toBe(1);
-    expect(check(result.summary, "ai_demo_flag_contract")).toMatchObject({
-      details: {
-        invalid: [expect.objectContaining({ name: "ENABLE_AI_DEMO" })],
-      },
-      status: "failed",
-    });
-    expect(check(result.summary, "ai_demo_telemetry_contract").details.enabled).toBe(
-      false
-    );
-  });
+      expect(result.status).toBe(1);
+      expect(check(result.summary, "ai_demo_flag_contract")).toMatchObject({
+        details: {
+          invalid: [expect.objectContaining({ name: "ENABLE_AI_DEMO" })],
+        },
+        status: "failed",
+      });
+      expect(check(result.summary, "ai_demo_telemetry_contract").details.enabled).toBe(
+        false
+      );
+    }
+  );
 
   it("requires a dedicated MFA backup-code pepper", () => {
     const result = runVerifier({ MFA_BACKUP_CODE_PEPPER: undefined });


### PR DESCRIPTION
## Summary

- upgrade @biomejs/biome from 2.5.2 to the current stable 2.5.4 release
- align the configuration schema and migrate deprecated rules.recommended to the equivalent rules.preset
- commit the deterministic curried test.each formatting introduced by Biome 2.5.4

## Research

- npm latest and the official Biome 2.5.4 changelog both identify 2.5.4 as current stable
- the patch release fixes curried test.each formatting, which accounts for all nine source-file changes
- opensrc resolved scoped-package cache paths but fell back to upstream default branch, so those paths were not treated as an exact version-to-version source diff

## Verification

- pnpm install --frozen-lockfile
- pnpm exec biome migrate: no migration needed
- pnpm biome:check: 1,277 files clean
- pnpm type-check
- focused Vitest: 9 files, 185 tests passed
- pnpm test:quick: 3,828 passed, 3 skipped
- pnpm test:affected: 3,828 passed, 3 skipped
- git diff --check
- two independent repository reviews plus gpt-5.6-sol xhigh codex-review: no remaining findings

No runtime dependencies, production code, or user-facing behavior change.