### PR TITLE
fix(ops): make CLI help exit successfully

### DIFF
--- a/scripts/ops.ts
+++ b/scripts/ops.ts
@@ -711,6 +711,12 @@ const commandMap: Record<string, Command> = {
 
 async function main(): Promise<void> {
   const [, , ...args] = process.argv;
+
+  if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+    printUsage();
+    return;
+  }
+
   const firstFlagIndex = args.findIndex((arg) => arg.startsWith("--"));
   const commandArgs = firstFlagIndex === -1 ? args : args.slice(0, firstFlagIndex);
   const key = commandArgs.join(":");

--- a/src/scripts/__tests__/ops.test.ts
+++ b/src/scripts/__tests__/ops.test.ts
@@ -1,0 +1,79 @@
+/** @vitest-environment node */
+
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const scriptPath = join(process.cwd(), "scripts/ops.ts");
+const tsxCliPath = fileURLToPath(import.meta.resolve("tsx/cli"));
+const operationalEnvKeys = [
+  "AI_GATEWAY_API_KEY",
+  "AI_GATEWAY_URL",
+  "ANTHROPIC_API_KEY",
+  "APP_BASE_URL",
+  "BYOK_HEALTHCHECK_KEY",
+  "NEXT_PUBLIC_APP_URL",
+  "NEXT_PUBLIC_BASE_URL",
+  "NEXT_PUBLIC_SITE_URL",
+  "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+  "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY",
+  "NEXT_PUBLIC_SUPABASE_URL",
+  "OPENAI_API_KEY",
+  "OPENROUTER_API_KEY",
+  "QSTASH_TOKEN",
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "UPSTASH_REDIS_REST_TOKEN",
+  "UPSTASH_REDIS_REST_URL",
+  "XAI_API_KEY",
+] as const;
+
+function runOps(args: string[] = []) {
+  const env = { ...process.env, FORCE_COLOR: "0" };
+  for (const key of operationalEnvKeys) {
+    Reflect.deleteProperty(env, key);
+  }
+
+  return spawnSync(process.execPath, [tsxCliPath, scriptPath, ...args], {
+    encoding: "utf8",
+    env,
+    timeout: 10_000,
+  });
+}
+
+describe("ops CLI help", () => {
+  it.each([["--help"], ["-h"]])("prints help for %s", (flag) => {
+    const result = runOps([flag]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Infrastructure checks:");
+    expect(result.stderr).toBe("");
+  });
+
+  it("prints help when no command is provided", () => {
+    const result = runOps();
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Test analysis:");
+    expect(result.stderr).toBe("");
+  });
+
+  it.each([
+    ["infra", "check", "supabase", "--help"],
+    ["--help", "infra", "check", "supabase"],
+  ])("does not dispatch a command when help is requested", (...args) => {
+    const result = runOps(args);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("pnpm ops infra check supabase");
+    expect(result.stderr).toBe("");
+  });
+
+  it("rejects an unknown non-empty command", () => {
+    const result = runOps(["unknown"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("Infrastructure checks:");
+    expect(result.stderr).toContain('Error: Unknown command "unknown"');
+  });
+});


### PR DESCRIPTION
## Summary

- make no-argument invocation print usage and exit successfully
- treat --help and -h as terminal help flags wherever they appear
- prevent help requests from dispatching infrastructure commands
- add shell-free subprocess coverage with operational environment variables removed

Fixes #815.

## Verification

- pnpm exec vitest run src/scripts/__tests__/ops.test.ts (6 passed)
- pnpm test:affected
- pnpm type-check
- pnpm biome:check
- direct no-args, --help, -h, command-before-help, and help-before-command matrix
- production build with CI placeholder environment before rebase
- two adversarial subagent review rounds plus gpt-5.6-sol and gpt-5.6-luna reviews: no actionable findings

## Behavior

Unknown non-empty commands still print usage and exit 1. Help and an omitted command print usage and exit 0 without reading operational credentials or contacting external services.